### PR TITLE
refactor(invoices): extract service modules and deduplicate views.py

### DIFF
--- a/backend/invoices/period_overview.py
+++ b/backend/invoices/period_overview.py
@@ -1,0 +1,118 @@
+"""
+Pure query logic for the invoice period overview.
+
+Extracted from InvoiceViewSet.period_overview so the data-assembly
+logic can be tested and reasoned about independently of the DRF
+request/response layer.
+"""
+
+from datetime import date as date_type, datetime, timedelta, timezone as dt_timezone
+
+from django.db.models import Q
+
+from zev.models import Participant, MeteringPointAssignment
+from metering.models import MeterReading
+from .models import Invoice
+from .serializers import InvoiceSerializer
+
+
+def compute_period_overview(*, zev, period_start: date_type, period_end: date_type, request) -> list[dict]:
+    """Return one row per active participant for *zev* over the billing period.
+
+    Each row contains:
+    - participant identity fields
+    - the participant's invoice for the period (or None)
+    - metering completeness flags and gap details
+
+    Only participants with at least one metering point assignment active
+    during the period are included.
+    """
+    period_start_dt = datetime.combine(period_start, datetime.min.time(), tzinfo=dt_timezone.utc)
+    period_end_exclusive_dt = datetime.combine(period_end, datetime.min.time(), tzinfo=dt_timezone.utc) + timedelta(days=1)
+
+    participants = list(
+        Participant.objects.filter(
+            zev=zev,
+            valid_from__lte=period_end,
+        ).filter(
+            Q(valid_to__isnull=True) | Q(valid_to__gte=period_start)
+        ).order_by("last_name", "first_name")
+    )
+
+    invoice_map = {
+        invoice.participant_id: invoice
+        for invoice in Invoice.objects.filter(
+            zev=zev,
+            period_start=period_start,
+            period_end=period_end,
+        ).select_related("participant", "zev").order_by("-created_at")
+    }
+
+    rows = []
+    for participant in participants:
+        assignments = list(
+            MeteringPointAssignment.objects.filter(
+                participant=participant,
+                valid_from__lte=period_end,
+            ).filter(
+                Q(valid_to__isnull=True) | Q(valid_to__gte=period_start)
+            ).select_related("metering_point")
+        )
+
+        if not assignments:
+            continue
+
+        assignment_mp_ids = [a.metering_point_id for a in assignments]
+        readings_by_metering_point: dict[int, set] = {}
+        for metering_point_id, timestamp in MeterReading.objects.filter(
+            metering_point_id__in=assignment_mp_ids,
+            timestamp__gte=period_start_dt,
+            timestamp__lt=period_end_exclusive_dt,
+        ).values_list("metering_point_id", "timestamp"):
+            readings_by_metering_point.setdefault(metering_point_id, set()).add(timestamp.date())
+
+        missing_meter_ids = []
+        missing_meter_details = []
+        for assignment in assignments:
+            mp = assignment.metering_point
+            effective_start = max(period_start, assignment.valid_from)
+            effective_end = min(
+                period_end,
+                assignment.valid_to if assignment.valid_to is not None else period_end,
+            )
+
+            if effective_start > effective_end:
+                continue
+
+            reading_days = readings_by_metering_point.get(mp.id, set())
+            cursor = effective_start
+            missing_days = 0
+            while cursor <= effective_end:
+                if cursor not in reading_days:
+                    missing_days += 1
+                cursor = cursor + timedelta(days=1)
+
+            if missing_days > 0:
+                missing_meter_ids.append(mp.meter_id)
+                missing_meter_details.append({"meter_id": mp.meter_id, "missing_days": missing_days})
+
+        total_metering_points = len(assignments)
+        metering_points_with_data = total_metering_points - len(missing_meter_ids)
+        metering_data_complete = total_metering_points > 0 and metering_points_with_data == total_metering_points
+
+        invoice = invoice_map.get(participant.id)
+        rows.append(
+            {
+                "participant_id": str(participant.id),
+                "participant_name": participant.full_name,
+                "participant_email": participant.email,
+                "invoice": InvoiceSerializer(invoice, context={"request": request}).data if invoice else None,
+                "metering_data_complete": metering_data_complete,
+                "metering_points_total": total_metering_points,
+                "metering_points_with_data": metering_points_with_data,
+                "missing_meter_ids": missing_meter_ids,
+                "missing_meter_details": missing_meter_details,
+            }
+        )
+
+    return rows

--- a/backend/invoices/template_context.py
+++ b/backend/invoices/template_context.py
@@ -1,0 +1,260 @@
+"""
+Pure helpers for building sample/preview template contexts.
+
+These functions produce realistic-looking placeholder data used by the
+pdf-template, contract-pdf-template, and annual-statement-pdf-template
+preview endpoints in views.py. They have no side effects and no Django
+request dependency, so they live here rather than in views.py.
+"""
+
+from .pdf import INVOICE_TRANSLATIONS
+from .contract_pdf import CONTRACT_TRANSLATIONS
+from .annual_statement import ANNUAL_TRANSLATIONS, _build_monthly_chart_svg
+
+
+class _Obj:
+    """Simple namespace that allows attribute access on a dict."""
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def __str__(self):
+        return self.__dict__.get("_str", "")
+
+    def get_status_display(self):
+        return self.__dict__.get("_status_display", "Draft")
+
+    def get_zev_type_display(self):
+        return self.__dict__.get("_zev_type_display", "vZEV")
+
+    def get_full_name(self):
+        return self.__dict__.get("_full_name", "")
+
+
+def build_sample_invoice_context() -> dict:
+    tr = INVOICE_TRANSLATIONS.get("en", INVOICE_TRANSLATIONS["de"])
+    return {
+        "invoice": _Obj(
+            invoice_number="INV-2026-001",
+            _status_display="Draft",
+            subtotal_chf="450.00",
+            vat_rate="8.1",
+            vat_chf="36.45",
+            total_chf="486.45",
+            notes="Sample invoice for template preview.",
+        ),
+        "items": [],
+        "grouped_items": [
+            {
+                "key": "energy",
+                "label": tr["cat_energy"],
+                "items": [
+                    _Obj(description="Local ZEV energy Jan 2026", quantity_kwh="320.50", unit="kWh", unit_price_chf="0.18", total_chf="57.69"),
+                    _Obj(description="Grid energy Jan 2026", quantity_kwh="180.00", unit="kWh", unit_price_chf="0.22", total_chf="39.60"),
+                ],
+                "subtotal": "97.29",
+            },
+            {
+                "key": "grid_fees",
+                "label": tr["cat_grid_fees"],
+                "items": [
+                    _Obj(description="Grid usage fee Jan 2026", quantity_kwh="500.50", unit="kWh", unit_price_chf="0.08", total_chf="40.04"),
+                ],
+                "subtotal": "40.04",
+            },
+        ],
+        "zev": _Obj(
+            name="Solar Community Example",
+            vat_number="CHE-123.456.789",
+            bank_iban="CH93 0076 2011 6238 5295 7",
+        ),
+        "owner_participant": _Obj(
+            full_name="Maria Muster",
+            address_line1="Solarweg 1",
+            address_line2="",
+            postal_code="8000",
+            city="Zürich",
+        ),
+        "creditor_city": "Zürich",
+        "participant": _Obj(
+            full_name="Hans Beispiel",
+            address_line1="Musterstrasse 42",
+            postal_code="3000",
+            city="Bern",
+            email="hans@example.com",
+        ),
+        "qr_svg": None,
+        "energy_chart_svg": None,
+        "hourly_profile_chart_svg": None,
+        "savings_data": {
+            "local_kwh": "320.50",
+            "local_chf": "57.69",
+            "local_rp": "18.00",
+            "grid_rp": "22.00",
+            "saved_rp": "4.00",
+            "hypothetical_chf": "70.51",
+            "saved_chf": "12.82",
+        },
+        "tr": tr,
+        "formatted_dates": {
+            "invoice_date": "15.01.2026",
+            "period_start": "01.01.2026",
+            "period_end": "31.01.2026",
+            "due_date": "14.02.2026",
+        },
+    }
+
+
+def build_sample_contract_context() -> dict:
+    tr = CONTRACT_TRANSLATIONS.get("en", CONTRACT_TRANSLATIONS["de"])
+    return {
+        "participant": _Obj(
+            full_name="Hans Beispiel",
+            address_line1="Musterstrasse 42",
+            address_line2="",
+            postal_code="3000",
+            city="Bern",
+            phone="+41 31 123 45 67",
+            email="hans@example.com",
+        ),
+        "owner_participant": _Obj(
+            full_name="Maria Muster",
+            address_line1="Solarweg 1",
+            address_line2="",
+            postal_code="8000",
+            city="Zürich",
+            phone="+41 44 987 65 43",
+            email="maria@example.com",
+        ),
+        "zev": _Obj(
+            name="Solar Community Example",
+            _zev_type_display="vZEV",
+            grid_operator="Stadtwerk Zürich",
+            vat_number="CHE-123.456.789",
+            bank_iban="CH93 0076 2011 6238 5295 7",
+            owner=_Obj(
+                _full_name="Maria Muster",
+                username="maria",
+                email="maria@example.com",
+            ),
+        ),
+        "consumption_mps": [
+            _Obj(meter_id="CH1008845123456000000000000012345", location_description="Apartment 3B"),
+        ],
+        "production_mps": [
+            _Obj(meter_id="CH1008845123456000000000000054321", location_description="Rooftop PV system"),
+        ],
+        "local_tariff_rows": [
+            {"name": "Local solar tariff", "rate_rp": "18.00", "rate_description": "Flat rate"},
+        ],
+        "billing_interval_display": "Quarterly",
+        "contract_date": "01.01.2026",
+        "tr": tr,
+        "lang": "en",
+        "local_tariff_notes": "The tariff may be adjusted annually based on production costs.",
+        "additional_contract_notes": "Participant agrees to the general terms and conditions of the ZEV.",
+    }
+
+
+def build_sample_annual_statement_context() -> dict:
+    tr = ANNUAL_TRANSLATIONS.get("en", ANNUAL_TRANSLATIONS["de"])
+    monthly_data = []
+    for i, month in enumerate(tr["months"]):
+        consumed = 320.0 + i * 15
+        from_zev = consumed * 0.62
+        from_grid = consumed - from_zev
+        produced = 80.0 + i * 10 if i < 6 else 80.0 + (11 - i) * 10
+        self_suf = round(from_zev / consumed * 100) if consumed > 0 else 0
+        monthly_data.append({
+            "month_label": month,
+            "consumed_kwh": f"{consumed:.2f}",
+            "from_zev_kwh": f"{from_zev:.2f}",
+            "from_grid_kwh": f"{from_grid:.2f}",
+            "produced_kwh": f"{produced:.2f}",
+            "self_sufficiency_pct": self_suf,
+        })
+    total_consumed = sum(float(m["consumed_kwh"]) for m in monthly_data)
+    total_from_zev = sum(float(m["from_zev_kwh"]) for m in monthly_data)
+    total_from_grid = sum(float(m["from_grid_kwh"]) for m in monthly_data)
+    total_produced = sum(float(m["produced_kwh"]) for m in monthly_data)
+    return {
+        "lang": "en",
+        "tr": tr,
+        "year": 2025,
+        "zev": _Obj(
+            name="Solar Community Example",
+            vat_number="CHE-123.456.789",
+        ),
+        "participant": _Obj(
+            full_name="Hans Beispiel",
+            address_line1="Musterstrasse 42",
+            address_line2="",
+            postal_code="3000",
+            city="Bern",
+        ),
+        "owner_participant": _Obj(
+            full_name="Maria Muster",
+            address_line1="Solarweg 1",
+            address_line2="",
+            postal_code="8000",
+            city="Zürich",
+        ),
+        "monthly_data": monthly_data,
+        "totals": {
+            "total_consumed_kwh": f"{total_consumed:.2f}",
+            "from_zev_kwh": f"{total_from_zev:.2f}",
+            "from_grid_kwh": f"{total_from_grid:.2f}",
+            "total_produced_kwh": f"{total_produced:.2f}",
+            "self_sufficiency_pct": round(total_from_zev / total_consumed * 100) if total_consumed > 0 else 0,
+        },
+        "monthly_chart_svg": _build_monthly_chart_svg(monthly_data, tr),
+        "invoices": [
+            {
+                "invoice_number": "INV-2025-001",
+                "period_start_formatted": "01.01.2025",
+                "period_end_formatted": "31.03.2025",
+                "subtotal_chf": "450.00",
+                "vat_chf": "36.45",
+                "total_chf": "486.45",
+            },
+            {
+                "invoice_number": "INV-2025-002",
+                "period_start_formatted": "01.04.2025",
+                "period_end_formatted": "30.06.2025",
+                "subtotal_chf": "520.00",
+                "vat_chf": "42.12",
+                "total_chf": "562.12",
+            },
+            {
+                "invoice_number": "INV-2025-003",
+                "period_start_formatted": "01.07.2025",
+                "period_end_formatted": "30.09.2025",
+                "subtotal_chf": "380.00",
+                "vat_chf": "30.78",
+                "total_chf": "410.78",
+            },
+            {
+                "invoice_number": "INV-2025-004",
+                "period_start_formatted": "01.10.2025",
+                "period_end_formatted": "31.12.2025",
+                "subtotal_chf": "490.00",
+                "vat_chf": "39.69",
+                "total_chf": "529.69",
+            },
+        ],
+        "invoice_totals": {
+            "subtotal_chf": "1840.00",
+            "vat_chf": "149.04",
+            "total_chf": "1989.04",
+        },
+        "savings": {
+            "local_kwh": "2976.00",
+            "local_chf": "535.68",
+            "local_rp": "18.00",
+            "grid_rp": "22.00",
+            "hypothetical_chf": "654.72",
+            "saved_chf": "119.04",
+        },
+        "formatted_dates": {
+            "statement_date": "01.01.2026",
+        },
+    }

--- a/backend/invoices/test_period_overview_unit.py
+++ b/backend/invoices/test_period_overview_unit.py
@@ -1,0 +1,218 @@
+"""Direct unit tests for invoices.period_overview.compute_period_overview.
+
+These tests call the pure function directly, bypassing the HTTP layer,
+to cover edge cases more precisely and cheaply.
+"""
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from django.test import TestCase
+
+from accounts.models import UserRole
+from invoices.models import InvoiceStatus
+from invoices.period_overview import compute_period_overview
+from invoices.test_helpers import make_invoice, make_participant, make_user, make_zev
+from metering.models import MeterReading, ReadingDirection, ReadingResolution
+from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType
+
+
+def _reading(mp, day_date):
+    return MeterReading.objects.create(
+        metering_point=mp,
+        timestamp=datetime(day_date.year, day_date.month, day_date.day, 0, 0, tzinfo=timezone.utc),
+        energy_kwh=Decimal("1.0000"),
+        direction=ReadingDirection.IN,
+        resolution=ReadingResolution.FIFTEEN_MIN,
+    )
+
+
+def _fill_readings(mp, start: date, end: date):
+    """Create one reading per day for mp over [start, end] inclusive."""
+    from datetime import timedelta
+    d = start
+    while d <= end:
+        _reading(mp, d)
+        d += timedelta(days=1)
+
+
+class ComputePeriodOverviewTests(TestCase):
+    def setUp(self):
+        self.owner = make_user("po_owner", UserRole.ZEV_OWNER)
+        self.zev = make_zev(self.owner, "Unit ZEV")
+        self.period_start = date(2026, 3, 1)
+        self.period_end = date(2026, 3, 31)
+
+    # ------------------------------------------------------------------ helpers
+    def _mp(self, meter_id="CH-UNIT-1"):
+        return MeteringPoint.objects.create(
+            zev=self.zev,
+            meter_id=meter_id,
+            meter_type=MeteringPointType.CONSUMPTION,
+        )
+
+    def _assign(self, mp, participant, valid_from=None, valid_to=None):
+        return MeteringPointAssignment.objects.create(
+            metering_point=mp,
+            participant=participant,
+            valid_from=valid_from or self.period_start,
+            valid_to=valid_to,
+        )
+
+    def _run(self):
+        return compute_period_overview(
+            zev=self.zev,
+            period_start=self.period_start,
+            period_end=self.period_end,
+            request=None,
+        )
+
+    # ------------------------------------------------------------------ tests
+
+    def test_participant_with_full_readings_is_complete(self):
+        p = make_participant(self.zev, first="Full", last="Coverage")
+        mp = self._mp("CH-UNIT-FULL")
+        self._assign(mp, p)
+        _fill_readings(mp, self.period_start, self.period_end)
+
+        rows = self._run()
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertTrue(row["metering_data_complete"])
+        self.assertEqual(row["missing_meter_ids"], [])
+        self.assertEqual(row["metering_points_total"], 1)
+        self.assertEqual(row["metering_points_with_data"], 1)
+
+    def test_participant_with_no_readings_is_incomplete(self):
+        p = make_participant(self.zev, first="No", last="Readings")
+        mp = self._mp("CH-UNIT-EMPTY")
+        self._assign(mp, p)
+        # no readings created
+
+        rows = self._run()
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertFalse(row["metering_data_complete"])
+        self.assertEqual(row["missing_meter_ids"], ["CH-UNIT-EMPTY"])
+        self.assertEqual(row["missing_meter_details"][0]["missing_days"], 31)
+
+    def test_participant_with_one_missing_day_is_incomplete(self):
+        p = make_participant(self.zev, first="Almost", last="Complete")
+        mp = self._mp("CH-UNIT-GAP")
+        self._assign(mp, p)
+        _fill_readings(mp, self.period_start, self.period_end)
+        # remove the last day
+        MeterReading.objects.filter(
+            metering_point=mp,
+            timestamp__date=self.period_end,
+        ).delete()
+
+        rows = self._run()
+        row = rows[0]
+
+        self.assertFalse(row["metering_data_complete"])
+        self.assertEqual(row["missing_meter_details"][0]["missing_days"], 1)
+
+    def test_participant_without_assignment_in_period_excluded(self):
+        p = make_participant(self.zev, first="No", last="Assignment")
+        # assignment ends before period starts
+        mp = self._mp("CH-UNIT-NOASSIGN")
+        MeteringPointAssignment.objects.create(
+            metering_point=mp,
+            participant=p,
+            valid_from=date(2025, 1, 1),
+            valid_to=date(2026, 2, 28),
+        )
+
+        rows = self._run()
+
+        self.assertEqual(rows, [])
+
+    def test_partial_assignment_restricts_required_days(self):
+        """Only days within the assignment window are required to have readings."""
+        p = make_participant(self.zev, first="Partial", last="Window")
+        mp = self._mp("CH-UNIT-PARTIAL")
+        # Assignment covers only March 10–20 (11 days)
+        self._assign(mp, p, valid_from=date(2026, 3, 10), valid_to=date(2026, 3, 20))
+        # Fill full month — all 11 assigned days are covered
+        _fill_readings(mp, self.period_start, self.period_end)
+
+        rows = self._run()
+
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["metering_data_complete"])
+
+    def test_partial_assignment_with_gap_inside_window(self):
+        """A missing day inside the assignment window still counts as incomplete."""
+        p = make_participant(self.zev, first="PartialGap", last="Window")
+        mp = self._mp("CH-UNIT-PARTGAP")
+        self._assign(mp, p, valid_from=date(2026, 3, 10), valid_to=date(2026, 3, 20))
+        _fill_readings(mp, date(2026, 3, 10), date(2026, 3, 20))
+        # Delete March 15 reading
+        MeterReading.objects.filter(
+            metering_point=mp,
+            timestamp__date=date(2026, 3, 15),
+        ).delete()
+
+        rows = self._run()
+        self.assertFalse(rows[0]["metering_data_complete"])
+        self.assertEqual(rows[0]["missing_meter_details"][0]["missing_days"], 1)
+
+    def test_invoice_is_included_for_matching_period(self):
+        p = make_participant(self.zev, first="Has", last="Invoice")
+        mp = self._mp("CH-UNIT-INV")
+        self._assign(mp, p)
+        _fill_readings(mp, self.period_start, self.period_end)
+        inv = make_invoice(self.zev, p, InvoiceStatus.APPROVED)
+        # Override period to match
+        inv.period_start = self.period_start
+        inv.period_end = self.period_end
+        inv.save()
+
+        rows = self._run()
+        self.assertIsNotNone(rows[0]["invoice"])
+        self.assertEqual(rows[0]["invoice"]["id"], str(inv.id))
+
+    def test_invoice_not_included_for_different_period(self):
+        p = make_participant(self.zev, first="Wrong", last="Period")
+        mp = self._mp("CH-UNIT-WRONGPERIOD")
+        self._assign(mp, p)
+        _fill_readings(mp, self.period_start, self.period_end)
+        # Invoice is for a different period
+        make_invoice(self.zev, p, InvoiceStatus.DRAFT)  # default period Jan 2026
+
+        rows = self._run()
+        self.assertIsNone(rows[0]["invoice"])
+
+    def test_rows_ordered_by_last_name_first_name(self):
+        p_b = make_participant(self.zev, first="Adam", last="Ziegler")
+        p_a = make_participant(self.zev, first="Zara", last="Alder")
+        for p, mid in [(p_b, "CH-UNIT-Z"), (p_a, "CH-UNIT-A")]:
+            mp = self._mp(mid)
+            self._assign(mp, p)
+
+        rows = self._run()
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["participant_name"], p_a.full_name)  # Alder before Ziegler
+        self.assertEqual(rows[1]["participant_name"], p_b.full_name)
+
+    def test_multiple_metering_points_counts_correctly(self):
+        p = make_participant(self.zev, first="Multi", last="Meter")
+        mp1 = self._mp("CH-UNIT-M1")
+        mp2 = self._mp("CH-UNIT-M2")
+        self._assign(mp1, p)
+        self._assign(mp2, p)
+        _fill_readings(mp1, self.period_start, self.period_end)
+        # mp2 has no readings
+
+        rows = self._run()
+        row = rows[0]
+
+        self.assertFalse(row["metering_data_complete"])
+        self.assertEqual(row["metering_points_total"], 2)
+        self.assertEqual(row["metering_points_with_data"], 1)
+        self.assertIn("CH-UNIT-M2", row["missing_meter_ids"])
+        self.assertNotIn("CH-UNIT-M1", row["missing_meter_ids"])

--- a/backend/invoices/test_template_context.py
+++ b/backend/invoices/test_template_context.py
@@ -1,0 +1,86 @@
+"""Smoke tests for invoices.template_context sample context builders.
+
+These verify that each builder returns a dict with the expected top-level
+keys and that the data is self-consistent (e.g. INVOICE_TRANSLATIONS used
+in the right language, monthly_data length matches months list).
+"""
+
+from django.test import SimpleTestCase
+
+from invoices.template_context import (
+    build_sample_invoice_context,
+    build_sample_contract_context,
+    build_sample_annual_statement_context,
+)
+
+
+class BuildSampleInvoiceContextTests(SimpleTestCase):
+    def setUp(self):
+        self.ctx = build_sample_invoice_context()
+
+    def test_required_keys_present(self):
+        for key in ("invoice", "grouped_items", "zev", "participant", "owner_participant",
+                    "formatted_dates", "savings_data", "tr"):
+            with self.subTest(key=key):
+                self.assertIn(key, self.ctx)
+
+    def test_invoice_has_number_and_totals(self):
+        inv = self.ctx["invoice"]
+        self.assertEqual(inv.invoice_number, "INV-2026-001")
+        self.assertTrue(float(inv.total_chf) > 0)
+
+    def test_grouped_items_structure(self):
+        for group in self.ctx["grouped_items"]:
+            self.assertIn("key", group)
+            self.assertIn("label", group)
+            self.assertIn("items", group)
+            self.assertIn("subtotal", group)
+
+    def test_formatted_dates_present(self):
+        dates = self.ctx["formatted_dates"]
+        for key in ("invoice_date", "period_start", "period_end", "due_date"):
+            self.assertIn(key, dates)
+
+
+class BuildSampleContractContextTests(SimpleTestCase):
+    def setUp(self):
+        self.ctx = build_sample_contract_context()
+
+    def test_required_keys_present(self):
+        for key in ("participant", "owner_participant", "zev", "consumption_mps",
+                    "production_mps", "local_tariff_rows", "tr", "lang"):
+            with self.subTest(key=key):
+                self.assertIn(key, self.ctx)
+
+    def test_zev_has_owner(self):
+        self.assertIsNotNone(self.ctx["zev"].owner)
+
+    def test_metering_points_are_lists(self):
+        self.assertIsInstance(self.ctx["consumption_mps"], list)
+        self.assertIsInstance(self.ctx["production_mps"], list)
+
+
+class BuildSampleAnnualStatementContextTests(SimpleTestCase):
+    def setUp(self):
+        self.ctx = build_sample_annual_statement_context()
+
+    def test_required_keys_present(self):
+        for key in ("monthly_data", "totals", "invoices", "invoice_totals",
+                    "savings", "formatted_dates", "tr", "year"):
+            with self.subTest(key=key):
+                self.assertIn(key, self.ctx)
+
+    def test_monthly_data_has_12_entries(self):
+        self.assertEqual(len(self.ctx["monthly_data"]), 12)
+
+    def test_totals_are_consistent_with_monthly_data(self):
+        monthly = self.ctx["monthly_data"]
+        expected_consumed = sum(float(m["consumed_kwh"]) for m in monthly)
+        self.assertAlmostEqual(float(self.ctx["totals"]["total_consumed_kwh"]), expected_consumed, places=1)
+
+    def test_monthly_chart_svg_produced(self):
+        self.assertIsNotNone(self.ctx["monthly_chart_svg"])
+        self.assertIn("<svg", self.ctx["monthly_chart_svg"])
+
+    def test_invoices_list_has_four_quarters(self):
+        self.assertEqual(len(self.ctx["invoices"]), 4)

--- a/backend/invoices/views.py
+++ b/backend/invoices/views.py
@@ -829,242 +829,69 @@ class InvoiceViewSet(viewsets.ModelViewSet):
             "recent_invoices": recent_data,
         })
 
-    @action(detail=False, methods=["get", "patch", "delete"], url_path="pdf-template", permission_classes=[IsAuthenticated])
-    def pdf_template(self, request):
-        """Admin-only read/write/reset access to the invoice PDF HTML template.
-
-        GET    — returns current content (DB override if present, else on-disk default)
-                 and is_customized flag.
-        PATCH  — saves content to the database (never touches the filesystem).
-        DELETE — removes the DB override, reverting to the on-disk default.
-        """
+    def _handle_pdf_template(self, request, template_name: str, audit_action_prefix: str):
+        """Shared GET/PATCH/DELETE handler for all three PDF template endpoints."""
         if not request.user.is_admin:
             record_audit_event(
                 request=request,
                 action_category=AuditActionCategory.GOVERNANCE,
-                action_type="template.invoice_pdf.update",
+                action_type=f"{audit_action_prefix}.update",
                 target_type="invoices.PdfTemplate",
-                target_id=TEMPLATE_NAME,
-                target_display=TEMPLATE_NAME,
-                summary="Denied invoice PDF template mutation by non-admin.",
+                target_id=template_name,
+                target_display=template_name,
+                summary=f"Denied PDF template mutation by non-admin ({template_name}).",
                 status=AuditEventStatus.DENIED,
             )
             return Response({"error": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
 
         if request.method == "GET":
-            record = PdfTemplate.objects.filter(template_name=TEMPLATE_NAME).first()
-            content = record.content if record else _read_default_template(TEMPLATE_NAME)
-            return Response(
-                {
-                    "template_name": TEMPLATE_NAME,
-                    "content": content,
-                    "is_customized": record is not None,
-                }
-            )
+            record = PdfTemplate.objects.filter(template_name=template_name).first()
+            content = record.content if record else _read_default_template(template_name)
+            return Response({"template_name": template_name, "content": content, "is_customized": record is not None})
 
         if request.method == "PATCH":
             content = request.data.get("content")
             if not isinstance(content, str) or not content.strip():
                 return Response({"error": "Template content is required."}, status=status.HTTP_400_BAD_REQUEST)
-            PdfTemplate.objects.update_or_create(
-                template_name=TEMPLATE_NAME,
-                defaults={"content": content},
-            )
+            PdfTemplate.objects.update_or_create(template_name=template_name, defaults={"content": content})
             record_audit_event(
                 request=request,
                 action_category=AuditActionCategory.GOVERNANCE,
-                action_type="template.invoice_pdf.update",
+                action_type=f"{audit_action_prefix}.update",
                 target_type="invoices.PdfTemplate",
-                target_id=TEMPLATE_NAME,
-                target_display=TEMPLATE_NAME,
-                summary="Updated invoice PDF template.",
+                target_id=template_name,
+                target_display=template_name,
+                summary=f"Updated PDF template {template_name}.",
             )
-            return Response(
-                {
-                    "template_name": TEMPLATE_NAME,
-                    "content": content,
-                    "is_customized": True,
-                    "detail": "PDF template updated successfully.",
-                }
-            )
+            return Response({"template_name": template_name, "content": content, "is_customized": True, "detail": "PDF template updated successfully."})
 
         # DELETE — revert to default
-        PdfTemplate.objects.filter(template_name=TEMPLATE_NAME).delete()
+        PdfTemplate.objects.filter(template_name=template_name).delete()
         record_audit_event(
             request=request,
             action_category=AuditActionCategory.GOVERNANCE,
-            action_type="template.invoice_pdf.reset",
+            action_type=f"{audit_action_prefix}.reset",
             target_type="invoices.PdfTemplate",
-            target_id=TEMPLATE_NAME,
-            target_display=TEMPLATE_NAME,
-            summary="Reset invoice PDF template to default.",
+            target_id=template_name,
+            target_display=template_name,
+            summary=f"Reset PDF template {template_name} to default.",
         )
-        return Response(
-            {
-                "template_name": TEMPLATE_NAME,
-                "content": _read_default_template(TEMPLATE_NAME),
-                "is_customized": False,
-                "detail": "PDF template reset to default.",
-            }
-        )
+        return Response({"template_name": template_name, "content": _read_default_template(template_name), "is_customized": False, "detail": "PDF template reset to default."})
+
+    @action(detail=False, methods=["get", "patch", "delete"], url_path="pdf-template", permission_classes=[IsAuthenticated])
+    def pdf_template(self, request):
+        """Admin-only read/write/reset for the invoice PDF HTML template."""
+        return self._handle_pdf_template(request, TEMPLATE_NAME, "template.invoice_pdf")
 
     @action(detail=False, methods=["get", "patch", "delete"], url_path="contract-pdf-template", permission_classes=[IsAuthenticated])
     def contract_pdf_template(self, request):
-        """Admin-only read/write/reset access to the contract PDF HTML template.
-
-        GET    — returns current content (DB override if present, else on-disk default)
-                 and is_customized flag.
-        PATCH  — saves content to the database (never touches the filesystem).
-        DELETE — removes the DB override, reverting to the on-disk default.
-        """
-        if not request.user.is_admin:
-            record_audit_event(
-                request=request,
-                action_category=AuditActionCategory.GOVERNANCE,
-                action_type="template.contract_pdf.update",
-                target_type="invoices.PdfTemplate",
-                target_id=CONTRACT_TEMPLATE_NAME,
-                target_display=CONTRACT_TEMPLATE_NAME,
-                summary="Denied contract PDF template mutation by non-admin.",
-                status=AuditEventStatus.DENIED,
-            )
-            return Response({"error": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
-
-        if request.method == "GET":
-            record = PdfTemplate.objects.filter(template_name=CONTRACT_TEMPLATE_NAME).first()
-            content = record.content if record else _read_default_template(CONTRACT_TEMPLATE_NAME)
-            return Response(
-                {
-                    "template_name": CONTRACT_TEMPLATE_NAME,
-                    "content": content,
-                    "is_customized": record is not None,
-                }
-            )
-
-        if request.method == "PATCH":
-            content = request.data.get("content")
-            if not isinstance(content, str) or not content.strip():
-                return Response({"error": "Template content is required."}, status=status.HTTP_400_BAD_REQUEST)
-            PdfTemplate.objects.update_or_create(
-                template_name=CONTRACT_TEMPLATE_NAME,
-                defaults={"content": content},
-            )
-            record_audit_event(
-                request=request,
-                action_category=AuditActionCategory.GOVERNANCE,
-                action_type="template.contract_pdf.update",
-                target_type="invoices.PdfTemplate",
-                target_id=CONTRACT_TEMPLATE_NAME,
-                target_display=CONTRACT_TEMPLATE_NAME,
-                summary="Updated contract PDF template.",
-            )
-            return Response(
-                {
-                    "template_name": CONTRACT_TEMPLATE_NAME,
-                    "content": content,
-                    "is_customized": True,
-                    "detail": "Contract PDF template updated successfully.",
-                }
-            )
-
-        # DELETE — revert to default
-        PdfTemplate.objects.filter(template_name=CONTRACT_TEMPLATE_NAME).delete()
-        record_audit_event(
-            request=request,
-            action_category=AuditActionCategory.GOVERNANCE,
-            action_type="template.contract_pdf.reset",
-            target_type="invoices.PdfTemplate",
-            target_id=CONTRACT_TEMPLATE_NAME,
-            target_display=CONTRACT_TEMPLATE_NAME,
-            summary="Reset contract PDF template to default.",
-        )
-        return Response(
-            {
-                "template_name": CONTRACT_TEMPLATE_NAME,
-                "content": _read_default_template(CONTRACT_TEMPLATE_NAME),
-                "is_customized": False,
-                "detail": "Contract PDF template reset to default.",
-            }
-        )
+        """Admin-only read/write/reset for the contract PDF HTML template."""
+        return self._handle_pdf_template(request, CONTRACT_TEMPLATE_NAME, "template.contract_pdf")
 
     @action(detail=False, methods=["get", "patch", "delete"], url_path="annual-statement-pdf-template", permission_classes=[IsAuthenticated])
     def annual_statement_pdf_template(self, request):
-        """Admin-only read/write/reset access to the annual statement PDF HTML template.
-
-        GET    — returns current content (DB override if present, else on-disk default)
-                 and is_customized flag.
-        PATCH  — saves content to the database (never touches the filesystem).
-        DELETE — removes the DB override, reverting to the on-disk default.
-        """
-        if not request.user.is_admin:
-            record_audit_event(
-                request=request,
-                action_category=AuditActionCategory.GOVERNANCE,
-                action_type="template.annual_statement_pdf.update",
-                target_type="invoices.PdfTemplate",
-                target_id=ANNUAL_STATEMENT_TEMPLATE,
-                target_display=ANNUAL_STATEMENT_TEMPLATE,
-                summary="Denied annual statement PDF template mutation by non-admin.",
-                status=AuditEventStatus.DENIED,
-            )
-            return Response({"error": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
-
-        if request.method == "GET":
-            record = PdfTemplate.objects.filter(template_name=ANNUAL_STATEMENT_TEMPLATE).first()
-            content = record.content if record else _read_default_template(ANNUAL_STATEMENT_TEMPLATE)
-            return Response(
-                {
-                    "template_name": ANNUAL_STATEMENT_TEMPLATE,
-                    "content": content,
-                    "is_customized": record is not None,
-                }
-            )
-
-        if request.method == "PATCH":
-            content = request.data.get("content")
-            if not isinstance(content, str) or not content.strip():
-                return Response({"error": "Template content is required."}, status=status.HTTP_400_BAD_REQUEST)
-            PdfTemplate.objects.update_or_create(
-                template_name=ANNUAL_STATEMENT_TEMPLATE,
-                defaults={"content": content},
-            )
-            record_audit_event(
-                request=request,
-                action_category=AuditActionCategory.GOVERNANCE,
-                action_type="template.annual_statement_pdf.update",
-                target_type="invoices.PdfTemplate",
-                target_id=ANNUAL_STATEMENT_TEMPLATE,
-                target_display=ANNUAL_STATEMENT_TEMPLATE,
-                summary="Updated annual statement PDF template.",
-            )
-            return Response(
-                {
-                    "template_name": ANNUAL_STATEMENT_TEMPLATE,
-                    "content": content,
-                    "is_customized": True,
-                    "detail": "Annual statement PDF template updated successfully.",
-                }
-            )
-
-        # DELETE — revert to default
-        PdfTemplate.objects.filter(template_name=ANNUAL_STATEMENT_TEMPLATE).delete()
-        record_audit_event(
-            request=request,
-            action_category=AuditActionCategory.GOVERNANCE,
-            action_type="template.annual_statement_pdf.reset",
-            target_type="invoices.PdfTemplate",
-            target_id=ANNUAL_STATEMENT_TEMPLATE,
-            target_display=ANNUAL_STATEMENT_TEMPLATE,
-            summary="Reset annual statement PDF template to default.",
-        )
-        return Response(
-            {
-                "template_name": ANNUAL_STATEMENT_TEMPLATE,
-                "content": _read_default_template(ANNUAL_STATEMENT_TEMPLATE),
-                "is_customized": False,
-                "detail": "Annual statement PDF template reset to default.",
-            }
-        )
+        """Admin-only read/write/reset for the annual statement PDF HTML template."""
+        return self._handle_pdf_template(request, ANNUAL_STATEMENT_TEMPLATE, "template.annual_statement_pdf")
 
     @action(detail=False, methods=["post"], url_path="preview-pdf-template", permission_classes=[IsAuthenticated])
     def preview_pdf_template(self, request):

--- a/backend/invoices/views.py
+++ b/backend/invoices/views.py
@@ -1,6 +1,6 @@
 import io
 import zipfile
-from datetime import date as date_type, datetime, timedelta, timezone as dt_timezone
+from datetime import date as date_type
 
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
@@ -8,21 +8,22 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from django.http import HttpResponse
 from accounts.permissions import IsZevOwnerOrAdmin
-from django.db.models import Count, Q, Sum, F, DecimalField
+from django.db.models import Count, Q, Sum
 from django.conf import settings
 from django.template import Template, Context
-from zev.models import Zev, Participant, MeteringPoint, MeteringPointAssignment
-from metering.models import MeterReading
+from zev.models import Zev, Participant
 from .models import Invoice, InvoiceStatus, EmailLog, PdfTemplate, EmailTemplate, EMAIL_TEMPLATE_DEFAULTS
 from .serializers import (
     InvoiceSerializer, GenerateInvoiceSerializer, GenerateZevInvoicesSerializer
 )
 from .engine import generate_invoice, generate_invoices_for_zev
-from .pdf import TEMPLATE_NAME, save_invoice_pdf, INVOICE_TRANSLATIONS
-from .contract_pdf import CONTRACT_TEMPLATE_NAME, CONTRACT_TRANSLATIONS
-from .annual_statement import generate_annual_statement_pdf, ANNUAL_STATEMENT_TEMPLATE, ANNUAL_TRANSLATIONS
+from .pdf import TEMPLATE_NAME, save_invoice_pdf
+from .contract_pdf import CONTRACT_TEMPLATE_NAME
+from .annual_statement import generate_annual_statement_pdf, ANNUAL_STATEMENT_TEMPLATE
 from .financial_summary import generate_financial_summary_pdf
 from .tasks import send_invoice_email_task
+from .template_context import build_sample_invoice_context, build_sample_contract_context, build_sample_annual_statement_context
+from .period_overview import compute_period_overview
 from audit.models import AuditActionCategory, AuditEventStatus
 from audit.services import build_diff, record_audit_event
 
@@ -32,254 +33,6 @@ def _read_default_template(template_name: str) -> str:
     path = settings.BASE_DIR / "templates" / template_name
     return path.read_text(encoding="utf-8")
 
-
-class _Obj:
-    """Simple namespace that allows attribute access on a dict."""
-    def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)
-
-    def __str__(self):
-        return self.__dict__.get("_str", "")
-
-    def get_status_display(self):
-        return self.__dict__.get("_status_display", "Draft")
-
-    def get_zev_type_display(self):
-        return self.__dict__.get("_zev_type_display", "vZEV")
-
-    def get_full_name(self):
-        return self.__dict__.get("_full_name", "")
-
-
-def _build_sample_invoice_context() -> dict:
-    tr = INVOICE_TRANSLATIONS.get("en", INVOICE_TRANSLATIONS["de"])
-    return {
-        "invoice": _Obj(
-            invoice_number="INV-2026-001",
-            _status_display="Draft",
-            subtotal_chf="450.00",
-            vat_rate="8.1",
-            vat_chf="36.45",
-            total_chf="486.45",
-            notes="Sample invoice for template preview.",
-        ),
-        "items": [],
-        "grouped_items": [
-            {
-                "key": "energy",
-                "label": tr["cat_energy"],
-                "items": [
-                    _Obj(description="Local ZEV energy Jan 2026", quantity_kwh="320.50", unit="kWh", unit_price_chf="0.18", total_chf="57.69"),
-                    _Obj(description="Grid energy Jan 2026", quantity_kwh="180.00", unit="kWh", unit_price_chf="0.22", total_chf="39.60"),
-                ],
-                "subtotal": "97.29",
-            },
-            {
-                "key": "grid_fees",
-                "label": tr["cat_grid_fees"],
-                "items": [
-                    _Obj(description="Grid usage fee Jan 2026", quantity_kwh="500.50", unit="kWh", unit_price_chf="0.08", total_chf="40.04"),
-                ],
-                "subtotal": "40.04",
-            },
-        ],
-        "zev": _Obj(
-            name="Solar Community Example",
-            vat_number="CHE-123.456.789",
-            bank_iban="CH93 0076 2011 6238 5295 7",
-        ),
-        "owner_participant": _Obj(
-            full_name="Maria Muster",
-            address_line1="Solarweg 1",
-            address_line2="",
-            postal_code="8000",
-            city="Zürich",
-        ),
-        "creditor_city": "Zürich",
-        "participant": _Obj(
-            full_name="Hans Beispiel",
-            address_line1="Musterstrasse 42",
-            postal_code="3000",
-            city="Bern",
-            email="hans@example.com",
-        ),
-        "qr_svg": None,
-        "energy_chart_svg": None,
-        "hourly_profile_chart_svg": None,
-        "savings_data": {
-            "local_kwh": "320.50",
-            "local_chf": "57.69",
-            "local_rp": "18.00",
-            "grid_rp": "22.00",
-            "saved_rp": "4.00",
-            "hypothetical_chf": "70.51",
-            "saved_chf": "12.82",
-        },
-        "tr": tr,
-        "formatted_dates": {
-            "invoice_date": "15.01.2026",
-            "period_start": "01.01.2026",
-            "period_end": "31.01.2026",
-            "due_date": "14.02.2026",
-        },
-    }
-
-
-def _build_sample_contract_context() -> dict:
-    tr = CONTRACT_TRANSLATIONS.get("en", CONTRACT_TRANSLATIONS["de"])
-    return {
-        "participant": _Obj(
-            full_name="Hans Beispiel",
-            address_line1="Musterstrasse 42",
-            address_line2="",
-            postal_code="3000",
-            city="Bern",
-            phone="+41 31 123 45 67",
-            email="hans@example.com",
-        ),
-        "owner_participant": _Obj(
-            full_name="Maria Muster",
-            address_line1="Solarweg 1",
-            address_line2="",
-            postal_code="8000",
-            city="Zürich",
-            phone="+41 44 987 65 43",
-            email="maria@example.com",
-        ),
-        "zev": _Obj(
-            name="Solar Community Example",
-            _zev_type_display="vZEV",
-            grid_operator="Stadtwerk Zürich",
-            vat_number="CHE-123.456.789",
-            bank_iban="CH93 0076 2011 6238 5295 7",
-            owner=_Obj(
-                _full_name="Maria Muster",
-                username="maria",
-                email="maria@example.com",
-            ),
-        ),
-        "consumption_mps": [
-            _Obj(meter_id="CH1008845123456000000000000012345", location_description="Apartment 3B"),
-        ],
-        "production_mps": [
-            _Obj(meter_id="CH1008845123456000000000000054321", location_description="Rooftop PV system"),
-        ],
-        "local_tariff_rows": [
-            {"name": "Local solar tariff", "rate_rp": "18.00", "rate_description": "Flat rate"},
-        ],
-        "billing_interval_display": "Quarterly",
-        "contract_date": "01.01.2026",
-        "tr": tr,
-        "lang": "en",
-        "local_tariff_notes": "The tariff may be adjusted annually based on production costs.",
-        "additional_contract_notes": "Participant agrees to the general terms and conditions of the ZEV.",
-    }
-
-
-def _build_sample_annual_statement_context() -> dict:
-    tr = ANNUAL_TRANSLATIONS.get("en", ANNUAL_TRANSLATIONS["de"])
-    monthly_data = []
-    for i, month in enumerate(tr["months"]):
-        consumed = 320.0 + i * 15
-        from_zev = consumed * 0.62
-        from_grid = consumed - from_zev
-        produced = 80.0 + i * 10 if i < 6 else 80.0 + (11 - i) * 10
-        self_suf = round(from_zev / consumed * 100) if consumed > 0 else 0
-        monthly_data.append({
-            "month_label": month,
-            "consumed_kwh": f"{consumed:.2f}",
-            "from_zev_kwh": f"{from_zev:.2f}",
-            "from_grid_kwh": f"{from_grid:.2f}",
-            "produced_kwh": f"{produced:.2f}",
-            "self_sufficiency_pct": self_suf,
-        })
-    total_consumed = sum(float(m["consumed_kwh"]) for m in monthly_data)
-    total_from_zev = sum(float(m["from_zev_kwh"]) for m in monthly_data)
-    total_from_grid = sum(float(m["from_grid_kwh"]) for m in monthly_data)
-    total_produced = sum(float(m["produced_kwh"]) for m in monthly_data)
-    from .annual_statement import _build_monthly_chart_svg
-    return {
-        "lang": "en",
-        "tr": tr,
-        "year": 2025,
-        "zev": _Obj(
-            name="Solar Community Example",
-            vat_number="CHE-123.456.789",
-        ),
-        "participant": _Obj(
-            full_name="Hans Beispiel",
-            address_line1="Musterstrasse 42",
-            address_line2="",
-            postal_code="3000",
-            city="Bern",
-        ),
-        "owner_participant": _Obj(
-            full_name="Maria Muster",
-            address_line1="Solarweg 1",
-            address_line2="",
-            postal_code="8000",
-            city="Zürich",
-        ),
-        "monthly_data": monthly_data,
-        "totals": {
-            "total_consumed_kwh": f"{total_consumed:.2f}",
-            "from_zev_kwh": f"{total_from_zev:.2f}",
-            "from_grid_kwh": f"{total_from_grid:.2f}",
-            "total_produced_kwh": f"{total_produced:.2f}",
-            "self_sufficiency_pct": round(total_from_zev / total_consumed * 100) if total_consumed > 0 else 0,
-        },
-        "monthly_chart_svg": _build_monthly_chart_svg(monthly_data, tr),
-        "invoices": [
-            {
-                "invoice_number": "INV-2025-001",
-                "period_start_formatted": "01.01.2025",
-                "period_end_formatted": "31.03.2025",
-                "subtotal_chf": "450.00",
-                "vat_chf": "36.45",
-                "total_chf": "486.45",
-            },
-            {
-                "invoice_number": "INV-2025-002",
-                "period_start_formatted": "01.04.2025",
-                "period_end_formatted": "30.06.2025",
-                "subtotal_chf": "520.00",
-                "vat_chf": "42.12",
-                "total_chf": "562.12",
-            },
-            {
-                "invoice_number": "INV-2025-003",
-                "period_start_formatted": "01.07.2025",
-                "period_end_formatted": "30.09.2025",
-                "subtotal_chf": "380.00",
-                "vat_chf": "30.78",
-                "total_chf": "410.78",
-            },
-            {
-                "invoice_number": "INV-2025-004",
-                "period_start_formatted": "01.10.2025",
-                "period_end_formatted": "31.12.2025",
-                "subtotal_chf": "490.00",
-                "vat_chf": "39.69",
-                "total_chf": "529.69",
-            },
-        ],
-        "invoice_totals": {
-            "subtotal_chf": "1840.00",
-            "vat_chf": "149.04",
-            "total_chf": "1989.04",
-        },
-        "savings": {
-            "local_kwh": "2976.00",
-            "local_chf": "535.68",
-            "local_rp": "18.00",
-            "grid_rp": "22.00",
-            "hypothetical_chf": "654.72",
-            "saved_chf": "119.04",
-        },
-        "formatted_dates": {
-            "statement_date": "01.01.2026",
-        },
-    }
 
 
 def _invoice_target_display(invoice: Invoice) -> str:
@@ -511,103 +264,7 @@ class InvoiceViewSet(viewsets.ModelViewSet):
         if not request.user.is_admin and zev.owner_id != request.user.id:
             return Response({"error": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
 
-        participants = list(
-            Participant.objects.filter(
-                zev=zev,
-                valid_from__lte=period_end,
-            ).filter(
-                Q(valid_to__isnull=True) | Q(valid_to__gte=period_start)
-            ).order_by("last_name", "first_name")
-        )
-
-        period_start_dt = datetime.combine(period_start, datetime.min.time(), tzinfo=dt_timezone.utc)
-        period_end_exclusive_dt = datetime.combine(period_end, datetime.min.time(), tzinfo=dt_timezone.utc) + timedelta(days=1)
-
-        invoice_map = {
-            invoice.participant_id: invoice
-            for invoice in Invoice.objects.filter(
-                zev=zev,
-                period_start=period_start,
-                period_end=period_end,
-            ).select_related("participant", "zev").order_by("-created_at")
-        }
-
-        rows = []
-        for participant in participants:
-            # Find all metering point assignments for this participant that overlap the period.
-            # Each assignment's valid_from/valid_to defines the exact days where readings are required.
-            assignments = list(
-                MeteringPointAssignment.objects.filter(
-                    participant=participant,
-                    valid_from__lte=period_end,
-                ).filter(
-                    Q(valid_to__isnull=True) | Q(valid_to__gte=period_start)
-                ).select_related("metering_point")
-            )
-
-            # Skip participants with no active assignment in this period.
-            if not assignments:
-                continue
-
-            # Fetch all readings for the involved metering points within the period, grouped by MP.
-            assignment_mp_ids = [a.metering_point_id for a in assignments]
-            readings_by_metering_point = {}
-            for metering_point_id, timestamp in MeterReading.objects.filter(
-                metering_point_id__in=assignment_mp_ids,
-                timestamp__gte=period_start_dt,
-                timestamp__lt=period_end_exclusive_dt,
-            ).values_list("metering_point_id", "timestamp"):
-                readings_by_metering_point.setdefault(metering_point_id, set()).add(timestamp.date())
-
-            missing_meter_ids = []
-            missing_meter_details = []
-            for assignment in assignments:
-                mp = assignment.metering_point
-                # Effective required window: intersection of billing period and assignment validity.
-                effective_start = max(period_start, assignment.valid_from)
-                effective_end = min(
-                    period_end,
-                    assignment.valid_to if assignment.valid_to is not None else period_end,
-                )
-
-                if effective_start > effective_end:
-                    continue
-
-                reading_days = readings_by_metering_point.get(mp.id, set())
-                cursor = effective_start
-                missing_days = 0
-                while cursor <= effective_end:
-                    if cursor not in reading_days:
-                        missing_days += 1
-                    cursor = cursor + timedelta(days=1)
-
-                if missing_days > 0:
-                    missing_meter_ids.append(mp.meter_id)
-                    missing_meter_details.append(
-                        {
-                            "meter_id": mp.meter_id,
-                            "missing_days": missing_days,
-                        }
-                    )
-
-            total_metering_points = len(assignments)
-            metering_points_with_data = total_metering_points - len(missing_meter_ids)
-            metering_data_complete = total_metering_points > 0 and metering_points_with_data == total_metering_points
-
-            invoice = invoice_map.get(participant.id)
-            rows.append(
-                {
-                    "participant_id": str(participant.id),
-                    "participant_name": participant.full_name,
-                    "participant_email": participant.email,
-                    "invoice": InvoiceSerializer(invoice, context={"request": request}).data if invoice else None,
-                    "metering_data_complete": metering_data_complete,
-                    "metering_points_total": total_metering_points,
-                    "metering_points_with_data": metering_points_with_data,
-                    "missing_meter_ids": missing_meter_ids,
-                    "missing_meter_details": missing_meter_details,
-                }
-            )
+        rows = compute_period_overview(zev=zev, period_start=period_start, period_end=period_end, request=request)
 
         return Response(
             {
@@ -1426,11 +1083,11 @@ class InvoiceViewSet(viewsets.ModelViewSet):
             return Response({"error": "Template content is required."}, status=status.HTTP_400_BAD_REQUEST)
 
         if template_type == "contract":
-            context = _build_sample_contract_context()
+            context = build_sample_contract_context()
         elif template_type == "annual_statement":
-            context = _build_sample_annual_statement_context()
+            context = build_sample_annual_statement_context()
         else:
-            context = _build_sample_invoice_context()
+            context = build_sample_invoice_context()
 
         try:
             rendered = Template(content).render(Context(context))


### PR DESCRIPTION
## Summary

Reduces `invoices/views.py` from **1,543 → 1,027 lines (−33%)** by extracting pure logic into focused modules and eliminating copy-pasted code.

---

## Changes

### `invoices/template_context.py` (new, 260 lines)
Moves `_Obj` helper class and all three `_build_sample_*_context()` functions out of `views.py`. These are pure data-construction helpers with no request dependency and no side effects — wrong place for them to live in a viewset file.

### `invoices/period_overview.py` (new, 118 lines)
Extracts the participant/metering-readiness query loop from `InvoiceViewSet.period_overview` into `compute_period_overview(zev, period_start, period_end, request)`. The view now delegates after input validation and ZEV permission check only.

### `invoices/views.py` (−516 lines)
- Removes extracted code, adds imports for new modules
- Drops unused imports (`datetime`, `timedelta`, `dt_timezone`, `MeteringPoint`, `MeteringPointAssignment`, `MeterReading`, `F`, `DecimalField`, translation dicts)
- Collapses three copy-pasted `pdf_template` / `contract_pdf_template` / `annual_statement_pdf_template` methods (~235 lines) into a single private `_handle_pdf_template(request, template_name, audit_action_prefix)` helper — each public action is now a 2-line delegator

---

## Tests

### `test_period_overview_unit.py` (new, 10 tests)
Direct unit tests calling `compute_period_overview()` without HTTP, covering:
- Full / empty / partial-gap coverage scenarios
- Assignment window trimming (only assigned days required)
- Assignment outside period → participant excluded
- Multiple metering points with mixed completeness
- Row ordering (last name, first name)
- Invoice matching by period

### `test_template_context.py` (new, 12 tests)
Smoke tests for all three `build_sample_*_context()` builders asserting key presence, structural consistency, and SVG chart output.

---

## Verification

All existing invoice tests continue to pass (54 tests). The 22 new tests all pass.