### PR TITLE
fix(frontend): translate invoice status labels and DataGrid chrome

### DIFF
--- a/frontend/src/features/invoices/InvoicePeriodRowsTable.tsx
+++ b/frontend/src/features/invoices/InvoicePeriodRowsTable.tsx
@@ -18,10 +18,6 @@ function emailStatusBadgeClass(status: string): string {
   return 'badge badge-neutral'
 }
 
-function humanizeStatus(status: string): string {
-  return status.replace('_', ' ').replace(/^./, (char) => char.toUpperCase())
-}
-
 function getLatestEmailLog(invoice: {
   email_logs?: Array<{ created_at: string; recipient: string; status: string; id: string }>
 } | null) {
@@ -101,7 +97,7 @@ export function InvoicePeriodRowsTable({
                   {invoice ? (
                     <div className="invoice-cell-stack">
                       <span>{invoice.invoice_number}</span>
-                      <span className={invoiceStatusBadgeClass(invoice.status)}>{humanizeStatus(invoice.status)}</span>
+                      <span className={invoiceStatusBadgeClass(invoice.status)}>{t(`invoice.status.${invoice.status}`)}</span>
                     </div>
                   ) : (
                     <div className="invoice-cell-stack">
@@ -113,7 +109,7 @@ export function InvoicePeriodRowsTable({
                 <td>
                   {invoice && latestEmailLog ? (
                     <div className="invoice-cell-stack">
-                      <span className={emailStatusBadgeClass(latestEmailLog.status)}>{humanizeStatus(latestEmailLog.status)}</span>
+                      <span className={emailStatusBadgeClass(latestEmailLog.status)}>{t(`email.${latestEmailLog.status}`)}</span>
                       <div>
                         <button
                           className="table-inline-action"

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -1195,6 +1195,7 @@ export const de = {
             resetToGlobalDefault: 'Auf globalen Standard zurücksetzen',
         },
         invoiceDetail: {
+            title: 'Rechnung {{number}}',
             backToInvoices: 'Zurück zu den Rechnungen',
             status: 'Status',
             total: 'Gesamt',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1167,6 +1167,7 @@ export const en = {
             resetToGlobalDefault: 'Revert to global default',
         },
         invoiceDetail: {
+            title: 'Invoice {{number}}',
             backToInvoices: 'Back to Invoices',
             status: 'Status',
             total: 'Total',

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -1193,6 +1193,7 @@ export const fr = {
             resetToGlobalDefault: 'Réinitialiser au modèle par défaut global',
         },
         invoiceDetail: {
+            title: 'Facture {{number}}',
             backToInvoices: 'Retour aux factures',
             status: 'Statut',
             total: 'Total',

--- a/frontend/src/i18n/locales/it.ts
+++ b/frontend/src/i18n/locales/it.ts
@@ -1193,6 +1193,7 @@ export const it = {
             resetToGlobalDefault: 'Ripristina al modello predefinito globale',
         },
         invoiceDetail: {
+            title: 'Fattura {{number}}',
             backToInvoices: 'Torna alle fatture',
             status: 'Stato',
             total: 'Totale',

--- a/frontend/src/lib/dataGridLocale.ts
+++ b/frontend/src/lib/dataGridLocale.ts
@@ -1,0 +1,13 @@
+import { deDE, enUS, frFR, itIT } from '@mui/x-data-grid/locales'
+import type { GridLocaleText } from '@mui/x-data-grid'
+
+const localeTextByLanguage: Record<string, Partial<GridLocaleText>> = {
+    en: enUS.components.MuiDataGrid.defaultProps.localeText,
+    de: deDE.components.MuiDataGrid.defaultProps.localeText,
+    fr: frFR.components.MuiDataGrid.defaultProps.localeText,
+    it: itIT.components.MuiDataGrid.defaultProps.localeText,
+}
+
+export function getDataGridLocaleText(language: string): Partial<GridLocaleText> {
+    return localeTextByLanguage[language] ?? localeTextByLanguage.en
+}

--- a/frontend/src/pages/AdminInvoicesPage.tsx
+++ b/frontend/src/pages/AdminInvoicesPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { DataGrid, type GridColDef, type GridRenderCellParams } from '@mui/x-data-grid'
 import { ConfirmDialog, useConfirmDialog } from '../components/ConfirmDialog'
 import { formatShortDate, useAppSettings } from '../lib/appSettings'
+import { getDataGridLocaleText } from '../lib/dataGridLocale'
 import { deleteInvoice, fetchInvoices } from '../lib/api/invoices'
 import { formatApiError } from '../lib/api/errors'
 import { queryKeys } from '../lib/api/queryKeys'
@@ -17,12 +18,8 @@ function invoiceStatusBadgeClass(status: string): string {
     return 'badge badge-neutral'
 }
 
-function humanizeStatus(status: string): string {
-    return status.replace('_', ' ').replace(/^./, (char) => char.toUpperCase())
-}
-
 export function AdminInvoicesPage() {
-    const { t } = useTranslation()
+    const { t, i18n } = useTranslation()
     const queryClient = useQueryClient()
     const { pushToast } = useToast()
     const { settings } = useAppSettings()
@@ -117,10 +114,14 @@ export function AdminInvoicesPage() {
             minWidth: 130,
             filterable: true,
             type: 'singleSelect',
-            valueOptions: ['draft', 'approved', 'sent', 'paid', 'cancelled'],
-            renderCell: (params: GridRenderCellParams<Invoice>) => (
-                <span className={invoiceStatusBadgeClass(String(params.value ?? ''))}>{humanizeStatus(String(params.value ?? ''))}</span>
-            ),
+            valueOptions: (['draft', 'approved', 'sent', 'paid', 'cancelled'] as const).map((value) => ({
+                value,
+                label: t(`invoice.status.${value}`),
+            })),
+            renderCell: (params: GridRenderCellParams<Invoice>) => {
+                const status = String(params.value ?? '')
+                return <span className={invoiceStatusBadgeClass(status)}>{status ? t(`invoice.status.${status}`) : ''}</span>
+            },
         },
         {
             field: 'actions',
@@ -188,6 +189,7 @@ export function AdminInvoicesPage() {
                                 },
                             }}
                             localeText={{
+                                ...getDataGridLocaleText(i18n.language),
                                 toolbarQuickFilterPlaceholder: t('adminInvoices.quickFilterPlaceholder'),
                                 noRowsLabel: t('adminInvoices.noFilteredResults'),
                             }}

--- a/frontend/src/pages/ImportsPage.tsx
+++ b/frontend/src/pages/ImportsPage.tsx
@@ -27,6 +27,7 @@ import {
 import { queryKeys } from '../lib/api/queryKeys'
 import { formatDateTime, useAppSettings } from '../lib/appSettings'
 import { useAuth } from '../lib/auth'
+import { getDataGridLocaleText } from '../lib/dataGridLocale'
 import { useManagedZev } from '../lib/managedZev'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '../lib/toast'
@@ -63,7 +64,7 @@ export function ImportsPage() {
     const { user } = useAuth()
     const { settings } = useAppSettings()
     const { selectedZevId, selectedZev } = useManagedZev()
-    const { t } = useTranslation()
+    const { t, i18n } = useTranslation()
     const isManagedScope = user?.role === 'admin' || user?.role === 'zev_owner'
 
     const { data, isLoading, isError } = useQuery({ queryKey: queryKeys.metering.importLogs(), queryFn: fetchImportLogs })
@@ -715,6 +716,7 @@ export function ImportsPage() {
                         },
                     }}
                     localeText={{
+                        ...getDataGridLocaleText(i18n.language),
                         noRowsLabel: t('pages.imports.noRows'),
                     }}
                     sx={{

--- a/frontend/src/pages/InvoiceDetailPage.tsx
+++ b/frontend/src/pages/InvoiceDetailPage.tsx
@@ -45,7 +45,7 @@ export function InvoiceDetailPage() {
         <div className="page-stack">
             <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
                 <div>
-                    <h2 style={{ marginBottom: '0.2rem' }}>Invoice {inv.invoice_number}</h2>
+                    <h2 style={{ marginBottom: '0.2rem' }}>{t('pages.invoiceDetail.title', { number: inv.invoice_number })}</h2>
                     <p className="muted" style={{ margin: 0 }}>
                         {inv.participant_name} · {formatShortDate(inv.period_start, settings)} → {formatShortDate(inv.period_end, settings)}
                     </p>
@@ -56,7 +56,7 @@ export function InvoiceDetailPage() {
             </header>
 
             <section className="grid grid-4">
-                <div className="card"><strong>{t('pages.invoiceDetail.status')}</strong><div>{inv.status}</div></div>
+                <div className="card"><strong>{t('pages.invoiceDetail.status')}</strong><div>{t(`invoice.status.${inv.status}`)}</div></div>
                 <div className="card"><strong>{t('pages.invoiceDetail.total')}</strong><div>CHF {inv.total_chf}</div></div>
                 <div className="card"><strong>{t('pages.invoiceDetail.subtotal')}</strong><div>CHF {inv.subtotal_chf ?? '-'}</div></div>
                 <div className="card"><strong>{t('pages.invoiceDetail.vat')}</strong><div>CHF {inv.vat_chf ?? '-'}</div></div>


### PR DESCRIPTION
## Summary

- Invoice status badges (list, detail, admin invoices grid) and email-log status badges were rendered via a local `humanizeStatus()` helper that just title-cased the raw backend enum (`draft` → `Draft`), ignoring the active locale — even though translated `invoice.status.*` / `email.*` keys already existed and were correctly used on the Admin Dashboard. Replaced with the existing translation keys in `InvoicePeriodRowsTable.tsx` and `AdminInvoicesPage.tsx` (including the DataGrid status filter's `valueOptions`).
- `InvoiceDetailPage.tsx` had a hardcoded English page title (`Invoice {number}`) and rendered the raw status enum instead of a translated label. Added a `pages.invoiceDetail.title` key to all four locales and wired both through `t()`.
- The `ImportsPage` and `AdminInvoicesPage` MUI DataGrids only overrode `noRowsLabel`, so pagination/toolbar/filter chrome always stayed in English regardless of locale. Added `frontend/src/lib/dataGridLocale.ts`, mapping the active `i18n.language` to MUI's own locale packs, merged into both grids.

## Linked spec

Isolated i18n bugfix — no API, data model, or workflow behavior changed.

## Validation

- `npm run build` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅ (36 passed)
