### PR TITLE
chore(deps): update backend-python (major)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 amqp==5.3.1
 asgiref==3.11.1
-attrs==25.4.0
+attrs==26.1.0
 billiard==4.2.4
 brotli==1.2.0
 celery==5.6.3
@@ -25,7 +25,7 @@ et_xmlfile==2.0.0
 factory_boy==3.3.3
 Faker==40.28.1
 fonttools==4.63.0
-gunicorn==25.3.0
+gunicorn==26.0.0
 inflection==0.5.1
 iniconfig==2.3.0
 iso3166==2.1.1
@@ -55,7 +55,7 @@ python-stdnum==2.2
 PyYAML==6.0.3
 qrbill==1.2.0
 qrcode==8.2
-redis==7.4.1
+redis==8.0.1
 referencing==0.37.0
 rpds-py==0.30.0
 six==1.17.0
@@ -63,12 +63,12 @@ sqlparse==0.5.5
 svgwrite==1.4.3
 tinycss2==1.5.1
 tinyhtml5==2.1.0
-tzdata==2025.3
+tzdata==2026.2
 tzlocal==5.4.4
 uritemplate==4.2.0
 vine==5.1.0
 wcwidth==0.8.2
-weasyprint==68.1
+weasyprint==69.0
 webencodings==0.5.1
 zopfli==0.4.3
 # MariaDB/MySQL support: install libmariadb-dev then add mysqlclient


### PR DESCRIPTION
Replaces #12, which cannot pass CI as proposed.

## Why #12 fails
`cron-descriptor==2.1.0` is uninstallable. `django-celery-beat 2.9.0` (the latest release) requires `cron-descriptor<2.0.0,>=1.2.32`, so pip aborts with `ResolutionImpossible`. `cron-descriptor` is only present in `requirements.txt` as a pinned transitive of django-celery-beat, so Renovate bumps it without seeing the constraint.

#12 is also 16 commits behind `main`, so it silently **downgrades** `cffi` (2.1.0→2.0.0), `Django` (6.0.7→6.0.6), `drf-spectacular` (0.30.0→0.29.0) and `numpy` (2.5.1→2.5.0).

## What this PR does
Branches from current `main` and applies only the majors that actually install:

| Package | From | To |
|---|---|---|
| attrs | 25.4.0 | 26.1.0 |
| gunicorn | 25.3.0 | 26.0.0 |
| redis | 7.4.1 | 8.0.1 |
| tzdata | 2025.3 | 2026.2 |
| weasyprint | 68.1 | 69.0 |

`cron-descriptor` stays at 1.4.5. See #291 for a Renovate rule that stops it being proposed again.

## Test plan
- [x] `pip install -r backend/requirements.txt` resolves cleanly
- [x] `python manage.py check` — no issues
- [x] `python -m pytest` — **275 passed, 91 subtests passed**
- [ ] CI runs Python 3.14; verified locally on 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
