### PR TITLE
chore(renovate): guard against unresolvable major bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,18 @@
     {
       "matchUpdateTypes": ["major"],
       "labels": ["dependencies", "major"]
+    },
+    {
+      "description": "Transitive dep of django-celery-beat, which pins cron-descriptor<2.0.0. Bumping it makes requirements.txt unresolvable.",
+      "matchManagers": ["pip_requirements"],
+      "matchPackageNames": ["cron-descriptor"],
+      "enabled": false
+    },
+    {
+      "description": "typescript-eslint has no TypeScript 7 support yet; TS7 crashes typescript-estree at lint time.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7.0.0"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Supports #290 and #292 by stopping Renovate from re-proposing two major bumps that cannot be installed.

## `cron-descriptor` — disabled
A transitive dep of `django-celery-beat`, which pins `cron-descriptor<2.0.0`. Bumping it makes `backend/requirements.txt` unresolvable (`pip ResolutionImpossible`). This is what broke #12.

## `typescript` — capped below 7.0.0
No `typescript-eslint` release supports TypeScript 7 — the peer range is `>=4.8.4 <6.1.0`, and even the `canary` (`8.63.1-alpha.8`) is unchanged. It is not just a conservative range: installing TS 7 with `--legacy-peer-deps` and running lint crashes with

```
TypeError: Cannot read properties of undefined (reading 'Cjs')
    at @typescript-eslint/typescript-estree/dist/create-program/shared.js:59
```

This unresolvable peer conflict is why Renovate could not regenerate `package-lock.json` on #147 ("Artifact file update failure"), which in turn broke `npm ci`.

Note the codebase itself is already TS7-ready — `tsc -b` under 7.0.2 compiles clean with zero errors. **Remove this rule once typescript-eslint ships TS7 support.**

## Test plan
- [x] `renovate.json` is valid JSON
- [ ] Confirm on the next Renovate run that neither package is proposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
