### PR TITLE
fix(deps): pin pandas to 3.0.3, away from the yanked 3.0.4

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -36,7 +36,7 @@ lxml==6.1.1
 numpy==2.5.1
 openpyxl==3.1.5
 packaging==26.2
-pandas==3.0.4
+pandas==3.0.3
 pillow==12.3.0
 pluggy==1.6.0
 prompt_toolkit==3.0.52


### PR DESCRIPTION
## Problem
`pandas==3.0.4` **has been yanked from PyPI**:

> Reported segfaults with datetime-related functionality

It was pinned by #264 on 2026-06-28 while still healthy, and yanked afterwards. Every `pip install -r requirements.txt` currently prints a yank warning, and CI has been installing a withdrawn release.

This is not theoretical for this codebase. `pandas` is imported in exactly one module — `metering/importers/csv_importer.py` — and that module calls `pd.to_datetime()` to parse reading timestamps, which is precisely the functionality named in the yank reason.

## Fix
Pin `3.0.3`: the newest non-yanked release, and what PyPI now reports as `latest`.

No Renovate rule is needed. Renovate skips yanked releases, so it will not re-propose 3.0.4 — and a version cap would only block a future 3.0.5.

## Test plan
- [x] `pip install -r backend/requirements.txt` resolves with **no yank warning**
- [x] `pytest` — **281 passed, 91 subtests passed**
- [x] The 36 import/CSV tests pass
- [x] Exercised `pd.to_datetime()` directly across the importer's formats (ISO, dotted, US, with/without time, `dayfirst` both ways) and `pd.isna()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)