### PR TITLE
perf(backend): use a fast password hasher for tests (6m40s → 6s)

### DIFF
--- a/backend/config/settings_test.py
+++ b/backend/config/settings_test.py
@@ -1,0 +1,12 @@
+"""Test-only settings.
+
+Imports the full production configuration and overrides only what makes the
+suite faster without changing behaviour under test. Kept separate so production
+password security is never weakened.
+"""
+from .settings import *  # noqa: F401,F403
+
+# The default PBKDF2 hasher runs ~600k iterations per password; the suite creates
+# well over a hundred users, so hashing dominates the run time. Tests don't need
+# real password security — MD5 cuts the full suite from minutes to well under one.
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = config.settings
+DJANGO_SETTINGS_MODULE = config.settings_test
 pythonpath = backend
 python_files = tests.py test_*.py *_tests.py
 addopts = -q


### PR DESCRIPTION
## Problem

The backend test suite took **~6m40s**. Profiling (`--durations`) showed every slow test at 3–4s, all creating multiple users. The suite makes **138 `create_user`/`set_password` calls**, and with Django's default **PBKDF2 hasher (~600k iterations)** and no test override, password hashing dominated the entire run.

## Proof

Timing the `accounts` suite (38 tests) in isolation:

| Config | Time |
|---|---|
| Default PBKDF2 (before) | 67s |
| MD5 hasher | 3s |
| MD5 + `--no-migrations` | 3s (no further gain) |

`--no-migrations` adding nothing confirms migration replay is *not* a factor — it's purely hashing.

## Fix

A dedicated test-settings module that overrides **only** `PASSWORD_HASHERS`, kept separate so production hashing is never weakened:

```python
# backend/config/settings_test.py
from .settings import *  # noqa
PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
```

and `pytest.ini` now points `DJANGO_SETTINGS_MODULE` at it.

**Full suite: ~6m40s → ~6s**, all tests still passing. CI picks this up automatically (it reads `pytest.ini`).

## Why not pytest-xdist too

Considered it, measured against it: at 6s, each parallel worker would rebuild the test DB (40 migrations) plus startup overhead, which exceeds the whole runtime. It would make the suite *slower*, so it's deliberately not added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)