### PR TITLE
feat(invoices): emit document PDFs as PDF/A-3b

### DIFF
--- a/Dockerfile.fullstack
+++ b/Dockerfile.fullstack
@@ -46,6 +46,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcairo2 \
     libffi-dev \
     shared-mime-info \
+    fonts-liberation \
+    fonts-noto \
     nginx \
     && rm -rf /var/lib/apt/lists/*
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcairo2 \
     libffi-dev \
     shared-mime-info \
+    fonts-liberation \
+    fonts-noto \
     && rm -rf /var/lib/apt/lists/*
 
 COPY backend/requirements.txt /tmp/requirements.txt

--- a/backend/invoices/annual_statement.py
+++ b/backend/invoices/annual_statement.py
@@ -14,7 +14,7 @@ from decimal import Decimal, ROUND_HALF_UP
 from django.template.loader import render_to_string
 from django.template import Template, Context
 from accounts.models import AppSettings
-from weasyprint import HTML
+from .pdf_render import render_pdf
 
 from metering.models import MeterReading, ReadingDirection
 from zev.models import MeteringPoint, MeteringPointType, MeteringPointAssignment
@@ -560,5 +560,4 @@ def generate_annual_statement_pdf(participant, zev, year: int) -> bytes:
     }
 
     html_string = _render_template(ANNUAL_STATEMENT_TEMPLATE, context)
-    pdf_bytes = HTML(string=html_string, base_url=".").write_pdf()
-    return pdf_bytes
+    return render_pdf(html_string)

--- a/backend/invoices/contract_pdf.py
+++ b/backend/invoices/contract_pdf.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 
 from django.template.loader import render_to_string
 from django.template import Template, Context
-from weasyprint import HTML
+from .pdf_render import render_pdf
 
 from tariffs.models import BillingMode, EnergyType, PeriodType
 from zev.models import MeteringPointType
@@ -751,5 +751,4 @@ def generate_contract_pdf(participant) -> bytes:
         html_string = Template(record.content).render(Context(context))
     else:
         html_string = render_to_string(CONTRACT_TEMPLATE_NAME, context)
-    pdf_bytes = HTML(string=html_string, base_url=".").write_pdf()
-    return pdf_bytes
+    return render_pdf(html_string)

--- a/backend/invoices/financial_summary.py
+++ b/backend/invoices/financial_summary.py
@@ -12,7 +12,7 @@ from datetime import date
 from decimal import Decimal
 
 from accounts.models import AppSettings
-from weasyprint import HTML
+from .pdf_render import render_pdf
 
 from .models import Invoice, InvoiceItem, InvoiceStatus
 from .pdf import _format_date_value, _render_template
@@ -312,4 +312,4 @@ def generate_financial_summary_pdf(zev, participant, year: int) -> bytes:
     }
 
     html_string = _render_template(FINANCIAL_SUMMARY_TEMPLATE, context)
-    return HTML(string=html_string, base_url=".").write_pdf()
+    return render_pdf(html_string)

--- a/backend/invoices/pdf.py
+++ b/backend/invoices/pdf.py
@@ -13,9 +13,9 @@ from django.template import Template, Context
 from django.core.files.base import ContentFile
 from django.utils import timezone
 from accounts.models import AppSettings
-from weasyprint import HTML, CSS
 from tariffs.models import TariffCategory
 from .description_utils import strip_period_suffix
+from .pdf_render import render_pdf
 from .models import Invoice
 
 # ── Invoice translations ───────────────────────────────────────────────────────
@@ -1286,8 +1286,7 @@ def _render_template(template_name: str, context: dict) -> str:
 def generate_pdf(invoice) -> bytes:
     """Render the invoice to PDF bytes."""
     html_string = _render_template(TEMPLATE_NAME, _build_template_context(invoice))
-    pdf_bytes = HTML(string=html_string, base_url=".").write_pdf()
-    return pdf_bytes
+    return render_pdf(html_string)
 
 
 def save_invoice_pdf(invoice) -> None:

--- a/backend/invoices/pdf_render.py
+++ b/backend/invoices/pdf_render.py
@@ -1,0 +1,20 @@
+"""Shared WeasyPrint rendering helper.
+
+All document PDFs (invoices, annual statements, financial summaries, contracts)
+are rendered through :func:`render_pdf` so they share a single output format.
+
+We emit **PDF/A-3b**: a long-term-archival format (relevant for Swiss GeBüV
+retention) whose ``3`` level also permits embedding structured attachments,
+keeping the door open for e-invoicing payloads (eBill / Factur-X style) next to
+the existing QR-Rechnung. WeasyPrint adds the required XMP identification,
+sRGB OutputIntent (with embedded ICC profile) and font subsets automatically.
+"""
+from weasyprint import HTML
+
+# PDF/A-3b — see module docstring for the rationale behind this variant.
+PDF_VARIANT = "pdf/a-3b"
+
+
+def render_pdf(html_string: str, *, base_url: str = ".") -> bytes:
+    """Render an HTML string to PDF/A bytes."""
+    return HTML(string=html_string, base_url=base_url).write_pdf(pdf_variant=PDF_VARIANT)

--- a/backend/invoices/test_pdfa.py
+++ b/backend/invoices/test_pdfa.py
@@ -1,0 +1,114 @@
+"""Regression tests guarding the PDF/A output format.
+
+All document PDFs are rendered through ``invoices.pdf_render.render_pdf`` which
+emits PDF/A-3b. WeasyPrint writes the PDF/A identification (XMP ``pdfaid``), the
+sRGB ``OutputIntent`` and embedded font subsets automatically — these tests make
+sure nobody silently drops the ``pdf_variant`` argument.
+"""
+import re
+import zlib
+from datetime import date
+from decimal import Decimal
+
+from django.test import TestCase
+
+from accounts.models import User, UserRole
+from tariffs.models import TariffCategory
+from zev.models import Participant, Zev
+from .models import Invoice, InvoiceItem
+from .pdf import generate_pdf
+from .pdf_render import render_pdf
+
+
+def _inflate_all(pdf_bytes: bytes) -> bytes:
+    """Return the raw bytes plus every zlib-inflated stream.
+
+    PDF/A-3b stores metadata in compressed object streams, so the markers are
+    only visible after decompression.
+    """
+    blob = pdf_bytes
+    for match in re.finditer(rb"stream\r?\n(.*?)\r?\nendstream", pdf_bytes, re.S):
+        try:
+            blob += zlib.decompress(match.group(1))
+        except zlib.error:
+            continue
+    return blob
+
+
+def assert_is_pdfa(test: TestCase, pdf_bytes: bytes) -> None:
+    test.assertTrue(pdf_bytes.startswith(b"%PDF-1.7"), "expected a PDF-1.7 header")
+    whole = _inflate_all(pdf_bytes)
+    test.assertIn(b"pdfaid", whole, "missing PDF/A identification metadata")
+    test.assertIn(b"OutputIntent", whole, "missing PDF/A OutputIntent")
+
+
+class RenderPdfVariantTests(TestCase):
+    def test_render_pdf_emits_pdfa(self):
+        html = (
+            "<!DOCTYPE html><html lang='de'><head><meta charset='utf-8'>"
+            "<title>T</title></head><body><p>Rechnung Zürich</p></body></html>"
+        )
+        assert_is_pdfa(self, render_pdf(html))
+
+
+class InvoicePdfaTests(TestCase):
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            username="pdfa_owner", password="pass1234", role=UserRole.ZEV_OWNER
+        )
+        self.zev = Zev.objects.create(
+            name="PDFA ZEV",
+            owner=self.owner,
+            zev_type="vzev",
+            start_date=date(2026, 1, 1),
+            billing_interval="monthly",
+            invoice_prefix="Q",
+            bank_iban="CH9300762011623852957",
+            invoice_language="de",
+        )
+        Participant.objects.create(
+            zev=self.zev,
+            user=self.owner,
+            first_name="Test",
+            last_name="Owner",
+            email="owner@example.com",
+            address_line1="Bahnhofstrasse 1",
+            postal_code="8001",
+            city="Zürich",
+            valid_from=date(2026, 1, 1),
+        )
+        self.participant = Participant.objects.create(
+            zev=self.zev,
+            first_name="Alice",
+            last_name="Müster",
+            email="alice@example.com",
+            address_line1="Musterweg 3",
+            postal_code="3000",
+            city="Bern",
+            valid_from=date(2026, 1, 1),
+        )
+
+    def test_generated_invoice_pdf_is_pdfa(self):
+        invoice = Invoice.objects.create(
+            invoice_number="Q-00001",
+            zev=self.zev,
+            participant=self.participant,
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 1, 31),
+            total_chf=Decimal("42.00"),
+            total_local_kwh=Decimal("100"),
+            total_grid_kwh=Decimal("50"),
+            due_date=date(2026, 2, 28),
+        )
+        InvoiceItem.objects.create(
+            invoice=invoice,
+            item_type=InvoiceItem.ItemType.LOCAL_ENERGY,
+            tariff_category=TariffCategory.ENERGY,
+            description="Energie",
+            quantity_kwh=Decimal("100"),
+            unit="kWh",
+            unit_price_chf=Decimal("0.20"),
+            total_chf=Decimal("20.00"),
+        )
+
+        assert_is_pdfa(self, generate_pdf(invoice))


### PR DESCRIPTION
## What & why

The invoice PDFs (and annual statements, financial summaries, contracts) were plain PDFs. This switches them to **PDF/A-3b**, a long-term-archival format relevant for Swiss GeBüV retention. The `3` level also permits embedded attachments, keeping the door open for e-invoicing payloads (eBill / Factur-X style) alongside the existing QR-Rechnung.

## Changes

- **New shared helper** `invoices/pdf_render.py` — a single `render_pdf(html_string)` that renders via WeasyPrint with `pdf_variant="pdf/a-3b"`. WeasyPrint then supplies everything PDF/A requires automatically: XMP `pdfaid` identification, an embedded sRGB ICC `OutputIntent`, and font subsets.
- **All four generators routed through it** (and their now-unused `from weasyprint import HTML` imports removed): `pdf.py`, `annual_statement.py`, `financial_summary.py`, `contract_pdf.py`.
- **Fonts in the production images** — added `fonts-liberation` (Arial/Helvetica metric-compatible, matching the templates' intent) and `fonts-noto` (broad Unicode, incl. the `✂` payment-slip glyph) to `backend/Dockerfile` and `Dockerfile.fullstack`. The images previously shipped no font package, so glyphs now embed cleanly and deterministically in prod — also fixes a latent rendering-fidelity gap independent of PDF/A.
- **Regression test** `invoices/test_pdfa.py` — asserts both the helper and the real `generate_pdf(invoice)` output carry the PDF/A markers (`%PDF-1.7` header, `pdfaid`, `OutputIntent`), so the variant can't be silently dropped.

## Verification

- New tests pass; existing `test_pdf.py` passes; full `invoices/` suite green.
- Confirmed end-to-end against the real invoice template (QR-Rechnung + SVG charts + Sankey flow diagram) — the `fill-opacity` in the charts is permitted under PDF/A-3.
- No new Python dependencies — WeasyPrint 69.0 (pinned) already supports the variant.

## Notes / follow-ups (out of scope)

- This is PDF/A-3**b** (faithful visual reproduction), not **a** (tagged/accessible). PDF-UA would be a separate, larger effort — WeasyPrint's tagging isn't reliable enough today.
- For a hard external conformance guarantee, a veraPDF check in CI is the gold standard; happy to add as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)