### PR TITLE
fix(zev): let admins edit a ZEV owner's own participant record

### DIFF
--- a/backend/zev/serializers.py
+++ b/backend/zev/serializers.py
@@ -61,8 +61,10 @@ class ParticipantSerializer(serializers.ModelSerializer):
         if not email:
             raise serializers.ValidationError({"email": "Participant email is required."})
 
+        request = self.context.get("request")
+        is_admin = bool(request and request.user.is_admin)
         user = getattr(self.instance, "user", None)
-        if user is not None and user.role != UserRole.PARTICIPANT:
+        if user is not None and user.role != UserRole.PARTICIPANT and not is_admin:
             raise serializers.ValidationError({"user": "Linked account must have participant role."})
 
         return attrs

--- a/backend/zev/tests.py
+++ b/backend/zev/tests.py
@@ -263,6 +263,64 @@ class ParticipantAccountLifecycleTests(TestCase):
 		self.assertTrue(created.user.must_change_password)
 
 
+class AdminCanEditOwnerParticipantTests(TestCase):
+	"""The owner's own participant record (linked to a zev_owner-role account,
+	not a participant-role one) is invoice-critical — it's the creditor
+	address on generated PDFs — so an admin must be able to edit it, even
+	though a regular participant edit is normally blocked for non-participant
+	accounts."""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.owner = make_user("owner_for_edit_test", UserRole.ZEV_OWNER)
+		self.zev = Zev.objects.create(
+			name="Owner Edit ZEV",
+			owner=self.owner,
+			zev_type="vzev",
+			invoice_prefix="O",
+		)
+		self.owner_participant = Participant.objects.create(
+			zev=self.zev,
+			user=self.owner,
+			first_name="Olivia",
+			last_name="Owner",
+			email="olivia.owner@example.com",
+			address_line1="Old Street 1",
+			postal_code="8000",
+			city="Zurich",
+			valid_from=date(2026, 1, 1),
+		)
+
+	def test_admin_can_edit_the_owner_participant_address(self):
+		admin = make_user("admin_edit_owner", UserRole.ADMIN)
+		auth(self.client, admin)
+
+		resp = self.client.patch(
+			f"/api/v1/zev/participants/{self.owner_participant.id}/",
+			{"address_line1": "New Street 5", "postal_code": "3000", "city": "Bern"},
+			format="json",
+		)
+
+		self.assertEqual(resp.status_code, 200)
+		self.owner_participant.refresh_from_db()
+		self.assertEqual(self.owner_participant.address_line1, "New Street 5")
+		self.assertEqual(self.owner_participant.city, "Bern")
+
+	def test_zev_owner_cannot_edit_their_own_owner_participant_record(self):
+		auth(self.client, self.owner)
+
+		resp = self.client.patch(
+			f"/api/v1/zev/participants/{self.owner_participant.id}/",
+			{"address_line1": "New Street 5", "postal_code": "3000", "city": "Bern"},
+			format="json",
+		)
+
+		self.assertEqual(resp.status_code, 400)
+		self.assertIn("user", resp.data)
+		self.owner_participant.refresh_from_db()
+		self.assertEqual(self.owner_participant.address_line1, "Old Street 1")
+
+
 class ParticipantAccountLinkingTests(TestCase):
 	def setUp(self):
 		self.client = APIClient()


### PR DESCRIPTION
## Summary
- `ParticipantSerializer.validate()` blocked editing *any* field on a participant whose linked account isn't role `participant` — which always includes the ZEV owner's own participant record (linked to their `zev_owner`-role account). That record's address is invoice-critical (it's the creditor address on generated invoice PDFs), so once set during ZEV creation it could never be corrected through any UI path.
- Admins can now edit it. A `zev_owner` still cannot edit their own owner-participant record through this endpoint — only the admin bypass was added, matching what was asked for.

## Test plan
- [x] New tests: admin can PATCH the owner-participant's address (200, persisted); the ZEV owner themselves still gets blocked (400) editing the same record
- [x] Full backend `pytest` suite green