### PR TITLE
test(zev): mock the geocode task in the owner-address-edit test

### DIFF
--- a/backend/zev/tests.py
+++ b/backend/zev/tests.py
@@ -295,7 +295,8 @@ class AdminCanEditOwnerParticipantTests(TestCase):
 			valid_from=date(2026, 1, 1),
 		)
 
-	def test_admin_can_edit_the_owner_participant_address(self):
+	@mock.patch("zev.tasks.warm_participant_geocode_cache_task.delay")
+	def test_admin_can_edit_the_owner_participant_address(self, mock_geocode_delay):
 		admin = make_user("admin_edit_owner", UserRole.ADMIN)
 		auth(self.client, admin)
 


### PR DESCRIPTION
## Summary
Fixes the "Backend checks and tests" failure currently showing on #318 (the release-please PR), caused by combining #319 and #320 on `main`.

- `test_admin_can_edit_the_owner_participant_address` (added in #320) performs a genuinely successful admin address update. Now that #319's geocoding trigger is also on `main`, that update calls `warm_participant_geocode_cache_task.delay()` for real — which needs a Celery broker/result backend CI doesn't provide, failing with `RuntimeError: Retry limit exceeded while trying to reconnect to the Celery result store backend`.
- Each PR was green on its own: the test was written against a pre-#319 `main`, so the geocode trigger wasn't part of its code path yet. The interaction only surfaces once both are merged together.
- Fix: mock `zev.tasks.warm_participant_geocode_cache_task.delay`, matching the same pattern already used for the other participant-address tests.

## Test plan
- [x] Reproduced the exact CI failure locally by stopping my local Redis and running the full suite — confirmed the same traceback
- [x] Applied the fix, reran the full suite with Redis still stopped (matching CI) — all green