### PR TITLE
fix(zev): include all editable fields in participant.update audit diff

### DIFF
--- a/backend/audit/tests.py
+++ b/backend/audit/tests.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest import mock
 
 from django.test import TestCase
 from django.utils import timezone
@@ -359,6 +360,37 @@ class AuditPhase3InstrumentationTests(TestCase):
         ).latest("created_at")
         self.assertEqual(event.action_category, AuditActionCategory.PARTICIPANT)
         self.assertEqual(event.status, AuditEventStatus.SUCCESS)
+
+    @mock.patch("zev.tasks.warm_participant_geocode_cache_task.delay")
+    def test_participant_update_emits_audit_event_with_field_changes(self, mock_geocode_delay):
+        auth(self.client, self.admin)
+        response = self.client.patch(
+            f"/api/v1/zev/participants/{self.participant.id}/",
+            {
+                "first_name": "Updated",
+                "phone": "+41 79 123 45 67",
+                "address_line1": "Musterstrasse 1",
+                "postal_code": "8000",
+                "city": "Zurich",
+                "notes": "Prefers e-mail contact.",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        event = AuditEvent.objects.filter(
+            action_type="participant.update",
+            target_id=str(self.participant.id),
+        ).latest("created_at")
+        self.assertEqual(event.status, AuditEventStatus.SUCCESS)
+        self.assertEqual(event.changes_json.get("first_name", {}).get("before"), "Phase")
+        self.assertEqual(event.changes_json.get("first_name", {}).get("after"), "Updated")
+        self.assertEqual(event.changes_json.get("phone", {}).get("after"), "+41 79 123 45 67")
+        self.assertEqual(event.changes_json.get("address_line1", {}).get("after"), "Musterstrasse 1")
+        self.assertEqual(event.changes_json.get("postal_code", {}).get("after"), "8000")
+        self.assertEqual(event.changes_json.get("city", {}).get("after"), "Zurich")
+        self.assertEqual(event.changes_json.get("notes", {}).get("after"), "Prefers e-mail contact.")
+        self.assertNotIn("last_name", event.changes_json)
 
     def test_metering_delete_readings_emits_audit_event(self):
         MeterReading.objects.create(

--- a/backend/zev/views.py
+++ b/backend/zev/views.py
@@ -137,25 +137,44 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
             metadata={"zev_id": str(participant.zev_id)},
         )
 
+    PARTICIPANT_TRACKED_FIELDS = [
+        "title",
+        "first_name",
+        "last_name",
+        "email",
+        "phone",
+        "address_line1",
+        "address_line2",
+        "postal_code",
+        "city",
+        "valid_from",
+        "valid_to",
+        "notes",
+        "user",
+    ]
+
+    def _participant_snapshot(self, participant):
+        return {
+            "title": participant.title,
+            "first_name": participant.first_name,
+            "last_name": participant.last_name,
+            "email": participant.email,
+            "phone": participant.phone,
+            "address_line1": participant.address_line1,
+            "address_line2": participant.address_line2,
+            "postal_code": participant.postal_code,
+            "city": participant.city,
+            "valid_from": participant.valid_from,
+            "valid_to": participant.valid_to,
+            "notes": participant.notes,
+            "user": str(participant.user_id) if participant.user_id else None,
+        }
+
     def perform_update(self, serializer):
         participant = self.get_object()
-        before = {
-            "first_name": participant.first_name,
-            "last_name": participant.last_name,
-            "email": participant.email,
-            "valid_from": participant.valid_from,
-            "valid_to": participant.valid_to,
-            "user": str(participant.user_id) if participant.user_id else None,
-        }
+        before = self._participant_snapshot(participant)
         participant = serializer.save()
-        after = {
-            "first_name": participant.first_name,
-            "last_name": participant.last_name,
-            "email": participant.email,
-            "valid_from": participant.valid_from,
-            "valid_to": participant.valid_to,
-            "user": str(participant.user_id) if participant.user_id else None,
-        }
+        after = self._participant_snapshot(participant)
         _record_zev_event(
             request=self.request,
             action_category=AuditActionCategory.PARTICIPANT,
@@ -165,11 +184,7 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
             target_id=str(participant.pk),
             target_display=participant.full_name,
             summary=f"Updated participant {participant.full_name}.",
-            changes=build_diff(
-                before,
-                after,
-                ["first_name", "last_name", "email", "valid_from", "valid_to", "user"],
-            ),
+            changes=build_diff(before, after, self.PARTICIPANT_TRACKED_FIELDS),
         )
 
     def perform_destroy(self, instance):


### PR DESCRIPTION
## Summary
- The audit log entry for `participant.update` only diffed 6 of the 13 editable `Participant` fields (`first_name`, `last_name`, `email`, `valid_from`, `valid_to`, `user`), so edits to `title`, `phone`, `address_line1`, `address_line2`, `postal_code`, `city`, or `notes` produced an empty `changes_json` even though the update succeeded.
- Extended the before/after snapshot in `ParticipantViewSet.perform_update` to cover all editable fields so the audit log now shows what actually changed.
- `metadata_json` being empty for this action is expected/unrelated — it's a separate free-form field this action never populated; the diff belongs in `changes_json`, which the frontend already renders unconditionally.

## Test plan
- [x] `python manage.py test audit zev` — 61/61 pass
- [x] Added `test_participant_update_emits_audit_event_with_field_changes` in `backend/audit/tests.py` asserting the diff now includes phone/address/notes/first_name changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)