### PR TITLE
fix(frontend): keep the sidebar nav from overflowing and needing dual scroll

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -28,8 +28,7 @@ export function Layout() {
         location.pathname.startsWith('/zev-settings') ||
         location.pathname.startsWith('/metering-points') ||
         location.pathname.startsWith('/metering-data') ||
-        location.pathname.startsWith('/audit-logs') ||
-        location.pathname.startsWith('/admin/zevs'),
+        location.pathname.startsWith('/audit-logs'),
     )
     const [isAdminNavOpen, setIsAdminNavOpen] = useState(location.pathname.startsWith('/admin'))
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(() => {
@@ -45,16 +44,16 @@ export function Layout() {
     useEffect(() => {
         if (location.pathname.startsWith('/admin')) {
             setIsAdminNavOpen(true)
-        }
-        if (
+            setIsManageNavOpen(false)
+        } else if (
             location.pathname.startsWith('/participants') ||
             location.pathname.startsWith('/zev-settings') ||
             location.pathname.startsWith('/metering-points') ||
             location.pathname.startsWith('/metering-data') ||
-            location.pathname.startsWith('/audit-logs') ||
-            location.pathname.startsWith('/admin/zevs')
+            location.pathname.startsWith('/audit-logs')
         ) {
             setIsManageNavOpen(true)
+            setIsAdminNavOpen(false)
         }
     }, [location.pathname])
 
@@ -99,8 +98,7 @@ export function Layout() {
         location.pathname.startsWith('/zev-settings') ||
         location.pathname.startsWith('/metering-points') ||
         location.pathname.startsWith('/metering-data') ||
-        location.pathname.startsWith('/audit-logs') ||
-        location.pathname.startsWith('/admin/zevs')
+        location.pathname.startsWith('/audit-logs')
 
     const ownerById = new Map((usersQuery.data?.results ?? []).map((candidate) => [candidate.id, candidate]))
     const selectedZevOwner = selectedZev ? ownerById.get(selectedZev.owner) : undefined
@@ -163,7 +161,11 @@ export function Layout() {
                                         <button
                                             type="button"
                                             className={`nav-toggle${manageIsActive ? ' active' : ''}`}
-                                            onClick={() => setIsManageNavOpen((prev) => !prev)}
+                                            onClick={() => setIsManageNavOpen((prev) => {
+                                                const next = !prev
+                                                if (next) setIsAdminNavOpen(false)
+                                                return next
+                                            })}
                                             title={t('nav.manageZev')}
                                         >
                                             <span className="nav-toggle-main">
@@ -269,7 +271,11 @@ export function Layout() {
                                         <button
                                             type="button"
                                             className={`nav-toggle${adminIsActive ? ' active' : ''}`}
-                                            onClick={() => setIsAdminNavOpen((prev) => !prev)}
+                                            onClick={() => setIsAdminNavOpen((prev) => {
+                                                const next = !prev
+                                                if (next) setIsManageNavOpen(false)
+                                                return next
+                                            })}
                                             title={t('nav.adminConsole')}
                                         >
                                             <span className="nav-toggle-main">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -111,7 +111,9 @@ label {
   display: grid;
   gap: 1.5rem;
   flex: 1;
+  min-width: 0;
   min-height: 0;
+  overflow-x: hidden;
   overflow-y: auto;
   padding-right: 0.25rem;
   scrollbar-width: thin;
@@ -187,6 +189,7 @@ label {
 .nav-list {
   display: grid;
   gap: 0.5rem;
+  min-width: 0;
 }
 
 .nav-zev-selector {
@@ -237,6 +240,7 @@ label {
 .nav-link,
 .nav-toggle {
   width: 100%;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: 0.8rem;
@@ -258,6 +262,7 @@ label {
 .nav-section {
   display: grid;
   gap: 0.4rem;
+  min-width: 0;
 }
 
 .nav-toggle {
@@ -272,6 +277,8 @@ label {
   display: inline-flex;
   align-items: center;
   gap: 0.8rem;
+  min-width: 0;
+  flex: 1;
 }
 
 .nav-icon {
@@ -290,6 +297,9 @@ label {
 
 .nav-label {
   min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .nav-caret {
@@ -301,6 +311,7 @@ label {
   display: grid;
   gap: 0.4rem;
   padding-left: 1rem;
+  min-width: 0;
 }
 
 .nav-sublist .nav-link {


### PR DESCRIPTION
## Summary
- The sidebar's "Manage (v)ZEV" and "Admin Console" groups could both be expanded at once (a route-based bug also forced both open when visiting `/admin/zevs`), pushing 21+ rows into view and permanently requiring vertical scrolling. Expanding one group now auto-collapses the other.
- Long nav labels (e.g. German `Wirtschaftlichkeitsrechner`, a single 26-character compound word) were forcing the sidebar wider than its 280px column, requiring horizontal scrolling. Root cause: several nested `display: grid`/`flex` containers in the nav chain (`nav-list` → `nav-section` → `nav-sublist`/`nav-toggle` → `nav-link`/`nav-label`) default to `min-width: auto`, so they grow to fit a label's full unwrapped width instead of respecting the fixed column, and `.sidebar-top`'s `overflow-y: auto` was implicitly making `overflow-x` behave as `auto` too instead of clipping. Fixed by threading `min-width: 0` down the chain and adding ellipsis truncation + an explicit `overflow-x: hidden`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Verified in a browser against the project's podman-compose dev stack (frontend :5173, backend :8001), with a temporary test admin (removed afterward):
  - Accordion: opening one nav group collapses the other; `/admin/zevs` no longer force-opens both.
  - English + German locales, both nav groups expanded and scrolled to the bottom: `sidebar-top.scrollWidth === clientWidth` (no horizontal overflow) in every state checked.
  - Long labels truncate visibly with an ellipsis instead of blowing out the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)