### PR TITLE
fix: duplicate plus icon, cache outage crash, and Swiss number formatting

### DIFF
--- a/backend/zev/geocoding.py
+++ b/backend/zev/geocoding.py
@@ -141,7 +141,11 @@ def get_cached_building_footprint(address_line1: str, postal_code: str, city: st
     if not (address_line1 or "").strip():
         return None
 
-    cached = cache.get(_cache_key(address_line1, postal_code, city))
+    try:
+        cached = cache.get(_cache_key(address_line1, postal_code, city))
+    except Exception:
+        logger.warning("Cache read failed for %s, %s %s", address_line1, postal_code, city, exc_info=True)
+        return None
     if cached is None or cached == _NOT_FOUND:
         return None
     return cached

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -5,13 +5,15 @@ import { de } from './locales/de'
 import { fr } from './locales/fr'
 import { it } from './locales/it'
 
-const getBrowserLanguage = (): string => {
-    const browserLang = navigator.language?.split('-')[0] || 'en'
-    return ['en', 'de', 'fr', 'it'].includes(browserLang) ? browserLang : 'en'
-}
+const langs = ['en', 'de', 'fr', 'it'] as const
+type Lang = (typeof langs)[number]
 
-const savedLang = localStorage.getItem('openzev.language')
-const initialLang = savedLang || getBrowserLanguage()
+const normalize = (lang?: string | null): Lang =>
+    langs.includes(lang as Lang) ? (lang as Lang) : 'en'
+
+const initial = normalize(
+    localStorage.getItem('openzev.language') ?? navigator.language?.split('-')[0],
+)
 
 void i18n.use(initReactI18next).init({
     resources: {
@@ -20,14 +22,22 @@ void i18n.use(initReactI18next).init({
         fr: { translation: fr },
         it: { translation: it },
     },
-    lng: initialLang,
+    lng: initial,
     fallbackLng: 'en',
+    supportedLngs: [...langs],
     interpolation: { escapeValue: false },
 })
 
-// Persist language preference when changed
+const setHtmlLang = (lang: string) => {
+    document.documentElement.lang = `${normalize(lang)}-CH`
+}
+
+setHtmlLang(initial)
+
 i18n.on('languageChanged', (lang) => {
-    localStorage.setItem('openzev.language', lang)
+    const next = normalize(lang)
+    localStorage.setItem('openzev.language', next)
+    setHtmlLang(next)
 })
 
 export default i18n

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -356,7 +356,7 @@ export const de = {
                 openProtocol: 'Protokoll öffnen',
                 deleteImport: 'Import löschen',
                 deleteImports: 'Importe löschen',
-                newImport: '+ Neuer Import',
+                newImport: 'Neuer Import',
             },
             messages: {
                 previewLoadedWithIssues: 'Vorschau mit {{count}} Problem(en) geladen.',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -357,7 +357,7 @@ export const en = {
                 openProtocol: 'Open protocol',
                 deleteImport: 'Delete import',
                 deleteImports: 'Delete imports',
-                newImport: '+ New Import',
+                newImport: 'New Import',
             },
             messages: {
                 previewLoadedWithIssues: 'Preview loaded with {{count}} issue(s).',

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -363,7 +363,7 @@ export const fr = {
                 openProtocol: 'Ouvrir le protocole',
                 deleteImport: 'Supprimer l’import',
                 deleteImports: 'Supprimer les imports',
-                newImport: '+ Nouvel import',
+                newImport: 'Nouvel import',
             },
             messages: {
                 previewLoadedWithIssues: 'Aperçu chargé avec {{count}} problème(s).',

--- a/frontend/src/i18n/locales/it.ts
+++ b/frontend/src/i18n/locales/it.ts
@@ -363,7 +363,7 @@ export const it = {
                 openProtocol: 'Apri protocollo',
                 deleteImport: 'Elimina importazione',
                 deleteImports: 'Elimina importazioni',
-                newImport: '+ Nuova importazione',
+                newImport: 'Nuova importazione',
             },
             messages: {
                 previewLoadedWithIssues: 'Anteprima caricata con {{count}} problema/i.',


### PR DESCRIPTION
## Summary

Three isolated bugfixes with no API or workflow impact:

- **Duplicate plus icon**: The "New Import" button rendered a `+` icon both in the i18n label and as a separate icon element. Removed the duplicate from the locale files.
- **Cache outage crash**: `get_cached_building_footprint()` calls Redis during participant serialization. When Redis is unreachable, the unhandled `ConnectionError` 500s the entire `/zev/participants/` endpoint. Now returns `None` (no footprint) instead of crashing.
- **Swiss number formatting**: Browsers map `<html lang="de">` to `de_DE` (comma decimal), not `de_CH` (dot decimal), causing commas in number inputs. Sets BCP 47 Swiss locale (`de-CH`, `fr-CH`, `it-CH`) on the `<html>` element and normalizes language detection with `supportedLngs`.

## Linked spec

- Spec: n/a
- ADR: n/a

These are small, isolated bugfixes with no API or workflow impact.

## Validation

- Backend tests run: `python -m pytest metering/ accounts/ invoices/ -q`
- Frontend build run: `npm run build`
- Manual checks done:
  - [x] i18n coverage for user-facing frontend changes

## Checklist

- [x] Small, isolated bugfixes — no spec or ADR needed
- [x] No API contract changes
