### PR TITLE
refactor(audit): derive update diffs from serializers and drop recorder boilerplate

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -35,6 +35,7 @@ from .serializers import (
 from .models import AppSettings, FeatureFlag, VatRate
 from .permissions import IsAdmin
 from audit.models import AuditActionCategory, AuditEventStatus
+from audit.mixins import AuditedUpdateMixin
 from audit.services import build_diff, record_audit_event
 
 logger = logging.getLogger(__name__)
@@ -81,39 +82,6 @@ def _clear_auth_cookies(
 ) -> None:
     response.delete_cookie(access_cookie, path="/")
     response.delete_cookie(refresh_cookie, path="/")
-
-
-def _record_accounts_event(
-    *,
-    request=None,
-    action_category: str,
-    action_type: str,
-    target_type: str,
-    summary: str,
-    target=None,
-    target_id: str = "",
-    target_display: str = "",
-    status: str = AuditEventStatus.SUCCESS,
-    changes: dict | None = None,
-    metadata: dict | None = None,
-    reason: str = "",
-    user=None,
-):
-    record_audit_event(
-        request=request,
-        user=user,
-        action_category=action_category,
-        action_type=action_type,
-        target_type=target_type,
-        target=target,
-        target_id=target_id,
-        target_display=target_display,
-        summary=summary,
-        status=status,
-        changes=changes,
-        metadata=metadata,
-        reason=reason,
-    )
 
 
 class CustomTokenObtainPairView(TokenObtainPairView):
@@ -182,7 +150,7 @@ class UserListCreateView(generics.ListCreateAPIView):
 
     def create(self, request, *args, **kwargs):
         if not request.user.is_admin:
-            _record_accounts_event(
+            record_audit_event(
                 request=request,
                 action_category=AuditActionCategory.AUTH,
                 action_type="user.create",
@@ -195,7 +163,7 @@ class UserListCreateView(generics.ListCreateAPIView):
 
     def perform_create(self, serializer):
         user = serializer.save()
-        _record_accounts_event(
+        record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.AUTH,
             action_type="user.create",
@@ -208,45 +176,23 @@ class UserListCreateView(generics.ListCreateAPIView):
         )
 
 
-class UserDetailView(generics.RetrieveUpdateDestroyAPIView):
+class UserDetailView(AuditedUpdateMixin, generics.RetrieveUpdateDestroyAPIView):
     """Admin: retrieve / update / delete a user."""
     queryset = User.objects.all()
     serializer_class = UserSerializer
     permission_classes = [IsAdmin]
 
-    USER_TRACKED_FIELDS = ["username", "email", "first_name", "last_name", "role", "must_change_password", "is_active"]
+    audit_action_category = AuditActionCategory.AUTH
+    audit_action_type = "user.update"
+    audit_target_type = "accounts.User"
+    audit_target_label = "user"
 
-    def _user_snapshot(self, user):
-        return {
-            "username": user.username,
-            "email": user.email,
-            "first_name": user.first_name,
-            "last_name": user.last_name,
-            "role": user.role,
-            "must_change_password": user.must_change_password,
-            "is_active": user.is_active,
-        }
-
-    def perform_update(self, serializer):
-        instance = self.get_object()
-        before = self._user_snapshot(instance)
-        user = serializer.save()
-        after = self._user_snapshot(user)
-        _record_accounts_event(
-            request=self.request,
-            action_category=AuditActionCategory.AUTH,
-            action_type="user.update",
-            target_type="accounts.User",
-            target=user,
-            target_id=str(user.pk),
-            target_display=user.email or user.username,
-            summary=f"Updated user {user.email or user.username}.",
-            changes=build_diff(before, after, self.USER_TRACKED_FIELDS),
-        )
+    def get_audit_target_display(self, instance):
+        return instance.email or instance.username
 
     def perform_destroy(self, instance):
         if instance.participations.exists():
-            _record_accounts_event(
+            record_audit_event(
                 request=self.request,
                 action_category=AuditActionCategory.AUTH,
                 action_type="user.delete",
@@ -261,7 +207,7 @@ class UserDetailView(generics.RetrieveUpdateDestroyAPIView):
         user_display = instance.email or instance.username
         user_id = str(instance.pk)
         instance.delete()
-        _record_accounts_event(
+        record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.AUTH,
             action_type="user.delete",
@@ -281,7 +227,7 @@ class VatRateListCreateView(generics.ListCreateAPIView):
     def perform_create(self, serializer):
         try:
             vat_rate = serializer.save()
-            _record_accounts_event(
+            record_audit_event(
                 request=self.request,
                 action_category=AuditActionCategory.GOVERNANCE,
                 action_type="vat_rate.create",
@@ -315,7 +261,7 @@ class VatRateDetailView(generics.RetrieveUpdateDestroyAPIView):
                 "valid_from": vat_rate.valid_from,
                 "valid_to": vat_rate.valid_to,
             }
-            _record_accounts_event(
+            record_audit_event(
                 request=self.request,
                 action_category=AuditActionCategory.GOVERNANCE,
                 action_type="vat_rate.update",
@@ -333,7 +279,7 @@ class VatRateDetailView(generics.RetrieveUpdateDestroyAPIView):
         vat_id = str(instance.pk)
         vat_display = f"VAT {instance.rate}%"
         instance.delete()
-        _record_accounts_event(
+        record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.GOVERNANCE,
             action_type="vat_rate.delete",
@@ -377,7 +323,7 @@ def change_password(request):
     serializer = ChangePasswordSerializer(data=request.data, context={"request": request})
     serializer.is_valid(raise_exception=True)
     serializer.save()
-    _record_accounts_event(
+    record_audit_event(
         request=request,
         action_category=AuditActionCategory.AUTH,
         action_type="password.change",
@@ -399,7 +345,7 @@ def app_settings(request):
         return Response(AppSettingsSerializer(settings_instance).data)
 
     if not request.user.is_admin:
-        _record_accounts_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.GOVERNANCE,
             action_type="app_settings.update",
@@ -422,7 +368,7 @@ def app_settings(request):
         "date_format_long": updated.date_format_long,
         "date_time_format": updated.date_time_format,
     }
-    _record_accounts_event(
+    record_audit_event(
         request=request,
         action_category=AuditActionCategory.GOVERNANCE,
         action_type="app_settings.update",
@@ -454,7 +400,7 @@ def feature_flags_list(request):
 def feature_flag_update(request, pk: int):
     """Toggle a feature flag. Admin-only."""
     if not request.user.is_admin:
-        _record_accounts_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.GOVERNANCE,
             action_type="feature_flag.update",
@@ -475,7 +421,7 @@ def feature_flag_update(request, pk: int):
     serializer.is_valid(raise_exception=True)
     before = {"enabled": flag.enabled}
     updated = serializer.save()
-    _record_accounts_event(
+    record_audit_event(
         request=request,
         action_category=AuditActionCategory.GOVERNANCE,
         action_type="feature_flag.update",
@@ -493,7 +439,7 @@ def feature_flag_update(request, pk: int):
 @permission_classes([IsAuthenticated])
 def impersonate_participant(request, user_id: int):
     if not request.user.is_admin:
-        _record_accounts_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.AUTH,
             action_type="impersonation.issue_token",
@@ -508,7 +454,7 @@ def impersonate_participant(request, user_id: int):
     try:
         target_user = User.objects.get(pk=user_id)
     except User.DoesNotExist:
-        _record_accounts_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.AUTH,
             action_type="impersonation.issue_token",
@@ -521,7 +467,7 @@ def impersonate_participant(request, user_id: int):
         return Response({"detail": "User not found."}, status=status.HTTP_404_NOT_FOUND)
 
     if target_user.role not in (UserRole.PARTICIPANT, UserRole.ZEV_OWNER):
-        _record_accounts_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.AUTH,
             action_type="impersonation.issue_token",
@@ -542,7 +488,7 @@ def impersonate_participant(request, user_id: int):
     refresh["must_change_password"] = target_user.must_change_password
     refresh["impersonated_by"] = request.user.id
 
-    _record_accounts_event(
+    record_audit_event(
         request=request,
         action_category=AuditActionCategory.AUTH,
         action_type="impersonation.issue_token",
@@ -692,7 +638,7 @@ def verify_email(request):
     user.is_active = True
     user.save(update_fields=["is_active"])
 
-    _record_accounts_event(
+    record_audit_event(
         action_category=AuditActionCategory.AUTH,
         action_type="email.verify",
         target_type="accounts.User",
@@ -720,7 +666,7 @@ def set_initial_password(request):
 
     user = request.user
     if not (user.must_change_password or not user.has_usable_password()):
-        _record_accounts_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.AUTH,
             action_type="password.set_initial",
@@ -745,7 +691,7 @@ def set_initial_password(request):
     user.must_change_password = False
     user.save(update_fields=["password", "must_change_password"])
 
-    _record_accounts_event(
+    record_audit_event(
         request=request,
         action_category=AuditActionCategory.AUTH,
         action_type="password.set_initial",

--- a/backend/audit/mixins.py
+++ b/backend/audit/mixins.py
@@ -1,0 +1,62 @@
+"""DRF mixins that wire views into the audit trail."""
+from __future__ import annotations
+
+from .models import AuditEventStatus
+from .services import build_diff, build_instance_snapshot, record_audit_event
+
+
+class AuditedUpdateMixin:
+    """Record an audit event with a before/after field diff on update.
+
+    Tracked fields default to the serializer's *writable* fields. Deriving them
+    rather than hand-listing them is the point of this mixin: a hand-written
+    list silently stops matching what the endpoint accepts as soon as a field is
+    added to the serializer, and the resulting diff looks empty even though the
+    update succeeded.
+
+    Subclasses must set :attr:`audit_action_category`, :attr:`audit_action_type`
+    and :attr:`audit_target_type`. Override :attr:`audit_tracked_fields` only to
+    deliberately deviate from the serializer, and :attr:`audit_extra_fields` to
+    track something the serializer does not expose.
+    """
+
+    audit_action_category: str = ""
+    audit_action_type: str = ""
+    audit_target_type: str = ""
+    audit_target_label: str = ""
+    audit_tracked_fields: list[str] | None = None
+    audit_extra_fields: tuple[str, ...] = ()
+
+    def get_audit_tracked_fields(self, serializer) -> list[str]:
+        if self.audit_tracked_fields is not None:
+            tracked = list(self.audit_tracked_fields)
+        else:
+            tracked = [name for name, field in serializer.fields.items() if not field.read_only]
+        return tracked + [name for name in self.audit_extra_fields if name not in tracked]
+
+    def get_audit_target_display(self, instance) -> str:
+        return str(instance)
+
+    def get_audit_summary(self, instance) -> str:
+        label = self.audit_target_label or self.audit_target_type.rsplit(".", 1)[-1].lower()
+        return f"Updated {label} {self.get_audit_target_display(instance)}."
+
+    def perform_update(self, serializer):
+        tracked_fields = self.get_audit_tracked_fields(serializer)
+        before = build_instance_snapshot(self.get_object(), tracked_fields)
+        instance = serializer.save()
+        after = build_instance_snapshot(instance, tracked_fields)
+
+        record_audit_event(
+            request=self.request,
+            action_category=self.audit_action_category,
+            action_type=self.audit_action_type,
+            target_type=self.audit_target_type,
+            target=instance,
+            target_id=str(instance.pk),
+            target_display=self.get_audit_target_display(instance),
+            summary=self.get_audit_summary(instance),
+            status=AuditEventStatus.SUCCESS,
+            changes=build_diff(before, after, tracked_fields),
+        )
+        return instance

--- a/backend/audit/services.py
+++ b/backend/audit/services.py
@@ -97,6 +97,23 @@ def build_diff(before: dict[str, Any] | None, after: dict[str, Any] | None, allo
     return diff
 
 
+def build_instance_snapshot(instance: Any, fields: Iterable[str]) -> dict[str, Any]:
+    """Capture ``fields`` off a model instance for use with :func:`build_diff`.
+
+    Foreign keys are read from their ``<field>_id`` attribute so the snapshot
+    stays a plain scalar and no related row has to be fetched.
+    """
+    snapshot: dict[str, Any] = {}
+    for field in fields:
+        fk_attr = f"{field}_id"
+        if hasattr(instance, fk_attr):
+            fk_value = getattr(instance, fk_attr)
+            snapshot[field] = str(fk_value) if fk_value is not None else None
+        else:
+            snapshot[field] = getattr(instance, field, None)
+    return snapshot
+
+
 def infer_zev(target: Any):
     if target is None:
         return None

--- a/backend/audit/test_summary_parity.py
+++ b/backend/audit/test_summary_parity.py
@@ -1,0 +1,145 @@
+"""Pin the audit summary/target_display strings produced by AuditedUpdateMixin.
+
+These strings were previously built inline in each viewset's perform_update.
+They are user-visible in the audit log, so they must not drift when the
+snapshot/diff plumbing is refactored.
+"""
+from unittest import mock
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from accounts.models import User, UserRole
+from audit.models import AuditEvent
+from tariffs.models import BillingMode, Tariff, TariffCategory
+from testing.helpers import authenticate as auth
+from zev.models import (
+    MeteringPoint,
+    MeteringPointAssignment,
+    MeteringPointType,
+    Participant,
+    Zev,
+)
+
+
+def make_user(username: str, role: str) -> User:
+    return User.objects.create_user(
+        username=username, email=f"{username}@example.com", password="pass1234", role=role
+    )
+
+
+class AuditSummaryParityTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = make_user("parity_admin", UserRole.ADMIN)
+        self.owner = make_user("parity_owner", UserRole.ZEV_OWNER)
+        self.zev = Zev.objects.create(name="Parity ZEV", owner=self.owner)
+        self.participant = Participant.objects.create(
+            zev=self.zev,
+            first_name="Par",
+            last_name="Ity",
+            email="parity@example.com",
+            valid_from=timezone.localdate(),
+        )
+        self.metering_point = MeteringPoint.objects.create(
+            zev=self.zev,
+            meter_id="CH9990000000000000000000000000010",
+            meter_type=MeteringPointType.CONSUMPTION,
+        )
+        self.assignment = MeteringPointAssignment.objects.create(
+            metering_point=self.metering_point,
+            participant=self.participant,
+            valid_from=timezone.localdate(),
+        )
+
+    def _latest(self, action_type, target_id):
+        return AuditEvent.objects.filter(action_type=action_type, target_id=str(target_id)).latest("created_at")
+
+    @mock.patch("zev.tasks.warm_participant_geocode_cache_task.delay")
+    def test_participant_update_summary(self, _geocode):
+        auth(self.client, self.admin)
+        resp = self.client.patch(
+            f"/api/v1/zev/participants/{self.participant.id}/", {"city": "Bern"}, format="json"
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.participant.refresh_from_db()
+        event = self._latest("participant.update", self.participant.id)
+        self.assertEqual(event.summary, f"Updated participant {self.participant.full_name}.")
+        self.assertEqual(event.target_display, self.participant.full_name)
+
+    def test_metering_point_update_summary(self):
+        auth(self.client, self.admin)
+        resp = self.client.patch(
+            f"/api/v1/zev/metering-points/{self.metering_point.id}/",
+            {"location_description": "Attic"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        event = self._latest("metering_point.update", self.metering_point.id)
+        self.assertEqual(event.summary, f"Updated metering point {self.metering_point.meter_id}.")
+        self.assertEqual(event.target_display, self.metering_point.meter_id)
+
+    def test_metering_assignment_update_summary(self):
+        auth(self.client, self.admin)
+        resp = self.client.patch(
+            f"/api/v1/zev/metering-point-assignments/{self.assignment.id}/",
+            {"valid_to": timezone.localdate().isoformat()},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        event = self._latest("metering_assignment.update", self.assignment.id)
+        self.assertEqual(
+            event.summary,
+            f"Updated metering point assignment for {self.metering_point.meter_id}.",
+        )
+        self.assertEqual(event.target_display, str(self.assignment.pk))
+
+    def test_tariff_update_summary(self):
+        tariff = Tariff.objects.create(
+            zev=self.zev,
+            name="Parity Tariff",
+            category=TariffCategory.ENERGY,
+            billing_mode=BillingMode.ENERGY,
+            energy_type="grid",
+            valid_from=timezone.localdate(),
+        )
+        auth(self.client, self.owner)
+        resp = self.client.patch(
+            f"/api/v1/tariffs/tariffs/{tariff.id}/", {"name": "Parity Renamed"}, format="json"
+        )
+        self.assertEqual(resp.status_code, 200)
+        event = self._latest("tariff.update", tariff.id)
+        self.assertEqual(event.summary, "Updated tariff Parity Renamed.")
+        self.assertEqual(event.target_display, "Parity Renamed")
+
+    def test_tariff_period_update_summary(self):
+        tariff = Tariff.objects.create(
+            zev=self.zev,
+            name="Parity Period Tariff",
+            category=TariffCategory.ENERGY,
+            billing_mode=BillingMode.ENERGY,
+            energy_type="local",
+            valid_from=timezone.localdate(),
+        )
+        period = tariff.periods.create(period_type="flat", price_chf_per_kwh="0.10000")
+        auth(self.client, self.owner)
+        resp = self.client.patch(
+            f"/api/v1/tariffs/periods/{period.id}/", {"price_chf_per_kwh": "0.11000"}, format="json"
+        )
+        self.assertEqual(resp.status_code, 200)
+        event = self._latest("tariff_period.update", period.id)
+        self.assertEqual(event.summary, f"Updated tariff period flat for tariff {tariff.name}.")
+        self.assertEqual(event.target_display, "flat")
+
+    def test_user_update_summary(self):
+        target = make_user("parity_target", UserRole.PARTICIPANT)
+        auth(self.client, self.admin)
+        resp = self.client.patch(
+            f"/api/v1/auth/users/{target.id}/", {"first_name": "Renamed"}, format="json"
+        )
+        self.assertEqual(resp.status_code, 200)
+        target.refresh_from_db()
+        event = self._latest("user.update", target.id)
+        self.assertEqual(event.summary, f"Updated user {target.email}.")
+        self.assertEqual(event.target_display, target.email)

--- a/backend/audit/tests.py
+++ b/backend/audit/tests.py
@@ -12,7 +12,14 @@ from tariffs.models import Tariff, TariffCategory, BillingMode
 from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
 
 from audit.models import AuditActionCategory, AuditEvent, AuditEventStatus
-from audit.services import build_diff, infer_zev, record_audit_event, redact_metadata
+from audit.services import (
+    build_diff,
+    build_instance_snapshot,
+    infer_zev,
+    record_audit_event,
+    redact_metadata,
+)
+from zev.serializers import ParticipantSerializer
 
 
 from testing.helpers import authenticate as auth
@@ -126,6 +133,39 @@ class AuditEventModelTests(TestCase):
             allowed_fields=["status", "total"],
         )
         self.assertEqual(diff, {"status": {"before": "draft", "after": "approved"}})
+
+    def test_build_instance_snapshot_reads_fks_without_extra_queries(self):
+        participant = Participant.objects.create(
+            zev=self.zev,
+            first_name="Snap",
+            last_name="Shot",
+            email="snap@example.com",
+            valid_from=timezone.localdate(),
+        )
+        # Re-fetch so the FK is not already cached on the instance.
+        participant = Participant.objects.get(pk=participant.pk)
+
+        with self.assertNumQueries(0):
+            snapshot = build_instance_snapshot(participant, ["zev", "first_name", "user"])
+
+        self.assertEqual(snapshot["zev"], str(self.zev.pk))
+        self.assertEqual(snapshot["first_name"], "Snap")
+        self.assertIsNone(snapshot["user"])
+
+    def test_audited_update_mixin_tracks_every_writable_serializer_field(self):
+        """The mixin derives tracked fields from the serializer rather than a
+        hand-written list, so a newly added writable field is audited without
+        anyone remembering to update a second list."""
+        from zev.views import ParticipantViewSet
+
+        view = ParticipantViewSet()
+        serializer = ParticipantSerializer()
+        tracked = set(view.get_audit_tracked_fields(serializer))
+        writable = {name for name, field in serializer.fields.items() if not field.read_only}
+
+        self.assertEqual(tracked, writable)
+        # Spot-check the fields whose absence caused the original bug.
+        self.assertTrue({"phone", "address_line1", "postal_code", "city", "notes"} <= tracked)
 
     def test_infer_zev_resolves_nested_objects(self):
         participant = Participant.objects.create(

--- a/backend/invoices/views.py
+++ b/backend/invoices/views.py
@@ -48,35 +48,19 @@ def _invoice_target_display(invoice: Invoice) -> str:
     return invoice.invoice_number or str(invoice.pk)
 
 
-def _record_invoice_event(
-    *,
-    request,
-    action_type: str,
-    summary: str,
-    status: str = AuditEventStatus.SUCCESS,
-    invoice: Invoice | None = None,
-    target_type: str = "invoices.Invoice",
-    target_id: str = "",
-    target_display: str = "",
-    changes: dict | None = None,
-    metadata: dict | None = None,
-    reason: str = "",
-):
-    resolved_target_id = target_id or (str(invoice.pk) if invoice else "")
-    resolved_target_display = target_display or (_invoice_target_display(invoice) if invoice else "")
+def _record_invoice_event(*, invoice: Invoice | None = None, target_id: str = "", target_display: str = "", **kwargs):
+    """Record an invoice audit event, defaulting the target to ``invoice``.
+
+    Unlike the other apps this wrapper earns its keep: callers pass the invoice
+    itself and get target/id/display derived from it.
+    """
     record_audit_event(
-        request=request,
         action_category=AuditActionCategory.INVOICE,
-        action_type=action_type,
-        target_type=target_type,
+        target_type=kwargs.pop("target_type", "invoices.Invoice"),
         target=invoice,
-        target_id=resolved_target_id,
-        target_display=resolved_target_display,
-        summary=summary,
-        status=status,
-        changes=changes,
-        metadata=metadata,
-        reason=reason,
+        target_id=target_id or (str(invoice.pk) if invoice else ""),
+        target_display=target_display or (_invoice_target_display(invoice) if invoice else ""),
+        **kwargs,
     )
 
 

--- a/backend/metering/views.py
+++ b/backend/metering/views.py
@@ -26,33 +26,6 @@ from audit.models import AuditActionCategory, AuditEventStatus
 from audit.services import record_audit_event
 
 
-def _record_metering_event(
-    *,
-    request,
-    action_category: str,
-    action_type: str,
-    target_type: str,
-    summary: str,
-    target=None,
-    target_id: str = "",
-    target_display: str = "",
-    status: str = AuditEventStatus.SUCCESS,
-    metadata: dict | None = None,
-):
-    record_audit_event(
-        request=request,
-        action_category=action_category,
-        action_type=action_type,
-        target_type=target_type,
-        target=target,
-        target_id=target_id,
-        target_display=target_display,
-        summary=summary,
-        status=status,
-        metadata=metadata,
-    )
-
-
 class MeterReadingViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     serializer_class = MeterReadingSerializer
     permission_classes = [IsAuthenticated, IsZevOwnerOrAdmin]
@@ -361,7 +334,7 @@ class ImportLogViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, mixins.
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
         result = self._delete_import_logs(self.get_queryset().filter(pk=instance.pk))
-        _record_metering_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.METERING,
             action_type="import_log.delete",
@@ -395,7 +368,7 @@ class ImportLogViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, mixins.
 
         result = self._delete_import_logs(queryset)
         result["mode"] = mode
-        _record_metering_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.METERING,
             action_type="import_log.bulk_delete",
@@ -429,7 +402,7 @@ class ImportView(viewsets.ViewSet):
     def preview_csv_import(self, request):
         file = request.FILES.get("file")
         if not file:
-            _record_metering_event(
+            record_audit_event(
                 request=request,
                 action_category=AuditActionCategory.IMPORT,
                 action_type="import.preview_csv",
@@ -462,7 +435,7 @@ class ImportView(viewsets.ViewSet):
                 values_count=values_count,
             )
         except Exception as exc:
-            _record_metering_event(
+            record_audit_event(
                 request=request,
                 action_category=AuditActionCategory.IMPORT,
                 action_type="import.preview_csv",
@@ -473,7 +446,7 @@ class ImportView(viewsets.ViewSet):
             )
             raise
 
-        _record_metering_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.IMPORT,
             action_type="import.preview_csv",
@@ -491,7 +464,7 @@ class ImportView(viewsets.ViewSet):
     def _do_import(self, request, source):
         file = request.FILES.get("file")
         if not file:
-            _record_metering_event(
+            record_audit_event(
                 request=request,
                 action_category=AuditActionCategory.IMPORT,
                 action_type="import.upload",
@@ -533,7 +506,7 @@ class ImportView(viewsets.ViewSet):
             try:
                 zev = Zev.objects.get(pk=zev_id)
             except Zev.DoesNotExist:
-                _record_metering_event(
+                record_audit_event(
                     request=request,
                     action_category=AuditActionCategory.IMPORT,
                     action_type="import.upload",
@@ -547,7 +520,7 @@ class ImportView(viewsets.ViewSet):
                 return Response({"error": "ZEV not found."}, status=status.HTTP_404_NOT_FOUND)
 
             if not request.user.is_admin and zev.owner != request.user:
-                _record_metering_event(
+                record_audit_event(
                     request=request,
                     action_category=AuditActionCategory.IMPORT,
                     action_type="import.upload",
@@ -563,7 +536,7 @@ class ImportView(viewsets.ViewSet):
 
             log = import_sdatch(file, zev, request.user)
 
-        _record_metering_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.IMPORT,
             action_type="import.upload",

--- a/backend/tariffs/views.py
+++ b/backend/tariffs/views.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -9,42 +11,27 @@ from .models import Tariff, TariffPeriod
 from zev.scoping import ZevScopedQuerySetMixin
 from .serializers import TariffSerializer, TariffPeriodSerializer
 from audit.models import AuditActionCategory, AuditEventStatus
-from audit.services import build_diff, record_audit_event
+from audit.mixins import AuditedUpdateMixin
+from audit.services import record_audit_event
 
 
-def _record_tariff_event(
-    *,
-    request,
-    action_type: str,
-    target_type: str,
-    summary: str,
-    target=None,
-    target_id: str = "",
-    target_display: str = "",
-    status: str = AuditEventStatus.SUCCESS,
-    changes: dict | None = None,
-    metadata: dict | None = None,
-):
-    record_audit_event(
-        request=request,
-        action_category=AuditActionCategory.TARIFF,
-        action_type=action_type,
-        target_type=target_type,
-        target=target,
-        target_id=target_id,
-        target_display=target_display,
-        summary=summary,
-        status=status,
-        changes=changes,
-        metadata=metadata,
-    )
+# Every audit event in this module is a tariff event; bind the category once.
+_record_tariff_event = partial(record_audit_event, action_category=AuditActionCategory.TARIFF)
 
 
-class TariffViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
+class TariffViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     serializer_class = TariffSerializer
     permission_classes = [IsAuthenticated, IsZevOwnerOrAdmin]
     zev_owner_filter = "zev__owner"
     participant_filter = None
+
+    audit_action_category = AuditActionCategory.TARIFF
+    audit_action_type = "tariff.update"
+    audit_target_type = "tariffs.Tariff"
+    audit_target_label = "tariff"
+
+    def get_audit_target_display(self, instance):
+        return instance.name
 
     def get_queryset(self):
         return self.scope_queryset(Tariff.objects.all())
@@ -60,49 +47,6 @@ class TariffViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
             target_display=tariff.name,
             summary=f"Created tariff {tariff.name}.",
             metadata={"zev_id": str(tariff.zev_id), "category": tariff.category},
-        )
-
-    TARIFF_TRACKED_FIELDS = [
-        "zev",
-        "name",
-        "category",
-        "billing_mode",
-        "energy_type",
-        "fixed_price_chf",
-        "percentage",
-        "valid_from",
-        "valid_to",
-        "notes",
-    ]
-
-    def _tariff_snapshot(self, tariff):
-        return {
-            "zev": str(tariff.zev_id) if tariff.zev_id else None,
-            "name": tariff.name,
-            "category": tariff.category,
-            "billing_mode": tariff.billing_mode,
-            "energy_type": tariff.energy_type,
-            "fixed_price_chf": tariff.fixed_price_chf,
-            "percentage": tariff.percentage,
-            "valid_from": tariff.valid_from,
-            "valid_to": tariff.valid_to,
-            "notes": tariff.notes,
-        }
-
-    def perform_update(self, serializer):
-        tariff = self.get_object()
-        before = self._tariff_snapshot(tariff)
-        tariff = serializer.save()
-        after = self._tariff_snapshot(tariff)
-        _record_tariff_event(
-            request=self.request,
-            action_type="tariff.update",
-            target_type="tariffs.Tariff",
-            target=tariff,
-            target_id=str(tariff.pk),
-            target_display=tariff.name,
-            summary=f"Updated tariff {tariff.name}.",
-            changes=build_diff(before, after, self.TARIFF_TRACKED_FIELDS),
         )
 
     def perform_destroy(self, instance):
@@ -297,11 +241,21 @@ class TariffViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
 
-class TariffPeriodViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
+class TariffPeriodViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     serializer_class = TariffPeriodSerializer
     permission_classes = [IsAuthenticated, IsZevOwnerOrAdmin]
     zev_owner_filter = "tariff__zev__owner"
     participant_filter = None
+
+    audit_action_category = AuditActionCategory.TARIFF
+    audit_action_type = "tariff_period.update"
+    audit_target_type = "tariffs.TariffPeriod"
+
+    def get_audit_target_display(self, instance):
+        return instance.period_type
+
+    def get_audit_summary(self, instance):
+        return f"Updated tariff period {instance.period_type} for tariff {instance.tariff.name}."
 
     def get_queryset(self):
         return self.scope_queryset(TariffPeriod.objects.all())
@@ -317,34 +271,6 @@ class TariffPeriodViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
             target_display=period.period_type,
             summary=f"Created tariff period {period.period_type} for tariff {period.tariff.name}.",
             metadata={"tariff_id": str(period.tariff_id)},
-        )
-
-    TARIFF_PERIOD_TRACKED_FIELDS = ["tariff", "period_type", "price_chf_per_kwh", "time_from", "time_to", "weekdays"]
-
-    def _tariff_period_snapshot(self, period):
-        return {
-            "tariff": str(period.tariff_id) if period.tariff_id else None,
-            "period_type": period.period_type,
-            "price_chf_per_kwh": period.price_chf_per_kwh,
-            "time_from": period.time_from,
-            "time_to": period.time_to,
-            "weekdays": period.weekdays,
-        }
-
-    def perform_update(self, serializer):
-        period = self.get_object()
-        before = self._tariff_period_snapshot(period)
-        period = serializer.save()
-        after = self._tariff_period_snapshot(period)
-        _record_tariff_event(
-            request=self.request,
-            action_type="tariff_period.update",
-            target_type="tariffs.TariffPeriod",
-            target=period,
-            target_id=str(period.pk),
-            target_display=period.period_type,
-            summary=f"Updated tariff period {period.period_type} for tariff {period.tariff.name}.",
-            changes=build_diff(before, after, self.TARIFF_PERIOD_TRACKED_FIELDS),
         )
 
     def perform_destroy(self, instance):

--- a/backend/zev/views.py
+++ b/backend/zev/views.py
@@ -29,36 +29,8 @@ from .permissions import (
 )
 from .services import send_participant_invitation, create_zev_for_existing_owner
 from audit.models import AuditActionCategory, AuditEventStatus
-from audit.services import build_diff, record_audit_event
-
-
-def _record_zev_event(
-    *,
-    request,
-    action_category: str,
-    action_type: str,
-    target_type: str,
-    summary: str,
-    target=None,
-    target_id: str = "",
-    target_display: str = "",
-    status: str = AuditEventStatus.SUCCESS,
-    changes: dict | None = None,
-    metadata: dict | None = None,
-):
-    record_audit_event(
-        request=request,
-        action_category=action_category,
-        action_type=action_type,
-        target_type=target_type,
-        target=target,
-        target_id=target_id,
-        target_display=target_display,
-        summary=summary,
-        status=status,
-        changes=changes,
-        metadata=metadata,
-    )
+from audit.mixins import AuditedUpdateMixin
+from audit.services import record_audit_event
 
 
 class ZevViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
@@ -114,18 +86,26 @@ class ZevViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
         return Response(result, status=status.HTTP_201_CREATED)
 
 
-class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
+class ParticipantViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     serializer_class = ParticipantSerializer
     permission_classes = [IsAuthenticated, ParticipantManagementPermission]
     zev_owner_filter = "zev__owner"
     participant_filter = "user"
+
+    audit_action_category = AuditActionCategory.PARTICIPANT
+    audit_action_type = "participant.update"
+    audit_target_type = "zev.Participant"
+    audit_target_label = "participant"
+
+    def get_audit_target_display(self, instance):
+        return instance.full_name
 
     def get_queryset(self):
         return self.scope_queryset(Participant.objects.prefetch_related("metering_point_assignments"))
 
     def perform_create(self, serializer):
         participant = serializer.save()
-        _record_zev_event(
+        record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.PARTICIPANT,
             action_type="participant.create",
@@ -137,64 +117,12 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
             metadata={"zev_id": str(participant.zev_id)},
         )
 
-    PARTICIPANT_TRACKED_FIELDS = [
-        "zev",
-        "title",
-        "first_name",
-        "last_name",
-        "email",
-        "phone",
-        "address_line1",
-        "address_line2",
-        "postal_code",
-        "city",
-        "valid_from",
-        "valid_to",
-        "notes",
-        "user",
-    ]
-
-    def _participant_snapshot(self, participant):
-        return {
-            "zev": str(participant.zev_id) if participant.zev_id else None,
-            "title": participant.title,
-            "first_name": participant.first_name,
-            "last_name": participant.last_name,
-            "email": participant.email,
-            "phone": participant.phone,
-            "address_line1": participant.address_line1,
-            "address_line2": participant.address_line2,
-            "postal_code": participant.postal_code,
-            "city": participant.city,
-            "valid_from": participant.valid_from,
-            "valid_to": participant.valid_to,
-            "notes": participant.notes,
-            "user": str(participant.user_id) if participant.user_id else None,
-        }
-
-    def perform_update(self, serializer):
-        participant = self.get_object()
-        before = self._participant_snapshot(participant)
-        participant = serializer.save()
-        after = self._participant_snapshot(participant)
-        _record_zev_event(
-            request=self.request,
-            action_category=AuditActionCategory.PARTICIPANT,
-            action_type="participant.update",
-            target_type="zev.Participant",
-            target=participant,
-            target_id=str(participant.pk),
-            target_display=participant.full_name,
-            summary=f"Updated participant {participant.full_name}.",
-            changes=build_diff(before, after, self.PARTICIPANT_TRACKED_FIELDS),
-        )
-
     def perform_destroy(self, instance):
         participant_id = str(instance.pk)
         participant_display = instance.full_name
         zev_id = str(instance.zev_id)
         instance.delete()
-        _record_zev_event(
+        record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.PARTICIPANT,
             action_type="participant.delete",
@@ -223,7 +151,7 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     @action(detail=True, methods=["post"], url_path="link-account")
     def link_account(self, request, pk=None):
         if not request.user.is_admin:
-            _record_zev_event(
+            record_audit_event(
                 request=request,
                 action_category=AuditActionCategory.PARTICIPANT,
                 action_type="participant.link_account",
@@ -254,7 +182,7 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
 
         participant.user = account
         participant.save(update_fields=["user", "updated_at"])
-        _record_zev_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.PARTICIPANT,
             action_type="participant.link_account",
@@ -271,7 +199,7 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     @action(detail=True, methods=["post"], url_path="unlink-account")
     def unlink_account(self, request, pk=None):
         if not request.user.is_admin:
-            _record_zev_event(
+            record_audit_event(
                 request=request,
                 action_category=AuditActionCategory.PARTICIPANT,
                 action_type="participant.unlink_account",
@@ -296,7 +224,7 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
 
         participant.user = None
         participant.save(update_fields=["user", "updated_at"])
-        _record_zev_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.PARTICIPANT,
             action_type="participant.unlink_account",
@@ -313,7 +241,7 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     @action(detail=True, methods=["post"], url_path="create-account")
     def create_account(self, request, pk=None):
         if not request.user.is_admin:
-            _record_zev_event(
+            record_audit_event(
                 request=request,
                 action_category=AuditActionCategory.PARTICIPANT,
                 action_type="participant.create_account",
@@ -354,7 +282,7 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
 
         participant.user = account
         participant.save(update_fields=["user", "updated_at"])
-        _record_zev_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.PARTICIPANT,
             action_type="participant.create_account",
@@ -401,7 +329,7 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
         try:
             username, temporary_password = send_participant_invitation(participant, request.user)
         except ValueError as exc:
-            _record_zev_event(
+            record_audit_event(
                 request=request,
                 action_category=AuditActionCategory.PARTICIPANT,
                 action_type="participant.send_invitation",
@@ -414,7 +342,7 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
                 metadata={"error": str(exc)},
             )
             return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
-        _record_zev_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.PARTICIPANT,
             action_type="participant.send_invitation",
@@ -435,19 +363,27 @@ class ParticipantViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
         )
 
 
-class MeteringPointViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
+class MeteringPointViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     serializer_class = MeteringPointSerializer
     permission_classes = [IsAuthenticated, MeteringPointPermission]
     zev_owner_filter = "zev__owner"
     participant_filter = "assignments__participant__user"
     participant_distinct = True
 
+    audit_action_category = AuditActionCategory.METERING
+    audit_action_type = "metering_point.update"
+    audit_target_type = "zev.MeteringPoint"
+    audit_target_label = "metering point"
+
+    def get_audit_target_display(self, instance):
+        return instance.meter_id
+
     def get_queryset(self):
         return self.scope_queryset(MeteringPoint.objects.select_related("zev"))
 
     def perform_create(self, serializer):
         metering_point = serializer.save()
-        _record_zev_event(
+        record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.METERING,
             action_type="metering_point.create",
@@ -459,40 +395,12 @@ class MeteringPointViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
             metadata={"zev_id": str(metering_point.zev_id), "meter_type": metering_point.meter_type},
         )
 
-    METERING_POINT_TRACKED_FIELDS = ["zev", "meter_id", "meter_type", "is_active", "location_description"]
-
-    def _metering_point_snapshot(self, metering_point):
-        return {
-            "zev": str(metering_point.zev_id) if metering_point.zev_id else None,
-            "meter_id": metering_point.meter_id,
-            "meter_type": metering_point.meter_type,
-            "is_active": metering_point.is_active,
-            "location_description": metering_point.location_description,
-        }
-
-    def perform_update(self, serializer):
-        metering_point = self.get_object()
-        before = self._metering_point_snapshot(metering_point)
-        metering_point = serializer.save()
-        after = self._metering_point_snapshot(metering_point)
-        _record_zev_event(
-            request=self.request,
-            action_category=AuditActionCategory.METERING,
-            action_type="metering_point.update",
-            target_type="zev.MeteringPoint",
-            target=metering_point,
-            target_id=str(metering_point.pk),
-            target_display=metering_point.meter_id,
-            summary=f"Updated metering point {metering_point.meter_id}.",
-            changes=build_diff(before, after, self.METERING_POINT_TRACKED_FIELDS),
-        )
-
     def perform_destroy(self, instance):
         meter_id = instance.meter_id
         metering_point_id = str(instance.pk)
         zev_id = str(instance.zev_id)
         instance.delete()
-        _record_zev_event(
+        record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.METERING,
             action_type="metering_point.delete",
@@ -545,7 +453,7 @@ class MeteringPointViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
         deleted_count = readings_qs.count()
         readings_qs.delete()
 
-        _record_zev_event(
+        record_audit_event(
             request=request,
             action_category=AuditActionCategory.METERING,
             action_type="metering_point.delete_readings",
@@ -560,11 +468,21 @@ class MeteringPointViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
         return Response({"deleted_count": deleted_count}, status=status.HTTP_200_OK)
 
 
-class MeteringPointAssignmentViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
+class MeteringPointAssignmentViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     serializer_class = MeteringPointAssignmentSerializer
     permission_classes = [IsAuthenticated, MeteringPointAssignmentPermission]
     zev_owner_filter = "metering_point__zev__owner"
     participant_filter = "participant__user"
+
+    audit_action_category = AuditActionCategory.METERING
+    audit_action_type = "metering_assignment.update"
+    audit_target_type = "zev.MeteringPointAssignment"
+
+    def get_audit_target_display(self, instance):
+        return str(instance.pk)
+
+    def get_audit_summary(self, instance):
+        return f"Updated metering point assignment for {instance.metering_point.meter_id}."
 
     def get_queryset(self):
         qs = self.scope_queryset(
@@ -584,7 +502,7 @@ class MeteringPointAssignmentViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewS
 
     def perform_create(self, serializer):
         assignment = serializer.save()
-        _record_zev_event(
+        record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.METERING,
             action_type="metering_assignment.create",
@@ -599,39 +517,12 @@ class MeteringPointAssignmentViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewS
             },
         )
 
-    def perform_update(self, serializer):
-        assignment = self.get_object()
-        before = {
-            "metering_point": str(assignment.metering_point_id),
-            "participant": str(assignment.participant_id),
-            "valid_from": assignment.valid_from,
-            "valid_to": assignment.valid_to,
-        }
-        assignment = serializer.save()
-        after = {
-            "metering_point": str(assignment.metering_point_id),
-            "participant": str(assignment.participant_id),
-            "valid_from": assignment.valid_from,
-            "valid_to": assignment.valid_to,
-        }
-        _record_zev_event(
-            request=self.request,
-            action_category=AuditActionCategory.METERING,
-            action_type="metering_assignment.update",
-            target_type="zev.MeteringPointAssignment",
-            target=assignment,
-            target_id=str(assignment.pk),
-            target_display=str(assignment.pk),
-            summary=f"Updated metering point assignment for {assignment.metering_point.meter_id}.",
-            changes=build_diff(before, after, ["metering_point", "participant", "valid_from", "valid_to"]),
-        )
-
     def perform_destroy(self, instance):
         assignment_id = str(instance.pk)
         meter_id = instance.metering_point.meter_id
         participant_id = str(instance.participant_id)
         instance.delete()
-        _record_zev_event(
+        record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.METERING,
             action_type="metering_assignment.delete",


### PR DESCRIPTION
Two related cleanups in the audit layer, from the backend refactoring analysis. Net **-203 lines of production code**, no behaviour change.

## 1. `AuditedUpdateMixin` — retire the bug class behind #322 and #327

Six viewsets each carried a hand-written `*_TRACKED_FIELDS` list *plus* a `_*_snapshot()` method restating every field by hand. Those two lists were independent copies of the same knowledge, so they drifted — and that drift is precisely what produced the empty `participant.update` diffs in #322 and the five further gaps in #327. Both fixes were re-audits of a list that had no mechanism keeping it honest.

The new mixin derives tracked fields from the **serializer's writable fields**, so the diff can't silently disagree with what the endpoint actually accepts. Each viewset now declares intent instead of restating structure:

```python
class ParticipantViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelViewSet):
    audit_action_category = AuditActionCategory.PARTICIPANT
    audit_action_type = "participant.update"
    audit_target_type = "zev.Participant"
    audit_target_label = "participant"

    def get_audit_target_display(self, instance):
        return instance.full_name
```

**Validation of the derivation.** Before converting anything I checked derived-vs-current for all seven serializers: **identical for six**, and no serializer uses a custom `source=` on a writable field. The single delta is `Participant.user`, which is in `read_only_fields` (and `validate()` rejects it outright), so it could never change via that endpoint — a permanent no-op entry, correctly dropped.

`VatRateDetailView` deliberately keeps its own `perform_update`: it wraps `save()` in bespoke `DjangoValidationError` translation, and its field list was already complete. Forcing it through the mixin would have added risk for no gain.

## 2. Audit recorder wrappers — 139 lines of boilerplate

| App | Before | After |
|---|---|---|
| zev / metering / accounts | 83 lines forwarding every arg unchanged | removed; call `record_audit_event` directly |
| tariffs | 26 lines binding one constant | `functools.partial(..., action_category=TARIFF)` |
| invoices | 30 lines | kept — it derives target/id/display from the invoice — minus its pass-through half |

Only `invoices` was doing real work; the rest were pure indirection that a reader had to jump to in order to discover it did nothing.

## Test plan
- [x] `pytest backend/` → **401 passed**, 91 subtests (was 393 + 8 new)
- [x] **Summary-string parity**: audit `summary`/`target_display` are user-visible in the log, so `audit/test_summary_parity.py` pins all six verbatim — they survive the refactor byte-identical
- [x] New test asserts the mixin's tracked fields equal the serializer's writable fields — the property that makes the bug class structurally impossible
- [x] New test asserts `build_instance_snapshot` reads FKs via `<field>_id` in **0 queries** (no N+1 from snapshotting)
- [x] The six diff-content regression tests from #327 pass unchanged
- [x] `manage.py check` clean; MRO verified so the mixin's `perform_update` actually wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)