### PR TITLE
refactor(metering): parse CSV and Excel imports without pandas

### DIFF
--- a/backend/metering/importers/csv_importer.py
+++ b/backend/metering/importers/csv_importer.py
@@ -8,11 +8,15 @@ Supported formats:
 Both formats support header-based mapping and index-based mapping for headerless files.
 """
 
+import csv
+import io
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 
-import pandas as pd
+import openpyxl
+from dateutil import parser as dateutil_parser
 
 from metering.models import ImportLog, ImportSource, MeterReading
 from zev.models import MeteringPoint, Zev
@@ -26,6 +30,26 @@ DEFAULT_COLUMN_MAP = {
 }
 
 
+class ImportFileError(ValueError):
+    """The uploaded file could not be read at all (bad format, encoding or delimiter)."""
+
+
+@dataclass
+class Table:
+    """A parsed spreadsheet: column labels plus rows of raw cell values.
+
+    Rows are padded to ``width`` so positional access is always safe. Labels are
+    kept as read — strings for a headered file, integers for a headerless one.
+    """
+
+    columns: list = field(default_factory=list)
+    rows: list = field(default_factory=list)
+
+    @property
+    def width(self):
+        return len(self.columns)
+
+
 def _to_bool(value, default=True):
     if value is None:
         return default
@@ -34,36 +58,151 @@ def _to_bool(value, default=True):
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _read_dataframe(file, *, has_header=True, delimiter=","):
-    if hasattr(file, "name") and file.name.endswith((".xlsx", ".xls")):
-        return pd.read_excel(file, header=0 if has_header else None)
-    return pd.read_csv(file, sep=delimiter, header=0 if has_header else None)
+def _normalise_delimiter(delimiter):
+    if not delimiter:
+        return ","
+    # The UI exposes a free-text delimiter field, where a tab cannot be typed.
+    if delimiter == "\\t":
+        return "\t"
+    if len(delimiter) != 1:
+        raise ImportFileError(
+            f"Delimiter must be a single character (got {delimiter!r}). Use '\\t' for a tab."
+        )
+    return delimiter
 
 
-def _resolve_column(df, ref):
+def _build_table(raw_rows, *, has_header):
+    if not raw_rows:
+        return Table()
+    if has_header:
+        columns, data = list(raw_rows[0]), raw_rows[1:]
+    else:
+        # Like pandas, the column count is fixed by the first row.
+        columns, data = list(range(len(raw_rows[0]))), raw_rows
+    width = len(columns)
+    rows = [
+        list(row) + [None] * (width - len(row)) if len(row) < width else list(row)
+        for row in data
+    ]
+    return Table(columns=columns, rows=rows)
+
+
+def _read_csv_table(file, *, has_header, delimiter):
+    try:
+        text = file.read().decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise ImportFileError(
+            "File is not valid UTF-8. Re-export it as UTF-8 (in Excel: 'CSV UTF-8') and try again."
+        ) from exc
+    reader = csv.reader(io.StringIO(text, newline=""), delimiter=delimiter)
+    # pandas skips blank lines *and* renumbers, so a blank line does not consume
+    # a row number. Rows of empty strings are data and are kept.
+    return _build_table([row for row in reader if row], has_header=has_header)
+
+
+def _read_xlsx_table(file, *, has_header):
+    try:
+        workbook = openpyxl.load_workbook(file, read_only=True, data_only=True, keep_links=False)
+    except Exception as exc:  # openpyxl raises a variety of types for bad files
+        raise ImportFileError(f"Could not read the Excel file: {exc}") from exc
+    try:
+        # pandas reads sheet index 0, which is not necessarily the sheet that was
+        # selected when the workbook was saved (openpyxl's ``active``).
+        raw_rows = [list(row) for row in workbook.worksheets[0].iter_rows(values_only=True)]
+    finally:
+        workbook.close()
+
+    # pandas trims trailing all-empty rows but keeps mid-file ones.
+    while raw_rows and all(cell is None for cell in raw_rows[-1]):
+        raw_rows.pop()
+    return _build_table(raw_rows, has_header=has_header)
+
+
+def _read_table(file, *, has_header=True, delimiter=","):
+    name = (getattr(file, "name", "") or "").lower()
+    if name.endswith(".xls"):
+        raise ImportFileError(
+            "Legacy .xls files are not supported. Please save the file as .xlsx or CSV."
+        )
+    if name.endswith(".xlsx"):
+        return _read_xlsx_table(file, has_header=has_header)
+    return _read_csv_table(
+        file, has_header=has_header, delimiter=_normalise_delimiter(delimiter)
+    )
+
+
+def _is_missing(value):
+    """True for cells pandas would have reported as NA.
+
+    Note that whitespace-only cells are *not* missing: callers distinguish an
+    absent value from a blank one (``Missing`` vs ``Empty`` errors).
+    """
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value == ""
+    return isinstance(value, float) and value != value
+
+
+def _cell(row, position):
+    """Positional access that returns None on a miss, like ``Series.get``."""
+    if position is None or position < 0 or position >= len(row):
+        return None
+    return row[position]
+
+
+def _parse_flexible(text, *, dayfirst=False):
+    """Parse a date/datetime string, preferring ISO-8601 then falling back to dateutil."""
+    if not dayfirst:
+        try:
+            return datetime.fromisoformat(text)
+        except ValueError:
+            pass
+    return dateutil_parser.parse(text, dayfirst=dayfirst)
+
+
+def _parse_datetime_utc(raw_value):
+    parsed = _parse_flexible(str(raw_value).strip())
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _resolve_column(table, ref):
+    """Resolve a column reference to a *position*.
+
+    A reference is either a literal column label or a decimal index. Returning a
+    position rather than a label keeps row access uniform for both the named
+    columns and the positional interval slots.
+    """
     if ref is None:
         return None
     key = str(ref).strip()
     if not key:
         return None
-    if key in df.columns:
-        return key
+    if key in table.columns:
+        return table.columns.index(key)
     if key.isdigit():
         idx = int(key)
-        if idx < 0 or idx >= len(df.columns):
-            raise KeyError(f"Column index {idx} is out of range (0..{len(df.columns)-1}).")
-        return df.columns[idx]
+        if idx < 0 or idx >= table.width:
+            raise KeyError(f"Column index {idx} is out of range (0..{table.width - 1}).")
+        return idx
     raise KeyError(f"Column '{key}' not found.")
 
 
 def _parse_decimal(raw_value):
-    if pd.isna(raw_value):
+    if _is_missing(raw_value):
         raise InvalidOperation("Missing numeric value")
     value_str = str(raw_value).strip()
     if not value_str:
         raise InvalidOperation("Empty numeric value")
     value_str = value_str.replace(",", ".")
-    return Decimal(value_str).quantize(Decimal("0.0001"))
+    value = Decimal(value_str).quantize(Decimal("0.0001"))
+    # Decimal happily accepts "nan"/"NaN", which would otherwise reach the
+    # database as a non-finite value. ("inf" already fails in quantize.)
+    if not value.is_finite():
+        raise InvalidOperation("Invalid numeric value")
+    return value
 
 
 def _infer_direction_and_energy(meter_type, energy, explicit_direction=None):
@@ -88,7 +227,7 @@ def _meter_queryset_for_user(user, zev=None):
     return qs.none()
 
 
-def _resolve_columns(df, col, required_keys):
+def _resolve_columns(table, col, required_keys):
     missing_mapping_keys = [key for key in required_keys if key not in col or not col.get(key)]
     if missing_mapping_keys:
         return None, f"Missing required column mappings for: {', '.join(missing_mapping_keys)}"
@@ -96,13 +235,13 @@ def _resolve_columns(df, col, required_keys):
     resolved_cols = {}
     try:
         for key in required_keys:
-            resolved_cols[key] = _resolve_column(df, col[key])
+            resolved_cols[key] = _resolve_column(table, col[key])
     except KeyError as exc:
         return None, str(exc)
 
     try:
         direction_ref = col.get("direction")
-        resolved_cols["direction"] = _resolve_column(df, direction_ref) if direction_ref else None
+        resolved_cols["direction"] = _resolve_column(table, direction_ref) if direction_ref else None
     except KeyError:
         resolved_cols["direction"] = None
 
@@ -116,10 +255,8 @@ def _build_day_start(raw_day, timestamp_format):
         raw_day_str = str(raw_day).strip()
         # Preserve unambiguous ISO dates; fall back to day-first parsing for
         # European CSV exports such as 07.01.2026 or 07/01/2026.
-        if raw_day_str[:10].count("-") == 2 and raw_day_str[:4].isdigit():
-            day_dt = pd.to_datetime(raw_day_str, dayfirst=False).to_pydatetime()
-        else:
-            day_dt = pd.to_datetime(raw_day_str, dayfirst=True).to_pydatetime()
+        iso_like = raw_day_str[:10].count("-") == 2 and raw_day_str[:4].isdigit()
+        day_dt = _parse_flexible(raw_day_str, dayfirst=not iso_like)
     return datetime(day_dt.year, day_dt.month, day_dt.day, tzinfo=timezone.utc)
 
 
@@ -148,13 +285,13 @@ def preview_csv(
 ):
     col = {**DEFAULT_COLUMN_MAP, **(column_map or {})}
     has_header = _to_bool(has_header, default=True)
-    df = _read_dataframe(file, has_header=has_header, delimiter=delimiter or ",")
+    table = _read_table(file, has_header=has_header, delimiter=delimiter)
 
     required_keys = ["meter_id", "timestamp", "energy_kwh"] if format_profile == "standard" else ["meter_id", "timestamp", "energy_start"]
-    resolved_cols, column_error = _resolve_columns(df, col, required_keys)
+    resolved_cols, column_error = _resolve_columns(table, col, required_keys)
     if column_error:
         return {
-            "rows_total": len(df),
+            "rows_total": len(table.rows),
             "preview_rows": [],
             "summary": {"existing_metering_points": 0, "missing_metering_points": 0, "rows_previewed": 0},
             "errors": [{"row": None, "error": column_error}],
@@ -165,9 +302,9 @@ def preview_csv(
     existing_mps = 0
     missing_mps = 0
 
-    for idx, row in df.head(max_rows).iterrows():
+    for idx, row in enumerate(table.rows[:max_rows]):
         row_number = idx + (2 if has_header else 1)
-        meter_id = None if pd.isna(row[resolved_cols["meter_id"]]) else str(row[resolved_cols["meter_id"]]).strip()
+        meter_id = None if _is_missing(row[resolved_cols["meter_id"]]) else str(row[resolved_cols["meter_id"]]).strip()
         mp = meter_lookup.get(meter_id or "")
         exists = mp is not None
         if exists:
@@ -178,7 +315,7 @@ def preview_csv(
         if format_profile == "daily_15min":
             date_value = None
             existing_data = False
-            if exists and not pd.isna(row[resolved_cols["timestamp"]]):
+            if exists and not _is_missing(row[resolved_cols["timestamp"]]):
                 try:
                     day_start = _build_day_start(row[resolved_cols["timestamp"]], timestamp_format)
                     day_end = day_start + timedelta(days=1)
@@ -190,7 +327,7 @@ def preview_csv(
                     date_value = day_start.date().isoformat()
                 except Exception:
                     date_value = str(row[resolved_cols["timestamp"]])
-            elif not pd.isna(row[resolved_cols["timestamp"]]):
+            elif not _is_missing(row[resolved_cols["timestamp"]]):
                 date_value = str(row[resolved_cols["timestamp"]])
 
             preview_rows.append(
@@ -207,8 +344,8 @@ def preview_csv(
             )
             continue
 
-        timestamp_value = None if pd.isna(row[resolved_cols["timestamp"]]) else str(row[resolved_cols["timestamp"]])
-        energy_value = None if pd.isna(row[resolved_cols["energy_kwh"]]) else str(row[resolved_cols["energy_kwh"]])
+        timestamp_value = None if _is_missing(row[resolved_cols["timestamp"]]) else str(row[resolved_cols["timestamp"]])
+        energy_value = None if _is_missing(row[resolved_cols["energy_kwh"]]) else str(row[resolved_cols["energy_kwh"]])
         preview_rows.append(
             {
                 "row": row_number,
@@ -221,7 +358,7 @@ def preview_csv(
         )
 
     return {
-        "rows_total": len(df),
+        "rows_total": len(table.rows),
         "preview_rows": preview_rows,
         "summary": {
             "existing_metering_points": existing_mps,
@@ -252,7 +389,7 @@ def import_csv(
 
     has_header = _to_bool(has_header, default=True)
     overwrite_existing = _to_bool(overwrite_existing, default=False)
-    df = _read_dataframe(file, has_header=has_header, delimiter=delimiter or ",")
+    table = _read_table(file, has_header=has_header, delimiter=delimiter)
 
     log = ImportLog.objects.create(
         batch_id=batch_id,
@@ -260,14 +397,14 @@ def import_csv(
         imported_by=user,
         source=ImportSource.CSV,
         filename=getattr(file, "name", "upload"),
-        rows_total=len(df),
+        rows_total=len(table.rows),
     )
 
     required_keys = ["meter_id", "timestamp", "energy_kwh"] if format_profile == "standard" else ["meter_id", "timestamp", "energy_start"]
-    resolved_cols, column_error = _resolve_columns(df, col, required_keys)
+    resolved_cols, column_error = _resolve_columns(table, col, required_keys)
     if column_error:
         log.rows_imported = 0
-        log.rows_skipped = len(df)
+        log.rows_skipped = len(table.rows)
         log.errors = [{"row": None, "error": column_error}]
         log.save()
         return log
@@ -280,10 +417,10 @@ def import_csv(
     errors = []
     touched_metering_points = set()
 
-    for idx, row in df.iterrows():
+    for idx, row in enumerate(table.rows):
         row_number = idx + (2 if has_header else 1)
         try:
-            if pd.isna(row[resolved_cols["meter_id"]]):
+            if _is_missing(row[resolved_cols["meter_id"]]):
                 skipped += 1
                 errors.append({"row": row_number, "error": "Missing meter_id value."})
                 continue
@@ -309,17 +446,17 @@ def import_csv(
 
             if format_profile == "daily_15min":
                 raw_day = row[resolved_cols["timestamp"]]
-                if pd.isna(raw_day):
+                if _is_missing(raw_day):
                     skipped += 1
                     errors.append({"row": row_number, "error": "Missing date value for daily profile."})
                     continue
 
                 day_start = _build_day_start(raw_day, timestamp_format)
-                start_pos = list(df.columns).index(resolved_cols["energy_start"])
+                start_pos = resolved_cols["energy_start"]
 
                 for slot in range(values_count):
                     col_pos = start_pos + slot
-                    if col_pos >= len(df.columns):
+                    if col_pos >= table.width:
                         skipped += 1
                         errors.append(
                             {
@@ -332,8 +469,8 @@ def import_csv(
                         )
                         continue
 
-                    raw_energy = row.iloc[col_pos]
-                    if pd.isna(raw_energy) or str(raw_energy).strip() == "":
+                    raw_energy = row[col_pos]
+                    if _is_missing(raw_energy) or str(raw_energy).strip() == "":
                         continue
 
                     energy_raw = _parse_decimal(raw_energy)
@@ -382,7 +519,7 @@ def import_csv(
                 continue
 
             raw_ts = row[resolved_cols["timestamp"]]
-            if pd.isna(raw_ts):
+            if _is_missing(raw_ts):
                 skipped += 1
                 errors.append({"row": row_number, "error": "Missing timestamp value."})
                 continue
@@ -392,15 +529,15 @@ def import_csv(
             elif isinstance(raw_ts, datetime):
                 ts = raw_ts if raw_ts.tzinfo else raw_ts.replace(tzinfo=timezone.utc)
             else:
-                ts = pd.to_datetime(raw_ts, utc=True).to_pydatetime()
+                ts = _parse_datetime_utc(raw_ts)
 
             energy_raw = _parse_decimal(row[resolved_cols["energy_kwh"]])
 
             explicit_direction = None
             direction_col = resolved_cols.get("direction")
             if direction_col is not None:
-                raw_direction = row.get(direction_col)
-                if not pd.isna(raw_direction):
+                raw_direction = _cell(row, direction_col)
+                if not _is_missing(raw_direction):
                     explicit_direction = str(raw_direction).strip().lower()
                     if explicit_direction and explicit_direction not in {"in", "out"}:
                         skipped += 1
@@ -450,7 +587,7 @@ def import_csv(
                             "error": "Duplicate reading for metering_point + timestamp + direction.",
                         }
                     )
-        except (KeyError, InvalidOperation, ValueError) as exc:
+        except (KeyError, InvalidOperation, TypeError, ValueError) as exc:
             errors.append({"row": row_number, "error": str(exc)})
             skipped += 1
 

--- a/backend/metering/test_import_csv_characterization.py
+++ b/backend/metering/test_import_csv_characterization.py
@@ -1,20 +1,18 @@
-"""Characterization tests pinning CSV/Excel import behaviour.
+"""Behavioural tests for the CSV/Excel metering import.
 
-These exist to make the upcoming pandas removal safe. The existing suite in
-``test_import_csv.py`` does not cover the paths production actually uses: the
-frontend defaults to ``format_profile=daily_15min`` with
+Written as characterization tests to make the pandas removal safe, and kept
+afterwards as the regression suite for the parser. They cover the paths the rest
+of the suite misses: the frontend defaults to ``format_profile=daily_15min`` with
 ``timestamp_format='%d.%m.%Y'`` (see ``frontend/src/pages/ImportsPage.tsx``), so
-real traffic goes through ``datetime.strptime`` while every existing test goes
-through ``pandas.to_datetime``. Excel is offered in the file picker and had no
-test at all.
+real traffic goes through ``datetime.strptime`` — and Excel, which is offered in
+the file picker, had no coverage at all.
 
-Each test below pins *current* behaviour so a reimplementation can be diffed
-against it. Where current behaviour is a bug, the test says so explicitly rather
-than quietly asserting the wrong thing.
+Several tests pin behaviour that is non-obvious but load-bearing (trailing vs
+mid-file blank rows, row numbering across blank lines, the missing-vs-empty cell
+distinction). Those assertions are deliberate, not incidental.
 """
 
 import io
-import unittest
 from datetime import date, datetime, timezone
 from decimal import Decimal
 
@@ -472,38 +470,13 @@ class CsvImportCharacterizationTests(TestCase):
             MeterReading.objects.filter(metering_point=self.numeric_metering_point).count(), 1
         )
 
-    def test_numeric_meter_id_column_with_a_blank_row_currently_reports_not_found(self):
-        """Pins the *current* (wrong) behaviour so the fix is visible as a diff.
-
-        A single empty cell forces the column to float64, so the valid meter id
-        1234 stringifies to '1234.0' and fails lookup with a misleading "not
-        found" error. Delete this test when the paired expectedFailure below is
-        flipped.
-        """
-        csv_bytes = (
-            b"meter_id,timestamp,energy_kwh\n"
-            b"1234,2026-07-02T00:00:00Z,1.0000\n"
-            b",2026-07-02T00:15:00Z,2.0000\n"
-        )
-
-        resp = self._upload("numeric-blank-current.csv", csv_bytes)
-
-        self.assertEqual(resp.status_code, 201)
-        self.assertEqual(resp.data["rows_imported"], 0)
-        self.assertTrue(
-            any("'1234.0' not found" in err["error"] for err in resp.data["errors"]),
-            resp.data["errors"],
-        )
-
-    @unittest.expectedFailure
     def test_numeric_meter_id_column_with_a_blank_row_still_matches(self):
-        """KNOWN BUG, pinned deliberately.
+        """Regression test for a bug pandas caused.
 
-        One empty cell forces the column to float64, so str() yields '1234.0'
-        and the meter lookup silently fails — a valid row is dropped with a
-        confusing "not found" error. Removing pandas fixes this; this test is
-        expected to fail now and will be flipped to a passing assertion in the
-        follow-up PR.
+        Under pandas a single empty cell forced the column to float64, so the
+        valid meter id 1234 stringified to '1234.0' and lookup failed with a
+        misleading "not found" — silently dropping a good row. Reading cells as
+        text keeps the id intact.
         """
         csv_bytes = (
             b"meter_id,timestamp,energy_kwh\n"
@@ -661,16 +634,94 @@ class CsvImportCharacterizationTests(TestCase):
         self.assertEqual(len(resp.data["errors"]), 1)
         self.assertIsNone(resp.data["errors"][0]["row"])
 
-    def test_import_of_unsupported_legacy_xls_is_not_silently_accepted(self):
-        """`.xls` is advertised by the file picker but xlrd is not installed, so
-        pandas cannot read it. Pinned as 'does not import anything' rather than
-        pinning the specific exception, since the rewrite replaces it with an
-        explicit error."""
+    # ── H. Unreadable files are rejected with 400, not a 500 ─────────────────
+
+    def test_legacy_xls_is_rejected_with_a_helpful_message(self):
+        """`.xls` was advertised by the file picker but never worked (xlrd is not
+        installed), so it surfaced as an opaque 500."""
         upload = SimpleUploadedFile(
             "legacy.xls", b"\xd0\xcf\x11\xe0\x00\x00\x00\x00", content_type="application/vnd.ms-excel"
         )
-        with self.assertRaises(Exception):
-            self.client.post(
-                "/api/v1/metering/import/csv/", {"file": upload}, format="multipart"
-            )
+
+        resp = self.client.post(
+            "/api/v1/metering/import/csv/", {"file": upload}, format="multipart"
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn(".xlsx", resp.data["error"])
         self.assertEqual(MeterReading.objects.count(), 0)
+
+    def test_multi_character_delimiter_is_rejected_with_a_helpful_message(self):
+        resp = self._upload(
+            "multidelim.csv",
+            b"meter_id;;timestamp;;energy_kwh\nCH-IMPORT-1;;2026-09-01T00:00:00Z;;1.0000\n",
+            delimiter=";;",
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("single character", resp.data["error"])
+
+    def test_tab_delimiter_can_be_requested_as_a_backslash_escape(self):
+        resp = self._upload(
+            "tabs.csv",
+            b"meter_id\ttimestamp\tenergy_kwh\nCH-IMPORT-1\t2026-09-02T00:00:00Z\t1.0000\n",
+            delimiter="\\t",
+        )
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.data["rows_imported"], 1)
+
+    def test_non_utf8_file_is_rejected_with_a_helpful_message(self):
+        resp = self._upload(
+            "latin1.csv",
+            "meter_id,timestamp,energy_kwh,note\nCH-IMPORT-1,2026-09-03T00:00:00Z,1.0,Zürich\n".encode(
+                "latin-1"
+            ),
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("UTF-8", resp.data["error"])
+
+    def test_preview_of_an_unreadable_file_is_rejected_with_400(self):
+        upload = SimpleUploadedFile(
+            "legacy.xls", b"\xd0\xcf\x11\xe0\x00\x00\x00\x00", content_type="application/vnd.ms-excel"
+        )
+
+        resp = self.client.post(
+            "/api/v1/metering/import/preview-csv/", {"file": upload}, format="multipart"
+        )
+
+        self.assertEqual(resp.status_code, 400)
+
+    # ── I. Ragged rows (previously a 500, or silent column misalignment) ──────
+
+    def test_row_with_extra_trailing_field_is_imported_without_misalignment(self):
+        """A trailing-comma export used to make pandas promote meter_id to the
+        index and shift every column left, then crash on the row numbering."""
+        csv_bytes = (
+            b"meter_id,timestamp,energy_kwh\n"
+            b"CH-IMPORT-1,2026-09-04T00:00:00Z,1.5000,EXTRA\n"
+        )
+
+        resp = self._upload("extrafield.csv", csv_bytes)
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.data["rows_imported"], 1)
+        reading = MeterReading.objects.get(metering_point=self.metering_point)
+        self.assertEqual(reading.energy_kwh, Decimal("1.5000"))
+        self.assertEqual(reading.timestamp, datetime(2026, 9, 4, 0, 0, tzinfo=timezone.utc))
+
+    def test_rows_of_differing_widths_are_handled_row_by_row(self):
+        csv_bytes = (
+            b"meter_id,timestamp,energy_kwh\n"
+            b"CH-IMPORT-1,2026-09-05T00:00:00Z,1.0000\n"
+            b"CH-IMPORT-1,2026-09-06T00:00:00Z,2.0000,EXTRA\n"
+            b"CH-IMPORT-1,2026-09-07T00:00:00Z\n"
+        )
+
+        resp = self._upload("ragged.csv", csv_bytes)
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.data["rows_imported"], 2)
+        self.assertEqual(resp.data["rows_skipped"], 1)
+        self.assertTrue(any("Missing numeric value" in err["error"] for err in resp.data["errors"]))

--- a/backend/metering/views.py
+++ b/backend/metering/views.py
@@ -14,7 +14,7 @@ from zev.models import Zev, Participant, MeteringPoint, MeteringPointAssignment
 from .models import MeterReading, ImportLog
 from zev.scoping import ZevScopedQuerySetMixin
 from .serializers import MeterReadingSerializer, ImportLogSerializer
-from .importers.csv_importer import import_csv, preview_csv
+from .importers.csv_importer import ImportFileError, import_csv, preview_csv
 from .importers.sdatch_importer import import_sdatch
 from .analytics import (
     owner_dashboard_summary,
@@ -434,6 +434,17 @@ class ImportView(viewsets.ViewSet):
                 interval_minutes=interval_minutes,
                 values_count=values_count,
             )
+        except ImportFileError as exc:
+            record_audit_event(
+                request=request,
+                action_category=AuditActionCategory.IMPORT,
+                action_type="import.preview_csv",
+                target_type="metering.ImportLog",
+                summary="CSV import preview failed: file could not be read.",
+                status=AuditEventStatus.FAILED,
+                metadata={"error": str(exc), "filename": file.name},
+            )
+            return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         except Exception as exc:
             record_audit_event(
                 request=request,
@@ -488,19 +499,31 @@ class ImportView(viewsets.ViewSet):
             overwrite_existing_raw = request.data.get("overwrite_existing", "false")
             overwrite_existing = str(overwrite_existing_raw).strip().lower() in {"1", "true", "yes", "on"}
 
-            log = import_csv(
-                file,
-                request.user,
-                zev=None,
-                column_map=column_map,
-                timestamp_format=timestamp_format,
-                has_header=has_header,
-                delimiter=delimiter,
-                format_profile=format_profile,
-                interval_minutes=interval_minutes,
-                values_count=values_count,
-                overwrite_existing=overwrite_existing,
-            )
+            try:
+                log = import_csv(
+                    file,
+                    request.user,
+                    zev=None,
+                    column_map=column_map,
+                    timestamp_format=timestamp_format,
+                    has_header=has_header,
+                    delimiter=delimiter,
+                    format_profile=format_profile,
+                    interval_minutes=interval_minutes,
+                    values_count=values_count,
+                    overwrite_existing=overwrite_existing,
+                )
+            except ImportFileError as exc:
+                record_audit_event(
+                    request=request,
+                    action_category=AuditActionCategory.IMPORT,
+                    action_type="import.upload",
+                    target_type="metering.ImportLog",
+                    summary="CSV import failed: file could not be read.",
+                    status=AuditEventStatus.FAILED,
+                    metadata={"error": str(exc), "filename": file.name, "source": source},
+                )
+                return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         else:
             zev_id = request.data.get("zev_id")
             try:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,10 +33,8 @@ jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 kombu==5.6.2
 lxml==6.1.1
-numpy==2.5.1
 openpyxl==3.1.5
 packaging==26.2
-pandas==3.0.5
 pillow==12.3.0
 pluggy==1.6.0
 prompt_toolkit==3.0.53
@@ -50,7 +48,7 @@ pytest==9.1.1
 pytest-cov==7.1.0
 pytest-django==4.12.0
 python-crontab==3.3.0
-python-dateutil==2.9.0.post0
+python-dateutil==2.9.0.post0  # direct: lenient timestamp parsing in the metering CSV import
 python-stdnum==2.2
 PyYAML==6.0.3
 qrbill==1.2.0

--- a/docs/specs/2026-03-metering-import-and-quality.md
+++ b/docs/specs/2026-03-metering-import-and-quality.md
@@ -126,7 +126,8 @@ touched meters belong to the same ZEV, that ZEV is stored; otherwise `null`.
 
 ### 4.1 CSV / Excel importer
 
-**Supported file types:** `.csv`, `.xlsx`, `.xls` (via pandas).
+**Supported file types:** `.csv` (stdlib `csv`), `.xlsx` (`openpyxl`). Legacy `.xls`
+is rejected with an explicit error asking for `.xlsx` or CSV.
 
 **Format profiles:**
 
@@ -163,6 +164,25 @@ touched meters belong to the same ZEV, that ZEV is stored; otherwise `null`.
 **Column resolution:** columns are resolved by name first; if the reference is
 a numeric string, it is used as a zero-based column index.  Out-of-range
 indices raise a column error that terminates the import with all rows skipped.
+Internally a reference resolves to a column *position*, so named columns and the
+positional `daily_15min` interval slots are read the same way.
+
+**Parsing semantics:**
+
+| Aspect | Behaviour |
+|---|---|
+| Encoding | UTF-8, BOM tolerated (`utf-8-sig`). Anything else is rejected with a 400 asking for a UTF-8 re-export |
+| Delimiter | Exactly one character. `\t` may be written as the two-character escape, since the UI field is free text. Multi-character delimiters are rejected with a 400 |
+| Blank lines | CSV blank lines are skipped and do **not** consume a row number |
+| Excel blank rows | Trailing all-empty rows are dropped; mid-file blank rows are kept and reported as rows with a missing `meter_id` |
+| Excel sheet | The first sheet is read, regardless of which sheet was active when the workbook was saved |
+| Ragged rows | Short rows are padded; extra trailing fields are ignored |
+| Missing values | An absent cell reports "Missing …"; a whitespace-only cell reports "Empty …" |
+| Numbers | Comma decimal separators are accepted. Non-finite values (`nan`, `inf`) are rejected |
+| Timestamps | `timestamp_format` (a `strptime` string) wins if supplied and is interpreted as UTC. Otherwise ISO-8601 is parsed first, falling back to a lenient parser; naive values are assumed UTC. For `daily_15min`, non-ISO dates are parsed day-first to suit European exports |
+
+Unreadable files (wrong format, bad encoding, invalid delimiter) return **400**
+before any `ImportLog` row is created, so a failed read leaves no orphan log.
 
 **Direction inference logic:**
 

--- a/frontend/src/pages/ImportsPage.tsx
+++ b/frontend/src/pages/ImportsPage.tsx
@@ -479,7 +479,7 @@ export function ImportsPage() {
                                 <input
                                     type="file"
                                     onChange={(event) => setFile(event.target.files?.[0] ?? null)}
-                                    accept={source === 'csv' ? '.csv,.xlsx,.xls' : '.xml'}
+                                    accept={source === 'csv' ? '.csv,.xlsx' : '.xml'}
                                 />
                             </label>
 


### PR DESCRIPTION
Step 2 of 2. **Stacked on #332** — merge that first; GitHub will retarget this to `main` automatically.

Removes `pandas` and `numpy`: **143 MB of a 395 MB site-packages (36%)**, measured like-for-like by installing the old and new `requirements.txt` into clean venvs. No new dependencies — `python-dateutil` was already required by celery, `openpyxl` already a direct requirement.

## What changed

The parser reads into a small `Table` (columns + padded rows) via the stdlib `csv` module or `openpyxl`. Column references now resolve to a **position** rather than a label, which collapses a duality the old code carried: it resolved to a label, then converted back with `list(df.columns).index(...)` *inside every row iteration* just to reach the positional interval slots. Both of those disappear.

## Five pandas behaviours reproduced deliberately

Each was verified against the real library before being reimplemented — these are the reason this wasn't a mechanical swap:

1. **`Decimal('nan')` is a valid Decimal and `quantize()` does not raise.** pandas coerced the text `nan` to a real NaN that `isna` caught; without that, `"nan"` would have reached a `DecimalField` and sailed past `abs()` and `energy >= 0`. `_parse_decimal` now rejects non-finite values. (`inf` already failed by accident.)
2. **`read_csv` skips blank lines *and compacts the index*** — so the row after a blank keeps its pre-blank number. "Fixing" that numbering would have shifted every reported row.
3. **`read_excel` trims trailing all-empty rows but keeps mid-file ones** (1 vs 3 rows).
4. **`read_excel` reads sheet 0, which is not `openpyxl`'s `wb.active`** (that's whatever tab was selected on save). Using `active` would have silently read the **wrong sheet**.
5. **An empty cell is missing; a whitespace-only cell is not** — that's what keeps the `Missing` and `Empty` errors distinct, so the check must not strip.

## Bugs fixed along the way

| Fix | Was |
|---|---|
| Numeric `meter_id` column with one blank cell | float64 → id `1234` became `"1234.0"` → lookup failed with a misleading "not found", **silently dropping a valid row** |
| Trailing-comma exports | pandas promoted `meter_id` to the index and shifted every column left — so `meter_id` held the *timestamp* — then crashed on `idx + 2` with an uncaught `TypeError` → **500** |
| Integer-like timestamps (`20260101`) | read as nanoseconds since epoch → `1970-01-01` |
| Unreadable files | 500; now **400** with a usable message, raised before any `ImportLog` row exists so no orphan log |
| `.xls` | never worked (`xlrd` isn't installed) but was advertised in the file picker; now says so explicitly and is removed from `accept` |

Also new: `\t` can be typed as a two-character escape in the free-text delimiter field, and multi-character delimiters get a 400 instead of pandas' silent regex fallback.

Trade-off worth naming: the importer grows 464 → 601 lines. That's 137 lines of explicit, tested parsing in exchange for 143 MB and a much clearer data path.

## Test plan
- [x] `pytest backend/` → **442 passed**
- [x] **442 pass with `pandas` and `numpy` import-blocked** via a `PYTHONPATH` shim — and the shim is proven effective: the *old* code fails under it, the new code passes. This is the real proof they're unused, since removing them from `requirements.txt` doesn't uninstall them locally.
- [x] The paired bug tests from #332 behaved exactly as designed on the swap: the "current buggy behaviour" pin failed and the `expectedFailure` became an unexpected success — the only two failures in the whole suite. Collapsed into one passing regression test.
- [x] Clean venv from the new `requirements.txt` installs and `import pandas` raises `ModuleNotFoundError`
- [x] `tsc --noEmit` + 67 frontend tests pass
- [x] **Manual end-to-end** against the dev stack with the two dominant real-world shapes — semicolon-delimited headerless European CSV (`%d.%m.%Y`, 96 quarter-hour columns) and the same data as `.xlsx`. Both stored 96 readings with identical correct UTC timestamps, comma decimals, and inferred direction; `.xls` returned the 400.

## Follow-ups (out of scope)
- cp1252/latin-1 uploads still fail (common in Swiss utility exports) — now with a readable message rather than a traceback.
- `int(request.data.get("interval_minutes", 15))` in `views.py` 500s on non-numeric input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)