### PR TITLE
ci(backend): add ruff lint to CI

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -73,6 +73,9 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
 
+            - name: Lint
+              run: ruff check .
+
             - name: Django system check
               run: python manage.py check
 

--- a/backend/accounts/permissions.py
+++ b/backend/accounts/permissions.py
@@ -1,5 +1,4 @@
 from rest_framework.permissions import BasePermission
-from .models import UserRole
 
 
 class IsAdmin(BasePermission):

--- a/backend/invoices/annual_statement.py
+++ b/backend/invoices/annual_statement.py
@@ -8,11 +8,9 @@ Produces a year-end summary document for a participant showing:
 - Energy self-sufficiency ratio
 """
 import logging
-from datetime import date, datetime, time, timezone as dt_timezone, timedelta
+from datetime import date, datetime, timezone as dt_timezone
 from decimal import Decimal, ROUND_HALF_UP
 
-from django.template.loader import render_to_string
-from django.template import Template, Context
 from accounts.models import AppSettings
 from .pdf_render import render_pdf
 
@@ -446,9 +444,7 @@ def _build_monthly_chart_svg(monthly_data: list[dict], tr: dict) -> str | None:
 
     # Bars
     for i, (zev_val, grid_val) in enumerate(values):
-        total = zev_val + grid_val
         x = margin_l + i * (bar_w + gap) + gap / 2
-        bar_total_h = (total / max_val) * bar_area_h if max_val > 0 else 0
 
         # ZEV portion (bottom, green)
         zev_h = (zev_val / max_val) * bar_area_h if max_val > 0 else 0

--- a/backend/invoices/engine.py
+++ b/backend/invoices/engine.py
@@ -13,7 +13,6 @@ from datetime import date, datetime, timezone as tz, timedelta
 from decimal import Decimal, ROUND_HALF_UP
 
 from django.db import models, transaction
-from django.utils import timezone
 
 from accounts.models import VatRate
 from zev.models import Zev, Participant, MeteringPoint, MeteringPointType, MeteringPointAssignment

--- a/backend/invoices/pdf.py
+++ b/backend/invoices/pdf.py
@@ -5,7 +5,6 @@ converted to PDF. Optionally embeds a Swiss QR-Rechnung.
 """
 import io
 import logging
-from pathlib import Path
 from datetime import date, datetime
 
 from django.template.loader import render_to_string

--- a/backend/invoices/tasks.py
+++ b/backend/invoices/tasks.py
@@ -58,7 +58,7 @@ def send_invoice_email_task(self, invoice_id: str, recipient_email: str = None):
     formatted_period_end = _format_date_value(invoice.period_end, app_settings.date_format_short)
 
     from zev.models import DEFAULT_EMAIL_SUBJECT_TEMPLATE, DEFAULT_EMAIL_BODY_TEMPLATE
-    from .models import EmailTemplate, EMAIL_TEMPLATE_DEFAULTS
+    from .models import EmailTemplate
 
     template_ctx = {
         "invoice_number": invoice.invoice_number,

--- a/backend/invoices/test_email_task.py
+++ b/backend/invoices/test_email_task.py
@@ -13,7 +13,7 @@ from unittest import mock
 import pytest
 from django.core.files.base import ContentFile
 
-from invoices.models import EmailLog, Invoice, InvoiceStatus
+from invoices.models import EmailLog, InvoiceStatus
 from invoices.tasks import send_invoice_email_task
 from testing import factories
 

--- a/backend/invoices/test_engine.py
+++ b/backend/invoices/test_engine.py
@@ -249,7 +249,7 @@ class InvoiceEngineTests(TestCase):
         )
         TariffPeriod.objects.create(tariff=levy, period_type=PeriodType.FLAT, price_chf_per_kwh=Decimal("0.02"))
 
-        pct_tariff = Tariff.objects.create(
+        Tariff.objects.create(
             zev=self.zev,
             name="Surcharge 50%",
             category=TariffCategory.GRID_FEES,

--- a/backend/metering/test_import_csv.py
+++ b/backend/metering/test_import_csv.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from rest_framework.test import APIClient
 
 from accounts.models import User, UserRole
-from metering.models import ImportLog, MeterReading, ReadingDirection, ReadingResolution
+from metering.models import ImportLog, MeterReading, ReadingDirection
 from testing.helpers import authenticate as auth
 from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
 

--- a/backend/metering/test_import_csv_characterization.py
+++ b/backend/metering/test_import_csv_characterization.py
@@ -13,7 +13,7 @@ distinction). Those assertions are deliberate, not incidental.
 """
 
 import io
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import openpyxl

--- a/backend/metering/tests.py
+++ b/backend/metering/tests.py
@@ -1,13 +1,11 @@
-import uuid
 from datetime import date, datetime, timezone
 from decimal import Decimal
-from django.core.files.uploadedfile import SimpleUploadedFile
 
 from django.test import TestCase
 from rest_framework.test import APIClient
 
 from accounts.models import User, UserRole
-from metering.models import ImportLog, ImportSource, MeterReading, ReadingDirection, ReadingResolution
+from metering.models import MeterReading, ReadingDirection, ReadingResolution
 from zev.models import Zev, Participant, MeteringPoint, MeteringPointAssignment, MeteringPointType
 
 

--- a/backend/metering/urls.py
+++ b/backend/metering/urls.py
@@ -1,5 +1,4 @@
 from rest_framework.routers import DefaultRouter
-from django.urls import path
 from .views import MeterReadingViewSet, ImportLogViewSet, ImportView
 
 router = DefaultRouter()

--- a/backend/metering/views.py
+++ b/backend/metering/views.py
@@ -10,7 +10,7 @@ from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from accounts.permissions import IsZevOwnerOrAdmin
-from zev.models import Zev, Participant, MeteringPoint, MeteringPointAssignment
+from zev.models import Zev, Participant, MeteringPoint
 from .models import MeterReading, ImportLog
 from zev.scoping import ZevScopedQuerySetMixin
 from .serializers import MeterReadingSerializer, ImportLogSerializer

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.ruff]
+target-version = "py314"
+
+[tool.ruff.lint]
+# Deliberately narrow: real bugs and dead code (pyflakes) plus genuine syntax/
+# runtime errors, not style opinions. Broader presets (line length, import
+# sorting, datetime-naivety, blind-except, ...) flag hundreds of pre-existing,
+# unrelated findings across the codebase — expanding this is a separate,
+# deliberate decision, not something CI should silently start enforcing.
+select = ["E9", "F"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -56,6 +56,7 @@ qrcode==8.2
 redis==8.0.1
 referencing==0.37.0
 rpds-py==0.30.0
+ruff==0.16.0
 six==1.17.0
 sqlparse==0.5.5
 svgwrite==1.4.3

--- a/backend/tariffs/serializers.py
+++ b/backend/tariffs/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from django.core.exceptions import ValidationError as DjangoValidationError
-from .models import BillingMode, EnergyType, Tariff, TariffPeriod
+from .models import BillingMode, Tariff, TariffPeriod
 
 ENERGY_BILLING_MODES = {BillingMode.ENERGY, BillingMode.PERCENTAGE_OF_ENERGY}
 

--- a/backend/zev/management/commands/seed_demo.py
+++ b/backend/zev/management/commands/seed_demo.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
 
         User = get_user_model()
 
-        admin = self._upsert_user(
+        self._upsert_user(
             User,
             username="admin",
             email="admin@openzev.local",

--- a/backend/zev/views.py
+++ b/backend/zev/views.py
@@ -1,6 +1,5 @@
 from datetime import date as date_type, datetime, timedelta, timezone as dt_timezone
 
-from django.db.models import Q
 from django.http import HttpResponse
 from django.utils.crypto import get_random_string
 from rest_framework import viewsets, status


### PR DESCRIPTION
## Summary

Item #4 from the backend refactoring analysis: the backend had no Python linter. Frontend gets `npm run lint`, Helm gets `helm lint`, but nothing looked at the Django app — which is exactly how the pandas removal (#332/#333) found 23 pre-existing dead-code findings sitting unnoticed.

## Rule set: deliberately narrow

Ruff's broader presets flag **~590** findings across this codebase today (line length, import sorting, blind `except`, naive datetimes, mutable class defaults, ...). Enabling that as a side effect of "add a linter" would mean either a much bigger unrelated diff or immediately-noisy CI. So `select = ["E9", "F"]` in `backend/pyproject.toml` — pyflakes (dead code, unused imports/variables, undefined names) plus genuine syntax/runtime errors. Nothing stylistic.

Worth calling out since it surprised me while scoping this: **ruff's effective default rule set is not stable to rely on** — running `ruff check .` with no config picked up a much broader ruleset than pyflakes-only, even with `--isolated`. Pinning `select` explicitly in a checked-in config means CI behavior doesn't depend on ambient defaults or the installed ruff version's opinions.

## Fixed the pre-existing findings so CI starts green

23 total: 20 unused imports (auto-fixed), 3 unused local variables (reviewed individually, not blindly auto-fixed):

- `invoices/annual_statement.py`: `total`/`bar_total_h` in the annual-statement bar chart were genuinely dead — computed but never read; `zev_h`/`grid_h` derive independently from the raw values. Deleted both lines.
- `invoices/test_engine.py` and `zev/management/commands/seed_demo.py`: `pct_tariff =` and `admin =` — the `Tariff.objects.create(...)` / `self._upsert_user(...)` calls matter for their side effect (DB writes the test/seed relies on), only the variable binding was unused. Dropped the binding, kept the call.

## Test plan
- [x] `ruff check .` clean from `backend/` using the checked-in config
- [x] Fresh venv, `pip install -r requirements.txt` (as CI does it), `ruff check .` clean
- [x] `pytest backend/` → 442 passed, 91 subtests — unchanged after the cleanup
- [x] Ran `ruff check . --isolated --select F,E9` (i.e. ignoring the new config) before and after to confirm the 23 findings are gone and nothing new appeared

🤖 Generated with [Claude Code](https://claude.com/claude-code)