### PR TITLE
refactor(invoices): dedupe the four status-transition actions

### DIFF
--- a/backend/invoices/views.py
+++ b/backend/invoices/views.py
@@ -316,104 +316,82 @@ class InvoiceViewSet(
         )
         return Response({"detail": f"Email queued for {recipient}."})
 
-    @action(detail=True, methods=["post"], url_path="approve",
-            permission_classes=[IsAuthenticated, IsZevOwnerOrAdmin])
-    def approve(self, request, pk=None):
+    def _perform_status_transition(self, request, *, action_type, workflow_fn, denied_verb, success_summary):
+        """Shared body for the four status-transition actions below.
+
+        Each just picks a workflow function (which raises InvoiceWorkflowError
+        on an invalid transition) and phrasing for the audit log; this method
+        owns the get-object/try-except/audit-event/response shape they all
+        share identically.
+        """
         invoice = self.get_object()
         try:
-            before = approve_invoice(invoice)
+            before = workflow_fn(invoice)
         except InvoiceWorkflowError as exc:
             _record_invoice_event(
                 request=request,
-                action_type="invoice.approve",
-                summary=f"Denied approval for {_invoice_target_display(invoice)} due to status guard.",
+                action_type=action_type,
+                summary=f"Denied {denied_verb} for {_invoice_target_display(invoice)}: {exc.user_message}",
                 status=AuditEventStatus.DENIED,
                 invoice=invoice,
             )
             return Response({"error": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
         _record_invoice_event(
             request=request,
-            action_type="invoice.approve",
-            summary=f"Approved invoice {_invoice_target_display(invoice)}.",
+            action_type=action_type,
+            summary=success_summary(invoice),
             invoice=invoice,
             changes=build_diff(before, {"status": invoice.status}, ["status"]),
         )
         return Response(InvoiceSerializer(invoice, context={"request": request}).data)
+
+    @action(detail=True, methods=["post"], url_path="approve",
+            permission_classes=[IsAuthenticated, IsZevOwnerOrAdmin])
+    def approve(self, request, pk=None):
+        """Transition a draft invoice to approved."""
+        return self._perform_status_transition(
+            request,
+            action_type="invoice.approve",
+            workflow_fn=approve_invoice,
+            denied_verb="approval",
+            success_summary=lambda invoice: f"Approved invoice {_invoice_target_display(invoice)}.",
+        )
 
     @action(detail=True, methods=["post"], url_path="mark-sent",
             permission_classes=[IsAuthenticated, IsZevOwnerOrAdmin])
     def mark_sent(self, request, pk=None):
         """Transition an approved invoice to sent/locked state."""
-        invoice = self.get_object()
-        try:
-            before = mark_invoice_sent(invoice)
-        except InvoiceWorkflowError as exc:
-            _record_invoice_event(
-                request=request,
-                action_type="invoice.mark_sent",
-                summary=f"Denied mark-sent for {_invoice_target_display(invoice)} due to status guard.",
-                status=AuditEventStatus.DENIED,
-                invoice=invoice,
-            )
-            return Response({"error": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
-        _record_invoice_event(
-            request=request,
+        return self._perform_status_transition(
+            request,
             action_type="invoice.mark_sent",
-            summary=f"Marked invoice {_invoice_target_display(invoice)} as sent.",
-            invoice=invoice,
-            changes=build_diff(before, {"status": invoice.status}, ["status"]),
+            workflow_fn=mark_invoice_sent,
+            denied_verb="mark-sent",
+            success_summary=lambda invoice: f"Marked invoice {_invoice_target_display(invoice)} as sent.",
         )
-        return Response(InvoiceSerializer(invoice, context={"request": request}).data)
 
     @action(detail=True, methods=["post"], url_path="mark-paid",
             permission_classes=[IsAuthenticated, IsZevOwnerOrAdmin])
     def mark_paid(self, request, pk=None):
         """Record that a sent invoice has been paid."""
-        invoice = self.get_object()
-        try:
-            before = mark_invoice_paid(invoice)
-        except InvoiceWorkflowError as exc:
-            _record_invoice_event(
-                request=request,
-                action_type="invoice.mark_paid",
-                summary=f"Denied mark-paid for {_invoice_target_display(invoice)} due to status guard.",
-                status=AuditEventStatus.DENIED,
-                invoice=invoice,
-            )
-            return Response({"error": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
-        _record_invoice_event(
-            request=request,
+        return self._perform_status_transition(
+            request,
             action_type="invoice.mark_paid",
-            summary=f"Marked invoice {_invoice_target_display(invoice)} as paid.",
-            invoice=invoice,
-            changes=build_diff(before, {"status": invoice.status}, ["status"]),
+            workflow_fn=mark_invoice_paid,
+            denied_verb="mark-paid",
+            success_summary=lambda invoice: f"Marked invoice {_invoice_target_display(invoice)} as paid.",
         )
-        return Response(InvoiceSerializer(invoice, context={"request": request}).data)
 
     @action(detail=True, methods=["post"], url_path="cancel",
             permission_classes=[IsAuthenticated, IsZevOwnerOrAdmin])
     def cancel(self, request, pk=None):
         """Cancel an invoice that has not yet been paid."""
-        invoice = self.get_object()
-        try:
-            before = cancel_invoice(invoice)
-        except InvoiceWorkflowError as exc:
-            _record_invoice_event(
-                request=request,
-                action_type="invoice.cancel",
-                summary=f"Denied cancellation for {_invoice_target_display(invoice)}: {exc.user_message}",
-                status=AuditEventStatus.DENIED,
-                invoice=invoice,
-            )
-            return Response({"error": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
-        _record_invoice_event(
-            request=request,
+        return self._perform_status_transition(
+            request,
             action_type="invoice.cancel",
-            summary=f"Cancelled invoice {_invoice_target_display(invoice)}.",
-            invoice=invoice,
-            changes=build_diff(before, {"status": invoice.status}, ["status"]),
+            workflow_fn=cancel_invoice,
+            denied_verb="cancellation",
+            success_summary=lambda invoice: f"Cancelled invoice {_invoice_target_display(invoice)}.",
         )
-        return Response(InvoiceSerializer(invoice, context={"request": request}).data)
 
     @action(detail=True, methods=["post"], url_path=r"retry-email/(?P<email_log_id>[^/.]+)",
             permission_classes=[IsAuthenticated, IsZevOwnerOrAdmin])


### PR DESCRIPTION
Item #6 from the backend refactoring analysis.

## Summary

`approve`, `mark_sent`, `mark_paid`, and `cancel` were ~92 lines of copy-pasted `get_object → try workflow_fn → except InvoiceWorkflowError → audit event → Response` scaffolding, differing only in which `workflow.py` function they call and two strings. Extracted `_perform_status_transition`; each action is now three keyword arguments naming its workflow function and audit phrasing — e.g.:

```python
def approve(self, request, pk=None):
    """Transition a draft invoice to approved."""
    return self._perform_status_transition(
        request,
        action_type="invoice.approve",
        workflow_fn=approve_invoice,
        denied_verb="approval",
        success_summary=lambda invoice: f"Approved invoice {_invoice_target_display(invoice)}.",
    )
```

## A real inconsistency this made visible

Three of the four denial paths (`approve`/`mark_sent`/`mark_paid`) logged only `"... due to status guard."` in the audit summary — the actual reason (e.g. "Only draft invoices can be approved.") was visible solely in the HTTP error body, not the audit trail. `cancel` already inlined `exc.user_message`. Unified on `cancel`'s format, so the audit log now always shows *why* a transition was refused, not just that it was:

```
approve    Denied approval for INV-2026-001: Only draft invoices can be approved.
mark-sent  Denied mark-sent for INV-2026-001: Only approved invoices can be marked as sent.
mark-paid  Denied mark-paid for INV-2026-001: Only sent invoices can be marked as paid.
cancel     Denied cancellation for INV-2026-001: Paid invoices cannot be cancelled.
```

## What's unchanged

Same URLs, status codes, audit `action_type` strings, response shape (`InvoiceSerializer` data on success, `{"error": ...}` on denial). No test asserts the exact denial summary text, so nothing needed updating there.

## Test plan
- [x] `pytest backend/` → 442 passed, 91 subtests, unchanged
- [x] `ruff check .` clean
- [x] Manually drove a `PAID` invoice through all four endpoints (the one state that denies every transition) and confirmed each denial reads naturally with the guard message inlined, and each success path still returns 200 with the serialized invoice

🤖 Generated with [Claude Code](https://claude.com/claude-code)