### PR TITLE
test(backend): consolidate 7 duplicate make_user() test helpers

### DIFF
--- a/backend/audit/test_summary_parity.py
+++ b/backend/audit/test_summary_parity.py
@@ -10,10 +10,10 @@ from django.test import TestCase
 from django.utils import timezone
 from rest_framework.test import APIClient
 
-from accounts.models import User, UserRole
+from accounts.models import UserRole
 from audit.models import AuditEvent
 from tariffs.models import BillingMode, Tariff, TariffCategory
-from testing.helpers import authenticate as auth
+from testing.helpers import authenticate as auth, make_user
 from zev.models import (
     MeteringPoint,
     MeteringPointAssignment,
@@ -21,12 +21,6 @@ from zev.models import (
     Participant,
     Zev,
 )
-
-
-def make_user(username: str, role: str) -> User:
-    return User.objects.create_user(
-        username=username, email=f"{username}@example.com", password="pass1234", role=role
-    )
 
 
 class AuditSummaryParityTests(TestCase):

--- a/backend/audit/tests.py
+++ b/backend/audit/tests.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.utils import timezone
 from rest_framework.test import APIClient
 
-from accounts.models import FeatureFlag, User, UserRole
+from accounts.models import FeatureFlag, UserRole
 from metering.models import MeterReading
 from invoices.models import Invoice, InvoiceStatus
 from tariffs.models import Tariff, TariffCategory, BillingMode
@@ -22,11 +22,7 @@ from audit.services import (
 from zev.serializers import ParticipantSerializer
 
 
-from testing.helpers import authenticate as auth
-
-
-def make_user(username: str, role: str) -> User:
-    return User.objects.create_user(username=username, email=f"{username}@example.com", password="pass1234", role=role)
+from testing.helpers import authenticate as auth, make_user
 
 
 class AuditEventModelTests(TestCase):

--- a/backend/metering/test_import_csv.py
+++ b/backend/metering/test_import_csv.py
@@ -7,14 +7,10 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from accounts.models import User, UserRole
+from accounts.models import UserRole
 from metering.models import ImportLog, MeterReading, ReadingDirection
-from testing.helpers import authenticate as auth
+from testing.helpers import authenticate as auth, make_user
 from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
-
-
-def make_user(username, role, password="pass1234"):
-    return User.objects.create_user(username=username, password=password, role=role)
 
 
 class CsvImportTests(TestCase):

--- a/backend/metering/test_import_logs.py
+++ b/backend/metering/test_import_logs.py
@@ -7,14 +7,10 @@ from decimal import Decimal
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from accounts.models import User, UserRole
+from accounts.models import UserRole
 from metering.models import ImportLog, ImportSource, MeterReading, ReadingDirection, ReadingResolution
-from testing.helpers import authenticate as auth
+from testing.helpers import authenticate as auth, make_user
 from zev.models import MeteringPoint, MeteringPointType, Participant, Zev
-
-
-def make_user(username, role, password="pass1234"):
-    return User.objects.create_user(username=username, password=password, role=role)
 
 
 class ImportLogDeletionTests(TestCase):

--- a/backend/metering/test_import_sdatch.py
+++ b/backend/metering/test_import_sdatch.py
@@ -7,14 +7,10 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from accounts.models import User, UserRole
+from accounts.models import UserRole
 from metering.models import ImportLog, ImportSource, MeterReading, ReadingDirection
-from testing.helpers import authenticate as auth
+from testing.helpers import authenticate as auth, make_user
 from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
-
-
-def make_user(username, role, password="pass1234"):
-    return User.objects.create_user(username=username, password=password, role=role)
 
 
 class SdatchImportTests(TestCase):

--- a/backend/metering/tests.py
+++ b/backend/metering/tests.py
@@ -4,16 +4,12 @@ from decimal import Decimal
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from accounts.models import User, UserRole
+from accounts.models import UserRole
 from metering.models import MeterReading, ReadingDirection, ReadingResolution
 from zev.models import Zev, Participant, MeteringPoint, MeteringPointAssignment, MeteringPointType
 
 
-from testing.helpers import authenticate as auth
-
-
-def make_user(username, role, password="pass1234"):
-	return User.objects.create_user(username=username, password=password, role=role)
+from testing.helpers import authenticate as auth, make_user
 
 
 class DashboardSummaryAlignmentTests(TestCase):

--- a/backend/testing/helpers.py
+++ b/backend/testing/helpers.py
@@ -1,4 +1,4 @@
-"""Authentication helpers shared across the test suite.
+"""User creation and authentication helpers shared across the test suite.
 
 The project authenticates with JWT delivered via httpOnly cookies, but
 ``CookieJWTAuthentication`` also accepts a standard ``Authorization: Bearer``
@@ -9,6 +9,22 @@ which avoids an extra HTTP round-trip through the login endpoint.
 from __future__ import annotations
 
 from rest_framework_simplejwt.tokens import RefreshToken
+
+from accounts.models import User
+
+
+def make_user(username: str, role: str, password: str = "pass1234") -> User:
+    """Create a bare user with a role and a conventional ``@example.com`` email.
+
+    Seven test modules each defined their own copy of this exact function
+    (two near-identical variants) before it was consolidated here. Prefer the
+    factory_boy factories in ``testing.factories`` for anything that needs a
+    fuller object graph (a Zev, a Participant, ...); reach for this when a
+    test genuinely only needs a user.
+    """
+    return User.objects.create_user(
+        username=username, email=f"{username}@example.com", password=password, role=role
+    )
 
 
 def authenticate(client, user) -> None:

--- a/backend/zev/tests.py
+++ b/backend/zev/tests.py
@@ -6,17 +6,13 @@ from django.core import mail
 from django.test import override_settings
 from rest_framework.test import APIClient
 
-from accounts.models import User, UserRole
+from accounts.models import UserRole
 from zev.management.commands.seed_demo import previous_quarter, quarter_start
 from metering.models import MeterReading
 from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
 
 
-from testing.helpers import authenticate as auth
-
-
-def make_user(username, role, password="pass1234"):
-	return User.objects.create_user(username=username, password=password, role=role)
+from testing.helpers import authenticate as auth, make_user
 
 
 class ParticipantEndpointRestrictionTests(TestCase):


### PR DESCRIPTION
Item #12 from the backend refactoring analysis ("test factories half-adopted").

## What I found

`testing/factories.py` and `conftest.py` already exist and are used by several files, but seven test modules each independently hand-rolled their own copy of the exact same helper instead:

```
audit/tests.py
audit/test_summary_parity.py
metering/tests.py
metering/test_import_csv.py
metering/test_import_logs.py
metering/test_import_sdatch.py
zev/tests.py
```

All seven define `make_user(username, role, ...)` — two near-identical three-line variants (one sets an email, one doesn't; one allows a `password` override, one doesn't) — and none of them import from `testing.factories`. Every one of the seven already imports `authenticate as auth` from `testing.helpers`, so that's where the consolidated version now lives.

## Scope decision: what I did *not* touch

There's an eighth hand-rolled helper module, `invoices/test_helpers.py`, used by 8 more files. I left it alone. It's structurally different from the seven above — it's a single shared module, not duplicated per-file, and its own docstring already says it's a deliberate, in-progress migration target ("preserves the object shapes used by the legacy `tests.py` module while newer tests gradually move to factories"). Folding it into `testing.factories` would mean touching many more call sites across 8 files for field-shape differences (e.g. `invoice_prefix="T"` vs the factory's `"INV"`) that are a separate decision, not a mechanical dedup. Flagging it here as the natural next step if you want to keep going on this item.

## What changed

- `testing/helpers.py` gains `make_user()` — the fuller (email-setting) of the two variants, since nothing depended on the email being absent.
- Each of the 7 files: local `def make_user(...)` removed, import extended to `from testing.helpers import authenticate as auth, make_user`. Call sites inside test methods are untouched — same function name, same signature.
- Each file's `from accounts.models import User, UserRole` drops `User`, which — verified individually — was otherwise unused in every one of the 7 files once the local `make_user` was gone.

## Test plan
- [x] `ruff check .` clean (would have caught a leftover unused `User` import if I'd missed one)
- [x] `pytest backend/` → 442 passed, 91 subtests, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)