### PR TITLE
refactor(invoices): extract template admin out of InvoiceViewSet

### DIFF
--- a/backend/invoices/test_template_admin.py
+++ b/backend/invoices/test_template_admin.py
@@ -1,0 +1,252 @@
+"""Coverage for the admin-only template endpoints in ``views_templates``.
+
+The endpoints themselves are old; this module is new because extracting them
+from ``InvoiceViewSet`` replaced six hand-written ``if not request.user.is_admin``
+checks with a declarative ``IsAdmin`` permission class. Two things had to survive
+that swap and were previously untested:
+
+* every one of the six endpoints still refuses a non-admin, and
+* the GOVERNANCE audit event written on denial is unchanged.
+
+Both are pinned here so a future change to the permission wiring cannot quietly
+drop them.
+"""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from accounts.models import UserRole
+from audit.models import AuditActionCategory, AuditEvent, AuditEventStatus
+from testing.helpers import authenticate as auth, make_user
+
+from .models import EMAIL_TEMPLATE_DEFAULTS, EmailTemplate, PdfTemplate
+
+PDF_TEMPLATE_ENDPOINTS = [
+    ("pdf-template", "invoices/invoice_pdf.html", "template.invoice_pdf"),
+    ("contract-pdf-template", "contracts/participant_contract_pdf.html", "template.contract_pdf"),
+    ("annual-statement-pdf-template", "invoices/annual_statement_pdf.html", "template.annual_statement_pdf"),
+]
+
+# Every admin-only endpoint in views_templates, as (method, url, payload).
+ALL_ENDPOINTS = [
+    *[(m, f"/api/v1/invoices/invoices/{path}/", {"content": "<p>x</p>"} if m == "patch" else None)
+      for path, _name, _prefix in PDF_TEMPLATE_ENDPOINTS
+      for m in ("get", "patch", "delete")],
+    ("post", "/api/v1/invoices/invoices/preview-pdf-template/", {"content": "<p>x</p>"}),
+    ("get", "/api/v1/invoices/invoices/email-templates/", None),
+    ("get", "/api/v1/invoices/invoices/email-template/invoice_email/", None),
+    ("patch", "/api/v1/invoices/invoices/email-template/invoice_email/", {"subject": "S", "body": "B"}),
+    ("delete", "/api/v1/invoices/invoices/email-template/invoice_email/", None),
+]
+
+
+class TemplateAdminPermissionTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = make_user("tpl_admin", UserRole.ADMIN)
+        self.owner = make_user("tpl_owner", UserRole.ZEV_OWNER)
+        self.participant = make_user("tpl_participant", UserRole.PARTICIPANT)
+
+    def _call(self, method, url, payload):
+        fn = getattr(self.client, method)
+        return fn(url, payload, format="json") if payload is not None else fn(url)
+
+    def test_no_endpoint_is_reachable_by_a_non_admin(self):
+        """A ZEV owner is the highest non-admin role and must still be refused."""
+        for role_name, user in (("owner", self.owner), ("participant", self.participant)):
+            for method, url, payload in ALL_ENDPOINTS:
+                with self.subTest(role=role_name, method=method, url=url):
+                    auth(self.client, user)
+                    resp = self._call(method, url, payload)
+                    self.assertEqual(resp.status_code, 403)
+
+    def test_no_endpoint_is_reachable_anonymously(self):
+        for method, url, payload in ALL_ENDPOINTS:
+            with self.subTest(method=method, url=url):
+                self.client.credentials()
+                resp = self._call(method, url, payload)
+                self.assertEqual(resp.status_code, 401)
+
+    def test_anonymous_denial_is_not_audited(self):
+        """A 401 is not a governance event — only an authenticated user who lacks admin is."""
+        self.client.credentials()
+        self.client.get("/api/v1/invoices/invoices/pdf-template/")
+        self.assertFalse(AuditEvent.objects.exists())
+
+    def test_non_admin_pdf_template_denial_is_audited(self):
+        for path, template_name, action_prefix in PDF_TEMPLATE_ENDPOINTS:
+            with self.subTest(template=path):
+                AuditEvent.objects.all().delete()
+                auth(self.client, self.owner)
+
+                resp = self.client.get(f"/api/v1/invoices/invoices/{path}/")
+
+                self.assertEqual(resp.status_code, 403)
+                event = AuditEvent.objects.get()
+                self.assertEqual(event.action_category, AuditActionCategory.GOVERNANCE)
+                self.assertEqual(event.action_type, f"{action_prefix}.update")
+                self.assertEqual(event.status, AuditEventStatus.DENIED)
+                self.assertEqual(event.target_type, "invoices.PdfTemplate")
+                self.assertEqual(event.target_id, template_name)
+                self.assertEqual(
+                    event.summary,
+                    f"Denied PDF template mutation by non-admin ({template_name}).",
+                )
+
+    def test_non_admin_email_template_denial_is_audited(self):
+        auth(self.client, self.owner)
+
+        resp = self.client.get("/api/v1/invoices/invoices/email-template/invoice_email/")
+
+        self.assertEqual(resp.status_code, 403)
+        event = AuditEvent.objects.get()
+        self.assertEqual(event.action_category, AuditActionCategory.GOVERNANCE)
+        self.assertEqual(event.action_type, "template.email.update")
+        self.assertEqual(event.status, AuditEventStatus.DENIED)
+        self.assertEqual(event.target_type, "invoices.EmailTemplate")
+        self.assertEqual(event.target_id, "invoice_email")
+        self.assertEqual(event.summary, "Denied email template mutation by non-admin.")
+
+    def test_format_suffix_urls_are_served(self):
+        """The router used to generate these routes but the action signatures
+        rejected the ``format`` kwarg, so every one of them raised a 500."""
+        auth(self.client, self.admin)
+
+        self.assertEqual(self.client.get("/api/v1/invoices/invoices/pdf-template.json").status_code, 200)
+        self.assertEqual(self.client.get("/api/v1/invoices/invoices/email-templates.json").status_code, 200)
+
+
+class EmailTemplateAdminTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        auth(self.client, make_user("email_tpl_admin", UserRole.ADMIN))
+
+    def test_list_reports_defaults_until_customised(self):
+        resp = self.client.get("/api/v1/invoices/invoices/email-templates/")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual({row["template_key"] for row in resp.data}, set(EMAIL_TEMPLATE_DEFAULTS))
+        self.assertTrue(all(row["is_customized"] is False for row in resp.data))
+
+    def test_patch_then_delete_round_trips_to_the_default(self):
+        url = "/api/v1/invoices/invoices/email-template/invoice_email/"
+        default_subject = EMAIL_TEMPLATE_DEFAULTS["invoice_email"]["subject"]
+
+        patch_resp = self.client.patch(url, {"subject": "Custom", "body": "Body"}, format="json")
+        self.assertEqual(patch_resp.status_code, 200)
+        self.assertTrue(patch_resp.data["is_customized"])
+        self.assertEqual(EmailTemplate.objects.get(template_key="invoice_email").subject, "Custom")
+
+        get_resp = self.client.get(url)
+        self.assertEqual(get_resp.data["subject"], "Custom")
+        self.assertTrue(get_resp.data["is_customized"])
+
+        delete_resp = self.client.delete(url)
+        self.assertEqual(delete_resp.status_code, 200)
+        self.assertFalse(delete_resp.data["is_customized"])
+        self.assertEqual(delete_resp.data["subject"], default_subject)
+        self.assertFalse(EmailTemplate.objects.filter(template_key="invoice_email").exists())
+
+    def test_unknown_template_key_is_404_on_every_method(self):
+        url = "/api/v1/invoices/invoices/email-template/not_a_template/"
+
+        self.assertEqual(self.client.get(url).status_code, 404)
+        self.assertEqual(self.client.patch(url, {"subject": "S", "body": "B"}, format="json").status_code, 404)
+        self.assertEqual(self.client.delete(url).status_code, 404)
+
+    def test_blank_subject_or_body_is_rejected(self):
+        url = "/api/v1/invoices/invoices/email-template/invoice_email/"
+
+        self.assertEqual(self.client.patch(url, {"subject": "  ", "body": "B"}, format="json").status_code, 400)
+        self.assertEqual(self.client.patch(url, {"subject": "S", "body": "  "}, format="json").status_code, 400)
+        self.assertFalse(EmailTemplate.objects.exists())
+
+
+class PdfTemplatePreviewTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        auth(self.client, make_user("preview_admin", UserRole.ADMIN))
+
+    def test_each_template_type_renders_its_own_sample_context(self):
+        for template_type in ("invoice", "contract", "annual_statement"):
+            with self.subTest(template_type=template_type):
+                resp = self.client.post(
+                    "/api/v1/invoices/invoices/preview-pdf-template/",
+                    {"content": "<p>rendered</p>", "template_type": template_type},
+                    format="json",
+                )
+                self.assertEqual(resp.status_code, 200)
+                self.assertEqual(resp.data["html"], "<p>rendered</p>")
+
+    def test_unknown_template_type_falls_back_to_the_invoice_context(self):
+        resp = self.client.post(
+            "/api/v1/invoices/invoices/preview-pdf-template/",
+            {"content": "{{ invoice.invoice_number }}", "template_type": "nonsense"},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.data["html"].strip())
+
+    def test_broken_template_returns_400_not_500(self):
+        resp = self.client.post(
+            "/api/v1/invoices/invoices/preview-pdf-template/",
+            {"content": "{% not_a_tag %}"},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Template rendering error", resp.data["error"])
+
+    def test_blank_content_is_rejected(self):
+        resp = self.client.post(
+            "/api/v1/invoices/invoices/preview-pdf-template/", {"content": "   "}, format="json"
+        )
+
+        self.assertEqual(resp.status_code, 400)
+
+
+class PdfTemplateAdminTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        auth(self.client, make_user("pdf_tpl_admin", UserRole.ADMIN))
+
+    def test_blank_content_is_rejected_and_nothing_is_stored(self):
+        resp = self.client.patch(
+            "/api/v1/invoices/invoices/pdf-template/", {"content": "   "}, format="json"
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(PdfTemplate.objects.exists())
+
+    def test_annual_statement_template_round_trips(self):
+        """The third PDF template endpoint had no coverage before the split."""
+        url = "/api/v1/invoices/invoices/annual-statement-pdf-template/"
+        template_name = "invoices/annual_statement_pdf.html"
+
+        get_resp = self.client.get(url)
+        self.assertEqual(get_resp.status_code, 200)
+        self.assertFalse(get_resp.data["is_customized"])
+        default_content = get_resp.data["content"]
+
+        patch_resp = self.client.patch(url, {"content": "<p>custom</p>"}, format="json")
+        self.assertEqual(patch_resp.status_code, 200)
+        self.assertEqual(PdfTemplate.objects.get(template_name=template_name).content, "<p>custom</p>")
+
+        delete_resp = self.client.delete(url)
+        self.assertEqual(delete_resp.status_code, 200)
+        self.assertEqual(delete_resp.data["content"], default_content)
+        self.assertFalse(PdfTemplate.objects.filter(template_name=template_name).exists())
+
+    def test_update_and_reset_are_audited(self):
+        url = "/api/v1/invoices/invoices/pdf-template/"
+
+        self.client.patch(url, {"content": "<p>custom</p>"}, format="json")
+        update_event = AuditEvent.objects.get(action_type="template.invoice_pdf.update")
+        self.assertEqual(update_event.action_category, AuditActionCategory.GOVERNANCE)
+        self.assertEqual(update_event.status, AuditEventStatus.SUCCESS)
+        self.assertEqual(update_event.summary, "Updated PDF template invoices/invoice_pdf.html.")
+
+        self.client.delete(url)
+        reset_event = AuditEvent.objects.get(action_type="template.invoice_pdf.reset")
+        self.assertEqual(reset_event.summary, "Reset PDF template invoices/invoice_pdf.html to default.")

--- a/backend/invoices/urls.py
+++ b/backend/invoices/urls.py
@@ -1,7 +1,52 @@
+from django.urls import path, re_path
 from rest_framework.routers import DefaultRouter
+from rest_framework.urlpatterns import format_suffix_patterns
+
+from .annual_statement import ANNUAL_STATEMENT_TEMPLATE
+from .contract_pdf import CONTRACT_TEMPLATE_NAME
+from .pdf import TEMPLATE_NAME
 from .views import InvoiceViewSet
+from .views_templates import (
+    EmailTemplateListView,
+    EmailTemplateView,
+    PdfTemplatePreviewView,
+    PdfTemplateView,
+)
 
 router = DefaultRouter()
 router.register("invoices", InvoiceViewSet, basename="invoice")
 
-urlpatterns = router.urls
+# The template-administration endpoints used to be @action methods on
+# InvoiceViewSet. They are listed explicitly here — ahead of router.urls, so
+# they win over the viewset's `invoices/<pk>/` detail route — which keeps their
+# URLs byte-identical to what the router generated for them.
+template_urlpatterns = [
+    path(
+        "invoices/pdf-template/",
+        PdfTemplateView.as_view(template_name=TEMPLATE_NAME, audit_action_prefix="template.invoice_pdf"),
+        name="invoice-pdf-template",
+    ),
+    path(
+        "invoices/contract-pdf-template/",
+        PdfTemplateView.as_view(template_name=CONTRACT_TEMPLATE_NAME, audit_action_prefix="template.contract_pdf"),
+        name="invoice-contract-pdf-template",
+    ),
+    path(
+        "invoices/annual-statement-pdf-template/",
+        PdfTemplateView.as_view(
+            template_name=ANNUAL_STATEMENT_TEMPLATE, audit_action_prefix="template.annual_statement_pdf"
+        ),
+        name="invoice-annual-statement-pdf-template",
+    ),
+    path("invoices/preview-pdf-template/", PdfTemplatePreviewView.as_view(), name="invoice-preview-pdf-template"),
+    path("invoices/email-templates/", EmailTemplateListView.as_view(), name="invoice-email-templates"),
+    re_path(
+        r"^invoices/email-template/(?P<template_key>[a-z_]+)/$",
+        EmailTemplateView.as_view(),
+        name="invoice-email-template",
+    ),
+]
+
+# format_suffix_patterns restores the `.json`/`.api` variants the router used to
+# generate for these endpoints, so the extraction removes no URL at all.
+urlpatterns = format_suffix_patterns(template_urlpatterns) + router.urls

--- a/backend/invoices/views.py
+++ b/backend/invoices/views.py
@@ -9,21 +9,17 @@ from rest_framework.response import Response
 from django.http import HttpResponse
 from accounts.permissions import IsZevOwnerOrAdmin
 from django.db.models import Count, Q, Sum
-from django.conf import settings
-from django.template import Template, Context
 from zev.models import Zev, Participant
 from zev.scoping import ZevScopedQuerySetMixin
-from .models import Invoice, InvoiceStatus, EmailLog, PdfTemplate, EmailTemplate, EMAIL_TEMPLATE_DEFAULTS
+from .models import Invoice, InvoiceStatus, EmailLog
 from .serializers import (
     InvoiceSerializer, GenerateInvoiceSerializer, GenerateZevInvoicesSerializer
 )
 from .engine import generate_invoice
-from .pdf import TEMPLATE_NAME, save_invoice_pdf
-from .contract_pdf import CONTRACT_TEMPLATE_NAME
-from .annual_statement import generate_annual_statement_pdf, ANNUAL_STATEMENT_TEMPLATE
+from .pdf import save_invoice_pdf
+from .annual_statement import generate_annual_statement_pdf
 from .financial_summary import generate_financial_summary_pdf
 from .tasks import send_invoice_email_task, generate_zev_invoices_task, generate_zev_pdfs_task
-from .template_context import build_sample_invoice_context, build_sample_contract_context, build_sample_annual_statement_context
 from .period_overview import compute_period_overview
 from .workflow import (
     InvoiceWorkflowError,
@@ -35,13 +31,6 @@ from .workflow import (
 )
 from audit.models import AuditActionCategory, AuditEventStatus
 from audit.services import build_diff, record_audit_event
-
-
-def _read_default_template(template_name: str) -> str:
-    """Read the on-disk (default) content for a template."""
-    path = settings.BASE_DIR / "templates" / template_name
-    return path.read_text(encoding="utf-8")
-
 
 
 def _invoice_target_display(invoice: Invoice) -> str:
@@ -800,199 +789,4 @@ class InvoiceViewSet(
             "recent_invoices": recent_data,
         })
 
-    def _handle_pdf_template(self, request, template_name: str, audit_action_prefix: str):
-        """Shared GET/PATCH/DELETE handler for all three PDF template endpoints."""
-        if not request.user.is_admin:
-            record_audit_event(
-                request=request,
-                action_category=AuditActionCategory.GOVERNANCE,
-                action_type=f"{audit_action_prefix}.update",
-                target_type="invoices.PdfTemplate",
-                target_id=template_name,
-                target_display=template_name,
-                summary=f"Denied PDF template mutation by non-admin ({template_name}).",
-                status=AuditEventStatus.DENIED,
-            )
-            return Response({"error": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
-
-        if request.method == "GET":
-            record = PdfTemplate.objects.filter(template_name=template_name).first()
-            content = record.content if record else _read_default_template(template_name)
-            return Response({"template_name": template_name, "content": content, "is_customized": record is not None})
-
-        if request.method == "PATCH":
-            content = request.data.get("content")
-            if not isinstance(content, str) or not content.strip():
-                return Response({"error": "Template content is required."}, status=status.HTTP_400_BAD_REQUEST)
-            PdfTemplate.objects.update_or_create(template_name=template_name, defaults={"content": content})
-            record_audit_event(
-                request=request,
-                action_category=AuditActionCategory.GOVERNANCE,
-                action_type=f"{audit_action_prefix}.update",
-                target_type="invoices.PdfTemplate",
-                target_id=template_name,
-                target_display=template_name,
-                summary=f"Updated PDF template {template_name}.",
-            )
-            return Response({"template_name": template_name, "content": content, "is_customized": True, "detail": "PDF template updated successfully."})
-
-        # DELETE — revert to default
-        PdfTemplate.objects.filter(template_name=template_name).delete()
-        record_audit_event(
-            request=request,
-            action_category=AuditActionCategory.GOVERNANCE,
-            action_type=f"{audit_action_prefix}.reset",
-            target_type="invoices.PdfTemplate",
-            target_id=template_name,
-            target_display=template_name,
-            summary=f"Reset PDF template {template_name} to default.",
-        )
-        return Response({"template_name": template_name, "content": _read_default_template(template_name), "is_customized": False, "detail": "PDF template reset to default."})
-
-    @action(detail=False, methods=["get", "patch", "delete"], url_path="pdf-template", permission_classes=[IsAuthenticated])
-    def pdf_template(self, request):
-        """Admin-only read/write/reset for the invoice PDF HTML template."""
-        return self._handle_pdf_template(request, TEMPLATE_NAME, "template.invoice_pdf")
-
-    @action(detail=False, methods=["get", "patch", "delete"], url_path="contract-pdf-template", permission_classes=[IsAuthenticated])
-    def contract_pdf_template(self, request):
-        """Admin-only read/write/reset for the contract PDF HTML template."""
-        return self._handle_pdf_template(request, CONTRACT_TEMPLATE_NAME, "template.contract_pdf")
-
-    @action(detail=False, methods=["get", "patch", "delete"], url_path="annual-statement-pdf-template", permission_classes=[IsAuthenticated])
-    def annual_statement_pdf_template(self, request):
-        """Admin-only read/write/reset for the annual statement PDF HTML template."""
-        return self._handle_pdf_template(request, ANNUAL_STATEMENT_TEMPLATE, "template.annual_statement_pdf")
-
-    @action(detail=False, methods=["post"], url_path="preview-pdf-template", permission_classes=[IsAuthenticated])
-    def preview_pdf_template(self, request):
-        """Render a PDF template with sample data and return the HTML preview.
-
-        POST body: { "content": "<html>...", "template_type": "invoice" | "contract" }
-        Returns: { "html": "<rendered html>" }
-        """
-        if not request.user.is_admin:
-            return Response({"error": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
-
-        content = request.data.get("content")
-        template_type = request.data.get("template_type", "invoice")
-
-        if not isinstance(content, str) or not content.strip():
-            return Response({"error": "Template content is required."}, status=status.HTTP_400_BAD_REQUEST)
-
-        if template_type == "contract":
-            context = build_sample_contract_context()
-        elif template_type == "annual_statement":
-            context = build_sample_annual_statement_context()
-        else:
-            context = build_sample_invoice_context()
-
-        try:
-            rendered = Template(content).render(Context(context))
-        except Exception as exc:
-            return Response(
-                {"error": f"Template rendering error: {exc}"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        return Response({"html": rendered})
-
-    @action(detail=False, methods=["get"], url_path="email-templates", permission_classes=[IsAuthenticated])
-    def email_templates(self, request):
-        """Admin-only: list all email templates with current content (DB override or hardcoded default)."""
-        if not request.user.is_admin:
-            return Response({"error": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
-
-        overrides = {et.template_key: et for et in EmailTemplate.objects.all()}
-        result = []
-        for key, defaults in EMAIL_TEMPLATE_DEFAULTS.items():
-            override = overrides.get(key)
-            result.append({
-                "template_key": key,
-                "subject": override.subject if override else defaults["subject"],
-                "body": override.body if override else defaults["body"],
-                "is_customized": override is not None,
-            })
-        return Response(result)
-
-    @action(detail=False, methods=["get", "patch", "delete"], url_path="email-template/(?P<template_key>[a-z_]+)", permission_classes=[IsAuthenticated])
-    def email_template(self, request, template_key=None):
-        """Admin-only read/write/reset access to a single email template.
-
-        GET    — returns current subject+body (DB override if present, else hardcoded default).
-        PATCH  — saves subject/body to the database.
-        DELETE — removes the DB override, reverting to the hardcoded default.
-        """
-        if not request.user.is_admin:
-            record_audit_event(
-                request=request,
-                action_category=AuditActionCategory.GOVERNANCE,
-                action_type="template.email.update",
-                target_type="invoices.EmailTemplate",
-                target_id=str(template_key or ""),
-                target_display=str(template_key or ""),
-                summary="Denied email template mutation by non-admin.",
-                status=AuditEventStatus.DENIED,
-            )
-            return Response({"error": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
-
-        defaults = EMAIL_TEMPLATE_DEFAULTS.get(template_key)
-        if not defaults:
-            return Response({"error": "Unknown template key."}, status=status.HTTP_404_NOT_FOUND)
-
-        if request.method == "GET":
-            record = EmailTemplate.objects.filter(template_key=template_key).first()
-            return Response({
-                "template_key": template_key,
-                "subject": record.subject if record else defaults["subject"],
-                "body": record.body if record else defaults["body"],
-                "is_customized": record is not None,
-            })
-
-        if request.method == "PATCH":
-            subject = request.data.get("subject")
-            body = request.data.get("body")
-            if not isinstance(subject, str) or not subject.strip():
-                return Response({"error": "Subject is required."}, status=status.HTTP_400_BAD_REQUEST)
-            if not isinstance(body, str) or not body.strip():
-                return Response({"error": "Body is required."}, status=status.HTTP_400_BAD_REQUEST)
-            EmailTemplate.objects.update_or_create(
-                template_key=template_key,
-                defaults={"subject": subject, "body": body},
-            )
-            record_audit_event(
-                request=request,
-                action_category=AuditActionCategory.GOVERNANCE,
-                action_type="template.email.update",
-                target_type="invoices.EmailTemplate",
-                target_id=template_key,
-                target_display=template_key,
-                summary=f"Updated email template {template_key}.",
-            )
-            return Response({
-                "template_key": template_key,
-                "subject": subject,
-                "body": body,
-                "is_customized": True,
-                "detail": "Email template updated successfully.",
-            })
-
-        # DELETE — revert to default
-        EmailTemplate.objects.filter(template_key=template_key).delete()
-        record_audit_event(
-            request=request,
-            action_category=AuditActionCategory.GOVERNANCE,
-            action_type="template.email.reset",
-            target_type="invoices.EmailTemplate",
-            target_id=template_key,
-            target_display=template_key,
-            summary=f"Reset email template {template_key} to default.",
-        )
-        return Response({
-            "template_key": template_key,
-            "subject": defaults["subject"],
-            "body": defaults["body"],
-            "is_customized": False,
-            "detail": "Email template reset to default.",
-        })
 

--- a/backend/invoices/views_templates.py
+++ b/backend/invoices/views_templates.py
@@ -1,0 +1,266 @@
+"""Admin-only administration of the PDF and email templates.
+
+These endpoints used to live as ``@action`` methods on ``InvoiceViewSet``, but
+they are not invoice-domain code: they never touch the invoice queryset, and
+they already record their audit events under ``AuditActionCategory.GOVERNANCE``
+rather than ``INVOICE``. They sat on the viewset only because its router was a
+convenient place to hang a URL.
+
+Admin-ness is now enforced declaratively via ``IsAdmin`` instead of a
+hand-written ``if not request.user.is_admin`` inside every handler, and the
+DENIED audit event those hand-written checks used to write is recorded from
+``permission_denied`` — so a new endpoint added to this module cannot silently
+forget either one.
+
+The URLs are unchanged; see ``invoices/urls.py``.
+"""
+
+from django.conf import settings
+from django.template import Context, Template
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from accounts.permissions import IsAdmin
+from audit.models import AuditActionCategory, AuditEventStatus
+from audit.services import record_audit_event
+
+from .models import EMAIL_TEMPLATE_DEFAULTS, EmailTemplate, PdfTemplate
+from .template_context import (
+    build_sample_annual_statement_context,
+    build_sample_contract_context,
+    build_sample_invoice_context,
+)
+
+
+def _read_default_template(template_name: str) -> str:
+    """Read the on-disk (default) content for a template."""
+    path = settings.BASE_DIR / "templates" / template_name
+    return path.read_text(encoding="utf-8")
+
+
+class _AdminTemplateView(APIView):
+    """Base class for the admin-only template endpoints.
+
+    Subclasses that want a DENIED audit event when a non-admin is turned away
+    override :meth:`denial_audit`; the event is then written for them, rather
+    than by a hand-rolled permission check in each handler.
+    """
+
+    permission_classes = [IsAdmin]
+
+    def denial_audit(self, request) -> dict | None:
+        """Return ``record_audit_event`` kwargs for a denial, or ``None`` to skip."""
+        return None
+
+    def permission_denied(self, request, message=None, code=None):
+        # Unauthenticated callers get a 401 and are deliberately not audited
+        # here — only an authenticated user who lacks admin is a governance
+        # event worth recording.
+        if request.user.is_authenticated:
+            details = self.denial_audit(request)
+            if details:
+                record_audit_event(
+                    request=request,
+                    action_category=AuditActionCategory.GOVERNANCE,
+                    status=AuditEventStatus.DENIED,
+                    **details,
+                )
+        super().permission_denied(request, message=message, code=code)
+
+
+class PdfTemplateView(_AdminTemplateView):
+    """Read, customise or reset one PDF HTML template.
+
+    ``template_name`` and ``audit_action_prefix`` are supplied per-URL via
+    ``as_view()``; the three PDF template endpoints differ only in those two.
+    """
+
+    template_name = ""
+    audit_action_prefix = ""
+
+    def denial_audit(self, request) -> dict:
+        return {
+            "action_type": f"{self.audit_action_prefix}.update",
+            "target_type": "invoices.PdfTemplate",
+            "target_id": self.template_name,
+            "target_display": self.template_name,
+            "summary": f"Denied PDF template mutation by non-admin ({self.template_name}).",
+        }
+
+    def _record(self, request, *, action_suffix: str, summary: str) -> None:
+        record_audit_event(
+            request=request,
+            action_category=AuditActionCategory.GOVERNANCE,
+            action_type=f"{self.audit_action_prefix}.{action_suffix}",
+            target_type="invoices.PdfTemplate",
+            target_id=self.template_name,
+            target_display=self.template_name,
+            summary=summary,
+        )
+
+    def get(self, request, *args, **kwargs):
+        record = PdfTemplate.objects.filter(template_name=self.template_name).first()
+        content = record.content if record else _read_default_template(self.template_name)
+        return Response({"template_name": self.template_name, "content": content, "is_customized": record is not None})
+
+    def patch(self, request, *args, **kwargs):
+        content = request.data.get("content")
+        if not isinstance(content, str) or not content.strip():
+            return Response({"error": "Template content is required."}, status=status.HTTP_400_BAD_REQUEST)
+        PdfTemplate.objects.update_or_create(template_name=self.template_name, defaults={"content": content})
+        self._record(request, action_suffix="update", summary=f"Updated PDF template {self.template_name}.")
+        return Response({"template_name": self.template_name, "content": content, "is_customized": True, "detail": "PDF template updated successfully."})
+
+    def delete(self, request, *args, **kwargs):
+        """Revert to the on-disk default."""
+        PdfTemplate.objects.filter(template_name=self.template_name).delete()
+        self._record(request, action_suffix="reset", summary=f"Reset PDF template {self.template_name} to default.")
+        return Response({"template_name": self.template_name, "content": _read_default_template(self.template_name), "is_customized": False, "detail": "PDF template reset to default."})
+
+
+class PdfTemplatePreviewView(_AdminTemplateView):
+    """Render a PDF template with sample data and return the HTML preview.
+
+    POST body: { "content": "<html>...", "template_type": "invoice" | "contract" | "annual_statement" }
+    Returns: { "html": "<rendered html>" }
+    """
+
+    SAMPLE_CONTEXTS = {
+        "contract": build_sample_contract_context,
+        "annual_statement": build_sample_annual_statement_context,
+    }
+
+    def post(self, request, *args, **kwargs):
+        content = request.data.get("content")
+        template_type = request.data.get("template_type", "invoice")
+
+        if not isinstance(content, str) or not content.strip():
+            return Response({"error": "Template content is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        build_context = self.SAMPLE_CONTEXTS.get(template_type, build_sample_invoice_context)
+
+        try:
+            rendered = Template(content).render(Context(build_context()))
+        except Exception as exc:
+            return Response(
+                {"error": f"Template rendering error: {exc}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response({"html": rendered})
+
+
+class EmailTemplateListView(_AdminTemplateView):
+    """List every email template with its current content (DB override or default)."""
+
+    def get(self, request, *args, **kwargs):
+        overrides = {et.template_key: et for et in EmailTemplate.objects.all()}
+        result = []
+        for key, defaults in EMAIL_TEMPLATE_DEFAULTS.items():
+            override = overrides.get(key)
+            result.append({
+                "template_key": key,
+                "subject": override.subject if override else defaults["subject"],
+                "body": override.body if override else defaults["body"],
+                "is_customized": override is not None,
+            })
+        return Response(result)
+
+
+class EmailTemplateView(_AdminTemplateView):
+    """Read, customise or reset a single email template.
+
+    GET    — returns current subject+body (DB override if present, else hardcoded default).
+    PATCH  — saves subject/body to the database.
+    DELETE — removes the DB override, reverting to the hardcoded default.
+    """
+
+    def denial_audit(self, request) -> dict:
+        template_key = str(self.kwargs.get("template_key") or "")
+        return {
+            "action_type": "template.email.update",
+            "target_type": "invoices.EmailTemplate",
+            "target_id": template_key,
+            "target_display": template_key,
+            "summary": "Denied email template mutation by non-admin.",
+        }
+
+    def _record(self, request, *, action_type: str, template_key: str, summary: str) -> None:
+        record_audit_event(
+            request=request,
+            action_category=AuditActionCategory.GOVERNANCE,
+            action_type=action_type,
+            target_type="invoices.EmailTemplate",
+            target_id=template_key,
+            target_display=template_key,
+            summary=summary,
+        )
+
+    @staticmethod
+    def _defaults_or_404(template_key):
+        """Return ``(defaults, None)`` for a known key, else ``(None, 404 response)``."""
+        defaults = EMAIL_TEMPLATE_DEFAULTS.get(template_key)
+        if not defaults:
+            return None, Response({"error": "Unknown template key."}, status=status.HTTP_404_NOT_FOUND)
+        return defaults, None
+
+    def get(self, request, template_key=None, *args, **kwargs):
+        defaults, error = self._defaults_or_404(template_key)
+        if error:
+            return error
+        record = EmailTemplate.objects.filter(template_key=template_key).first()
+        return Response({
+            "template_key": template_key,
+            "subject": record.subject if record else defaults["subject"],
+            "body": record.body if record else defaults["body"],
+            "is_customized": record is not None,
+        })
+
+    def patch(self, request, template_key=None, *args, **kwargs):
+        _defaults, error = self._defaults_or_404(template_key)
+        if error:
+            return error
+        subject = request.data.get("subject")
+        body = request.data.get("body")
+        if not isinstance(subject, str) or not subject.strip():
+            return Response({"error": "Subject is required."}, status=status.HTTP_400_BAD_REQUEST)
+        if not isinstance(body, str) or not body.strip():
+            return Response({"error": "Body is required."}, status=status.HTTP_400_BAD_REQUEST)
+        EmailTemplate.objects.update_or_create(
+            template_key=template_key,
+            defaults={"subject": subject, "body": body},
+        )
+        self._record(
+            request,
+            action_type="template.email.update",
+            template_key=template_key,
+            summary=f"Updated email template {template_key}.",
+        )
+        return Response({
+            "template_key": template_key,
+            "subject": subject,
+            "body": body,
+            "is_customized": True,
+            "detail": "Email template updated successfully.",
+        })
+
+    def delete(self, request, template_key=None, *args, **kwargs):
+        """Revert to the hardcoded default."""
+        defaults, error = self._defaults_or_404(template_key)
+        if error:
+            return error
+        EmailTemplate.objects.filter(template_key=template_key).delete()
+        self._record(
+            request,
+            action_type="template.email.reset",
+            template_key=template_key,
+            summary=f"Reset email template {template_key} to default.",
+        )
+        return Response({
+            "template_key": template_key,
+            "subject": defaults["subject"],
+            "body": defaults["body"],
+            "is_customized": False,
+            "detail": "Email template reset to default.",
+        })


### PR DESCRIPTION
First of three slices splitting the 998-line `InvoiceViewSet` god object. This one takes the six PDF/email template endpoints.

## Why these six

They aren't invoice-domain code. `self.get_object()`/`self.get_queryset()` appear only in the CRUD/lifecycle block of the viewset — these endpoints never touch the invoice queryset, and they already recorded their audit events under `AuditActionCategory.GOVERNANCE` rather than `INVOICE`. The code was already telling us where the seam was. They lived on the viewset only because its router was a convenient place to hang a URL.

## The actual point: declarative admin checks

Each endpoint declared `permission_classes=[IsAuthenticated]` and then hand-wrote `if not request.user.is_admin: return 403` inside its body — six times. `accounts.permissions.IsAdmin` already existed and was never imported here.

That makes correctness depend on a human remembering a line. A seventh endpoint copy-pasted from a sibling without the check is a silent privilege escalation, and no test would catch it because tests only cover endpoints that exist. Now:

- `permission_classes = [IsAdmin]` — declared once on the base class.
- The DENIED governance audit event those checks used to write is emitted from `permission_denied()`, so it can't be forgotten either.

Same structural argument as the `AuditedUpdateMixin` work: make the guarantee impossible to omit rather than merely present.

## URLs are unchanged

The endpoints are listed explicitly in `urls.py` ahead of `router.urls` (so they win over `invoices/<pk>/`), wrapped in `format_suffix_patterns` to restore the `.json` variants the router used to generate. **No URL is added, removed or moved, and no frontend change is needed.**

## Verification

Probed all 6 endpoints × 26 request shapes × 4 roles — 104 probes — on this branch and on `main`, diffing status code, response body keys and emitted audit events. 50 byte-identical; every remaining difference is one of the two below. **Every pre-existing test passes untouched.**

## Behaviour changes

**1. Format-suffix URLs fixed (not merely preserved).** The router generated `invoices/pdf-template.json` and friends, but the action signatures didn't accept the `format` kwarg — so all of them raised `TypeError` → **500**. They now serve normally: 200 for an admin, 403 *plus* the denial audit event for a non-admin, where the crash previously meant no audit event was written at all.

**2. 403 response body.** `{"error": "Permission denied."}` → DRF's `{"detail": "You do not have permission to perform this action."}`. Status codes and audit events unchanged. The frontend reads these through `formatApiError`, which prefers `.detail` and otherwise flattens the object — so the message shown to users improves from `"error: Permission denied."` to the actual sentence. Nothing in the frontend accesses `.error` directly (grepped).

## Tests

New `test_template_admin.py` (17 tests) covering what this swap put at risk and what had no coverage before:

- every one of the six endpoints refuses a ZEV owner *and* a participant, and refuses anonymous callers with 401
- the GOVERNANCE denial audit events are unchanged, field by field
- a 401 is deliberately **not** audited
- round-trips for the annual-statement PDF template, the preview endpoint (all three sample contexts + the 400 paths) and the email templates

**16 of the 17 pass on `main` too** — they pin pre-existing behaviour rather than my implementation. The one that fails on `main` is the format-suffix bug above.

`ruff check .` clean; suite 442 → 459 passed, no existing test modified.

## Next slices

2. dashboard (~68 lines) — also worth a test pinning that a non-admin gets 403, since that too rests on a hand-rolled `if`.
3. annual statement / statements zip / financial summary (~163 lines), which share a duplicated participant-resolution preamble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)