### PR TITLE
refactor(invoices): extract the dashboard out of InvoiceViewSet

### DIFF
--- a/backend/invoices/test_dashboard.py
+++ b/backend/invoices/test_dashboard.py
@@ -8,7 +8,6 @@ reports across *every* tenant: a ZEV owner reaching it would see every other
 owner's revenue.
 """
 
-import unittest
 from decimal import Decimal
 
 from django.test import TestCase
@@ -137,11 +136,9 @@ class DashboardStatisticsTests(TestCase):
         self.assertEqual(data["zevs"]["total"], 2)
         self.assertEqual(data["invoices"]["draft"], 2)
 
-    @unittest.expectedFailure
     def test_cancelled_invoices_are_counted(self):
-        """Pins the bug this extraction inherited: the aggregate runs over a
-        queryset that has already excluded cancelled invoices, so the cancelled
-        count it reports is unconditionally 0. Fixed in the next commit."""
+        """The aggregate used to run over a queryset that had already excluded
+        cancelled invoices, so this count was unconditionally 0."""
         make_invoice(self.zev, self.participant, InvoiceStatus.CANCELLED)
         make_invoice(self.zev, self.participant, InvoiceStatus.CANCELLED)
         make_invoice(self.zev, self.participant, InvoiceStatus.DRAFT)

--- a/backend/invoices/test_dashboard.py
+++ b/backend/invoices/test_dashboard.py
@@ -1,0 +1,152 @@
+"""Coverage for the admin dashboard statistics endpoint.
+
+The endpoint is old but had no tests at all — the one test whose name mentions
+it (``test_end_to_end_billing_generation_workflow_and_dashboard_consistency``)
+never actually calls it. That mattered, because admin-only access rested
+entirely on a hand-written ``if not request.user.is_admin`` and this endpoint
+reports across *every* tenant: a ZEV owner reaching it would see every other
+owner's revenue.
+"""
+
+import unittest
+from decimal import Decimal
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from accounts.models import UserRole
+from testing.helpers import authenticate as auth, make_user
+
+from .models import EmailLog, InvoiceStatus
+from .test_helpers import make_invoice, make_participant, make_zev
+
+URL = "/api/v1/invoices/invoices/dashboard/"
+
+
+class DashboardPermissionTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_admin_is_allowed(self):
+        auth(self.client, make_user("dash_admin", UserRole.ADMIN))
+
+        self.assertEqual(self.client.get(URL).status_code, 200)
+
+    def test_non_admins_are_refused(self):
+        """This endpoint aggregates across all tenants, so the permission check
+        is the only thing keeping one owner out of another owner's figures."""
+        for role in (UserRole.ZEV_OWNER, UserRole.PARTICIPANT):
+            with self.subTest(role=role):
+                auth(self.client, make_user(f"dash_{role}", role))
+                self.assertEqual(self.client.get(URL).status_code, 403)
+
+    def test_anonymous_is_refused(self):
+        self.client.credentials()
+
+        self.assertEqual(self.client.get(URL).status_code, 401)
+
+
+class DashboardStatisticsTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.owner = make_user("dash_stats_owner", UserRole.ZEV_OWNER)
+        self.zev = make_zev(self.owner, "Dash ZEV")
+        self.participant = make_participant(self.zev, first="Dana")
+        auth(self.client, make_user("dash_stats_admin", UserRole.ADMIN))
+
+    def _get(self):
+        resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        return resp.data
+
+    def test_empty_database_reports_zeroes_not_nulls(self):
+        data = self._get()
+
+        self.assertEqual(data["invoices"]["draft"], 0)
+        self.assertEqual(data["invoices"]["total_revenue"], 0)
+        self.assertEqual(data["emails"]["total"], 0)
+        self.assertEqual(data["recent_invoices"], [])
+
+    def test_counts_are_reported_per_status(self):
+        for st in (InvoiceStatus.DRAFT, InvoiceStatus.DRAFT, InvoiceStatus.APPROVED,
+                   InvoiceStatus.SENT, InvoiceStatus.PAID):
+            make_invoice(self.zev, self.participant, st)
+
+        data = self._get()
+
+        self.assertEqual(data["invoices"]["draft"], 2)
+        self.assertEqual(data["invoices"]["approved"], 1)
+        self.assertEqual(data["invoices"]["sent"], 1)
+        self.assertEqual(data["invoices"]["paid"], 1)
+
+    def test_revenue_counts_sent_and_paid_only(self):
+        make_invoice(self.zev, self.participant, InvoiceStatus.SENT)
+        make_invoice(self.zev, self.participant, InvoiceStatus.PAID)
+        make_invoice(self.zev, self.participant, InvoiceStatus.DRAFT)
+        make_invoice(self.zev, self.participant, InvoiceStatus.CANCELLED)
+        per_invoice = float(make_invoice(self.zev, self.participant, InvoiceStatus.DRAFT).total_chf)
+
+        data = self._get()
+
+        self.assertEqual(data["invoices"]["total_revenue"], per_invoice * 2)
+
+    def test_zev_and_participant_totals(self):
+        make_participant(self.zev, first="Second")
+
+        data = self._get()
+
+        self.assertEqual(data["zevs"]["total"], 1)
+        self.assertEqual(data["participants"]["total"], 2)
+
+    def test_email_statistics_are_grouped_by_status(self):
+        invoice = make_invoice(self.zev, self.participant)
+        for st in (EmailLog.Status.SENT, EmailLog.Status.SENT,
+                   EmailLog.Status.FAILED, EmailLog.Status.PENDING):
+            EmailLog.objects.create(invoice=invoice, recipient="x@example.com", status=st)
+
+        data = self._get()
+
+        self.assertEqual(data["emails"], {"total": 4, "sent": 2, "failed": 1, "pending": 1})
+
+    def test_recent_invoices_are_capped_at_ten_newest_first(self):
+        created = [make_invoice(self.zev, self.participant) for _ in range(12)]
+
+        data = self._get()
+
+        self.assertEqual(len(data["recent_invoices"]), 10)
+        self.assertEqual(data["recent_invoices"][0]["invoice_number"], created[-1].invoice_number)
+
+    def test_recent_invoice_rows_carry_denormalised_names(self):
+        invoice = make_invoice(self.zev, self.participant, InvoiceStatus.PAID)
+
+        row = self._get()["recent_invoices"][0]
+
+        self.assertEqual(row["invoice_number"], invoice.invoice_number)
+        self.assertEqual(row["participant_name"], self.participant.full_name)
+        self.assertEqual(row["zev_name"], self.zev.name)
+        self.assertEqual(row["status"], InvoiceStatus.PAID)
+        self.assertEqual(Decimal(str(row["total_chf"])), invoice.total_chf)
+
+    def test_statistics_span_every_tenant(self):
+        other_zev = make_zev(make_user("dash_other_owner", UserRole.ZEV_OWNER), "Other ZEV")
+        make_invoice(other_zev, make_participant(other_zev, first="Otto"), InvoiceStatus.DRAFT)
+        make_invoice(self.zev, self.participant, InvoiceStatus.DRAFT)
+
+        data = self._get()
+
+        self.assertEqual(data["zevs"]["total"], 2)
+        self.assertEqual(data["invoices"]["draft"], 2)
+
+    @unittest.expectedFailure
+    def test_cancelled_invoices_are_counted(self):
+        """Pins the bug this extraction inherited: the aggregate runs over a
+        queryset that has already excluded cancelled invoices, so the cancelled
+        count it reports is unconditionally 0. Fixed in the next commit."""
+        make_invoice(self.zev, self.participant, InvoiceStatus.CANCELLED)
+        make_invoice(self.zev, self.participant, InvoiceStatus.CANCELLED)
+        make_invoice(self.zev, self.participant, InvoiceStatus.DRAFT)
+
+        data = self._get()
+
+        self.assertEqual(data["invoices"]["cancelled"], 2)
+        self.assertEqual(data["invoices"]["draft"], 1)

--- a/backend/invoices/urls.py
+++ b/backend/invoices/urls.py
@@ -6,6 +6,7 @@ from .annual_statement import ANNUAL_STATEMENT_TEMPLATE
 from .contract_pdf import CONTRACT_TEMPLATE_NAME
 from .pdf import TEMPLATE_NAME
 from .views import InvoiceViewSet
+from .views_dashboard import InvoiceDashboardView
 from .views_templates import (
     EmailTemplateListView,
     EmailTemplateView,
@@ -16,11 +17,12 @@ from .views_templates import (
 router = DefaultRouter()
 router.register("invoices", InvoiceViewSet, basename="invoice")
 
-# The template-administration endpoints used to be @action methods on
-# InvoiceViewSet. They are listed explicitly here — ahead of router.urls, so
-# they win over the viewset's `invoices/<pk>/` detail route — which keeps their
-# URLs byte-identical to what the router generated for them.
-template_urlpatterns = [
+# These endpoints used to be @action methods on InvoiceViewSet. They are listed
+# explicitly here — ahead of router.urls, so they win over the viewset's
+# `invoices/<pk>/` detail route — which keeps their URLs byte-identical to what
+# the router generated for them.
+extracted_urlpatterns = [
+    path("invoices/dashboard/", InvoiceDashboardView.as_view(), name="invoice-dashboard"),
     path(
         "invoices/pdf-template/",
         PdfTemplateView.as_view(template_name=TEMPLATE_NAME, audit_action_prefix="template.invoice_pdf"),
@@ -49,4 +51,4 @@ template_urlpatterns = [
 
 # format_suffix_patterns restores the `.json`/`.api` variants the router used to
 # generate for these endpoints, so the extraction removes no URL at all.
-urlpatterns = format_suffix_patterns(template_urlpatterns) + router.urls
+urlpatterns = format_suffix_patterns(extracted_urlpatterns) + router.urls

--- a/backend/invoices/views.py
+++ b/backend/invoices/views.py
@@ -8,7 +8,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from django.http import HttpResponse
 from accounts.permissions import IsZevOwnerOrAdmin
-from django.db.models import Count, Q, Sum
 from zev.models import Zev, Participant
 from zev.scoping import ZevScopedQuerySetMixin
 from .models import Invoice, InvoiceStatus, EmailLog
@@ -719,74 +718,3 @@ class InvoiceViewSet(
         filename = f"financial-summary-{year}-{participant.last_name}.pdf"
         response["Content-Disposition"] = f'attachment; filename="{filename}"'
         return response
-
-    @action(detail=False, methods=["get"], permission_classes=[IsAuthenticated])
-    def dashboard(self, request):
-        """Get dashboard statistics (admin only)."""
-        if not request.user.is_admin:
-            return Response({"error": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
-
-        # ZEV statistics
-        total_zevs = Zev.objects.count()
-        total_participants = Participant.objects.count()
-        
-        # Invoice statistics
-        invoice_stats = Invoice.objects.filter(~Q(status=InvoiceStatus.CANCELLED)).aggregate(
-            draft_count=Count('id', filter=Q(status=InvoiceStatus.DRAFT)),
-            approved_count=Count('id', filter=Q(status=InvoiceStatus.APPROVED)),
-            sent_count=Count('id', filter=Q(status=InvoiceStatus.SENT)),
-            paid_count=Count('id', filter=Q(status=InvoiceStatus.PAID)),
-            cancelled_count=Count('id', filter=Q(status=InvoiceStatus.CANCELLED)),
-            total_revenue=Sum('total_chf', filter=Q(status__in=[InvoiceStatus.SENT, InvoiceStatus.PAID])),
-        )
-        
-        # Ensure total_revenue is a Decimal, not None
-        total_revenue = invoice_stats['total_revenue'] or 0
-        
-        # Recent invoices
-        recent_invoices = Invoice.objects.select_related("participant", "zev").order_by("-created_at")[:10]
-        recent_data = [
-            {
-                "invoice_number": inv.invoice_number,
-                "participant_name": inv.participant.full_name,
-                "zev_name": inv.zev.name,
-                "total_chf": float(inv.total_chf),
-                "status": inv.status,
-                "created_at": inv.created_at.isoformat(),
-            }
-            for inv in recent_invoices
-        ]
-        
-        # Email statistics
-        email_stats = EmailLog.objects.aggregate(
-            total_emails=Count('id'),
-            sent_emails=Count('id', filter=Q(status=EmailLog.Status.SENT)),
-            failed_emails=Count('id', filter=Q(status=EmailLog.Status.FAILED)),
-            pending_emails=Count('id', filter=Q(status=EmailLog.Status.PENDING)),
-        )
-        
-        return Response({
-            "zevs": {
-                "total": total_zevs,
-            },
-            "participants": {
-                "total": total_participants,
-            },
-            "invoices": {
-                "draft": invoice_stats['draft_count'] or 0,
-                "approved": invoice_stats['approved_count'] or 0,
-                "sent": invoice_stats['sent_count'] or 0,
-                "paid": invoice_stats['paid_count'] or 0,
-                "cancelled": invoice_stats['cancelled_count'] or 0,
-                "total_revenue": float(total_revenue),
-            },
-            "emails": {
-                "total": email_stats['total_emails'],
-                "sent": email_stats['sent_emails'],
-                "failed": email_stats['failed_emails'],
-                "pending": email_stats['pending_emails'],
-            },
-            "recent_invoices": recent_data,
-        })
-
-

--- a/backend/invoices/views_dashboard.py
+++ b/backend/invoices/views_dashboard.py
@@ -31,7 +31,10 @@ class InvoiceDashboardView(APIView):
     permission_classes = [IsAdmin]
 
     def get(self, request, *args, **kwargs):
-        invoice_stats = Invoice.objects.filter(~Q(status=InvoiceStatus.CANCELLED)).aggregate(
+        # Aggregate over every invoice: each count carries its own status
+        # filter, so pre-filtering the queryset only ever suppressed the
+        # cancelled count (the other statuses are disjoint from CANCELLED).
+        invoice_stats = Invoice.objects.aggregate(
             draft_count=Count("id", filter=Q(status=InvoiceStatus.DRAFT)),
             approved_count=Count("id", filter=Q(status=InvoiceStatus.APPROVED)),
             sent_count=Count("id", filter=Q(status=InvoiceStatus.SENT)),

--- a/backend/invoices/views_dashboard.py
+++ b/backend/invoices/views_dashboard.py
@@ -1,0 +1,87 @@
+"""Admin-only, cross-tenant statistics for the dashboard landing page.
+
+Like the template endpoints in ``views_templates``, this used to be an
+``@action`` on ``InvoiceViewSet`` despite not being invoice-domain code: it
+aggregates over Zev, Participant, Invoice and EmailLog, and it deliberately
+queries ``Invoice.objects`` unscoped rather than the viewset's tenant-scoped
+``get_queryset()``. Sitting on the viewset made that unscoped access look like
+an oversight; on its own admin-only view it reads as the intent it is.
+"""
+
+from django.db.models import Count, Q, Sum
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from accounts.permissions import IsAdmin
+from zev.models import Participant, Zev
+
+from .models import EmailLog, Invoice, InvoiceStatus
+
+RECENT_INVOICE_LIMIT = 10
+
+
+class InvoiceDashboardView(APIView):
+    """Aggregate counts across every tenant, for the admin dashboard.
+
+    Admin-only, and enforced declaratively — this view reports across all
+    tenants, so the permission class is the only thing standing between a ZEV
+    owner and every other owner's revenue figures.
+    """
+
+    permission_classes = [IsAdmin]
+
+    def get(self, request, *args, **kwargs):
+        invoice_stats = Invoice.objects.filter(~Q(status=InvoiceStatus.CANCELLED)).aggregate(
+            draft_count=Count("id", filter=Q(status=InvoiceStatus.DRAFT)),
+            approved_count=Count("id", filter=Q(status=InvoiceStatus.APPROVED)),
+            sent_count=Count("id", filter=Q(status=InvoiceStatus.SENT)),
+            paid_count=Count("id", filter=Q(status=InvoiceStatus.PAID)),
+            cancelled_count=Count("id", filter=Q(status=InvoiceStatus.CANCELLED)),
+            total_revenue=Sum("total_chf", filter=Q(status__in=[InvoiceStatus.SENT, InvoiceStatus.PAID])),
+        )
+
+        email_stats = EmailLog.objects.aggregate(
+            total_emails=Count("id"),
+            sent_emails=Count("id", filter=Q(status=EmailLog.Status.SENT)),
+            failed_emails=Count("id", filter=Q(status=EmailLog.Status.FAILED)),
+            pending_emails=Count("id", filter=Q(status=EmailLog.Status.PENDING)),
+        )
+
+        recent_invoices = (
+            Invoice.objects.select_related("participant", "zev")
+            .order_by("-created_at")[:RECENT_INVOICE_LIMIT]
+        )
+
+        return Response({
+            "zevs": {
+                "total": Zev.objects.count(),
+            },
+            "participants": {
+                "total": Participant.objects.count(),
+            },
+            "invoices": {
+                "draft": invoice_stats["draft_count"] or 0,
+                "approved": invoice_stats["approved_count"] or 0,
+                "sent": invoice_stats["sent_count"] or 0,
+                "paid": invoice_stats["paid_count"] or 0,
+                "cancelled": invoice_stats["cancelled_count"] or 0,
+                "total_revenue": float(invoice_stats["total_revenue"] or 0),
+            },
+            "emails": {
+                "total": email_stats["total_emails"],
+                "sent": email_stats["sent_emails"],
+                "failed": email_stats["failed_emails"],
+                "pending": email_stats["pending_emails"],
+            },
+            "recent_invoices": [
+                {
+                    "invoice_number": inv.invoice_number,
+                    "participant_name": inv.participant.full_name,
+                    "zev_name": inv.zev.name,
+                    "total_chf": float(inv.total_chf),
+                    "status": inv.status,
+                    "created_at": inv.created_at.isoformat(),
+                }
+                for inv in recent_invoices
+            ],
+        })


### PR DESCRIPTION
Second of three slices splitting the `InvoiceViewSet` god object (after #337). Two commits, deliberately separable: a faithful extraction, then a bug fix it exposed.

## Commit 1 — the extraction

`dashboard` was an `@action` but isn't invoice-domain code: it aggregates over Zev, Participant, Invoice and EmailLog, and it queries `Invoice.objects` **unscoped** rather than the viewset's tenant-scoped `get_queryset()`. Sitting on the viewset made that unscoped access look like an oversight; on its own admin-only view it reads as the intent it is.

Admin-ness moves from a hand-written `if not request.user.is_admin` to `permission_classes = [IsAdmin]`. That matters more here than anywhere else in this split — **this endpoint reports across every tenant**, so that one check is all that keeps one ZEV owner out of every other owner's revenue figures.

URL listed explicitly ahead of `router.urls` and wrapped in `format_suffix_patterns`, so it's unchanged.

**Verification:** probed the endpoint across 4 roles × both URL forms on this branch and on `main`. The admin payload is byte-identical field for field. The two differences are the same pair as #337:

- `dashboard.json` used to raise `TypeError` → **500** (the action signature rejected the `format` kwarg); now serves normally.
- A 403 body is DRF's `{"detail": ...}` rather than `{"error": ...}`. Frontend reads these via `formatApiError`, which prefers `.detail`.

### The endpoint had no tests at all

The one test whose name mentions it — `test_end_to_end_billing_generation_workflow_and_dashboard_consistency` — never calls it. New `test_dashboard.py` covers the permission boundary (owner and participant → 403, anonymous → 401), per-status counts, revenue counting sent+paid only, email grouping, the 10-row recent cap and ordering, denormalised row fields, and that statistics span every tenant.

## Commit 2 — `cancelled` was always 0

Writing those tests turned up a real bug. The aggregate ran over `Invoice.objects.filter(~Q(status=CANCELLED))` while one of the aggregates inside it was `cancelled_count=Count("id", filter=Q(status=CANCELLED))` — counting cancelled invoices in a set they'd already been removed from. It reported **0 unconditionally**.

This is user-visible: `AdminDashboardPage.tsx:122` renders `stats.invoices.cancelled` in the status breakdown, so admins have always seen a hard-coded-looking zero.

The outer filter only ever affected that one number — the other statuses are disjoint from `CANCELLED`, and `total_revenue` counts sent+paid — so dropping it is surgical. **Verified by re-running the payload probe: `cancelled` 0→1 is the only field that moves; approved, draft, paid, sent, total_revenue, emails, participants, zevs and the recent-invoice list are all byte-identical.**

The test for it is committed as an `expectedFailure` in commit 1 and flipped in commit 2, so the bug is visible in the diff and the move stays separable from the behaviour change.

`ruff check .` clean; suite 459 → 471 passed, no existing test modified.

## Next slice

3. annual statement / statements zip / financial summary (~163 lines), which share a duplicated participant-resolution preamble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)