### PR TITLE
refactor(accounts): extract impersonation into its own module

### DIFF
--- a/backend/accounts/cookies.py
+++ b/backend/accounts/cookies.py
@@ -1,0 +1,56 @@
+"""Auth cookie names and helpers shared across the accounts views.
+
+The project delivers JWTs in httpOnly cookies (``CookieJWTAuthentication`` also
+accepts an ``Authorization: Bearer`` header as a fallback). Login, refresh,
+logout, registration, email verification, OAuth and impersonation all set or
+clear these cookies, so the names and the set/clear helpers live here rather
+than being module-private to any one of them.
+
+``ADMIN_*`` are the backup pair: while an admin is impersonating another user,
+their own tokens are parked under these names so ``stop-impersonation`` can put
+them back.
+"""
+
+from datetime import timedelta
+
+from django.conf import settings
+
+ACCESS_COOKIE = "openzev_access"
+REFRESH_COOKIE = "openzev_refresh"
+ADMIN_ACCESS_COOKIE = "openzev_admin_access"
+ADMIN_REFRESH_COOKIE = "openzev_admin_refresh"
+
+
+def cookie_kwargs() -> dict:
+    """Shared kwargs for all auth cookies: httpOnly, Secure in prod, SameSite=Lax."""
+    return {
+        "httponly": True,
+        "samesite": "Lax",
+        "secure": not settings.DEBUG,
+        "path": "/",
+    }
+
+
+def set_auth_cookies(
+    response,
+    *,
+    access: str,
+    refresh: str,
+    access_cookie: str = ACCESS_COOKIE,
+    refresh_cookie: str = REFRESH_COOKIE,
+) -> None:
+    jwt_settings = settings.SIMPLE_JWT
+    access_max_age = int(jwt_settings.get("ACCESS_TOKEN_LIFETIME", timedelta(minutes=60)).total_seconds())
+    refresh_max_age = int(jwt_settings.get("REFRESH_TOKEN_LIFETIME", timedelta(days=7)).total_seconds())
+    kw = cookie_kwargs()
+    response.set_cookie(access_cookie, access, max_age=access_max_age, **kw)
+    response.set_cookie(refresh_cookie, refresh, max_age=refresh_max_age, **kw)
+
+
+def clear_auth_cookies(
+    response,
+    access_cookie: str = ACCESS_COOKIE,
+    refresh_cookie: str = REFRESH_COOKIE,
+) -> None:
+    response.delete_cookie(access_cookie, path="/")
+    response.delete_cookie(refresh_cookie, path="/")

--- a/backend/accounts/test_impersonation.py
+++ b/backend/accounts/test_impersonation.py
@@ -234,3 +234,48 @@ class StopImpersonationTests(TestCase):
         self.client.credentials()
 
         self.assertEqual(self.client.post(STOP).status_code, 401)
+
+    def test_a_no_op_stop_is_not_audited(self):
+        """Nothing changed, so there is nothing to record — keeps the AUTH
+        trail free of noise from double-clicks and stale tabs."""
+        auth(self.client, make_user("stop_noop", UserRole.ADMIN))
+
+        self.client.post(STOP)
+
+        self.assertFalse(AuditEvent.objects.filter(action_type="impersonation.end").exists())
+
+
+class StopImpersonationAuditTests(TestCase):
+    """Starting an impersonation was audited three ways; ending one was not
+    recorded at all, so the trail showed a session opening and never closing."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = make_user("end_admin", UserRole.ADMIN)
+        self.target = make_user("end_target", UserRole.PARTICIPANT)
+
+    def test_ending_a_session_is_recorded_against_the_impersonated_user(self):
+        self.client.post(TOKEN, {"username": self.admin.username, "password": "pass1234"})
+        self.client.post(impersonate_url(self.target.pk))
+        AuditEvent.objects.all().delete()
+
+        resp = self.client.post(STOP)
+
+        self.assertEqual(resp.status_code, 200)
+        event = AuditEvent.objects.get()
+        self.assertEqual(event.action_category, AuditActionCategory.AUTH)
+        self.assertEqual(event.action_type, "impersonation.end")
+        self.assertEqual(event.status, AuditEventStatus.SUCCESS)
+        self.assertEqual(event.target_id, str(self.target.pk))
+        self.assertEqual(event.summary, f"Ended impersonation of {self.target.email}.")
+
+    def test_the_admin_behind_the_session_is_recoverable(self):
+        """request.user is the impersonated user by this point, so the only
+        record of who was driving is the claim stamped on the token."""
+        self.client.post(TOKEN, {"username": self.admin.username, "password": "pass1234"})
+        self.client.post(impersonate_url(self.target.pk))
+        AuditEvent.objects.all().delete()
+
+        self.client.post(STOP)
+
+        self.assertEqual(AuditEvent.objects.get().metadata_json["impersonated_by"], self.admin.pk)

--- a/backend/accounts/test_impersonation.py
+++ b/backend/accounts/test_impersonation.py
@@ -1,0 +1,236 @@
+"""Coverage for admin impersonation.
+
+``accounts/tests.py`` already had four tests here, all driving the endpoint with
+an ``Authorization: Bearer`` header — despite the helper being named
+``_cookie_auth``. That mattered: the whole point of the feature is that the
+admin's own tokens are parked in backup cookies and restored afterwards, and
+``request.COOKIES`` is empty under Bearer auth, so **the backup-and-restore path
+was never executed by any test**. ``stop-impersonation`` had no tests at all.
+
+These tests drive the real cookie flow through ``/auth/token/``, and pin the
+audit events, which are the part most at risk from moving the admin check from
+a hand-written ``if`` to a permission class.
+"""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import AccessToken
+
+from audit.models import AuditActionCategory, AuditEvent, AuditEventStatus
+from testing.helpers import authenticate as auth, make_user
+
+from .cookies import ACCESS_COOKIE, ADMIN_ACCESS_COOKIE, ADMIN_REFRESH_COOKIE, REFRESH_COOKIE
+from .models import UserRole
+
+TOKEN = "/api/v1/auth/token/"
+STOP = "/api/v1/auth/users/stop-impersonation/"
+
+
+def impersonate_url(user_id) -> str:
+    return f"/api/v1/auth/users/{user_id}/impersonate/"
+
+
+class ImpersonationPermissionTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = make_user("imp_admin", UserRole.ADMIN)
+        self.target = make_user("imp_target", UserRole.PARTICIPANT)
+
+    def test_admin_may_impersonate_a_participant(self):
+        auth(self.client, self.admin)
+
+        resp = self.client.post(impersonate_url(self.target.pk))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["impersonated_user"]["id"], self.target.pk)
+        self.assertEqual(resp.data["impersonator"]["id"], self.admin.pk)
+
+    def test_admin_may_impersonate_a_zev_owner(self):
+        auth(self.client, self.admin)
+        owner = make_user("imp_owner_target", UserRole.ZEV_OWNER)
+
+        self.assertEqual(self.client.post(impersonate_url(owner.pk)).status_code, 200)
+
+    def test_admins_and_guests_may_not_be_impersonated(self):
+        """The role guard is what stops an admin minting a token for another
+        admin, which would transfer privilege with no record of the human."""
+        auth(self.client, self.admin)
+        for role in (UserRole.ADMIN, UserRole.GUEST):
+            with self.subTest(role=role):
+                victim = make_user(f"imp_victim_{role}", role)
+                resp = self.client.post(impersonate_url(victim.pk))
+                self.assertEqual(resp.status_code, 400)
+
+    def test_non_admins_are_refused(self):
+        for role in (UserRole.ZEV_OWNER, UserRole.PARTICIPANT, UserRole.GUEST):
+            with self.subTest(role=role):
+                auth(self.client, make_user(f"imp_actor_{role}", role))
+                resp = self.client.post(impersonate_url(self.target.pk))
+                self.assertEqual(resp.status_code, 403)
+
+    def test_anonymous_is_refused(self):
+        self.client.credentials()
+
+        self.assertEqual(self.client.post(impersonate_url(self.target.pk)).status_code, 401)
+
+    def test_unknown_target_is_404(self):
+        auth(self.client, self.admin)
+
+        self.assertEqual(self.client.post(impersonate_url(999999)).status_code, 404)
+
+
+class ImpersonationAuditTests(TestCase):
+    """The audit trail is the reason this endpoint is safe to have at all."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = make_user("aud_admin", UserRole.ADMIN)
+        self.target = make_user("aud_target", UserRole.PARTICIPANT)
+
+    def _event(self):
+        event = AuditEvent.objects.get()
+        self.assertEqual(event.action_category, AuditActionCategory.AUTH)
+        self.assertEqual(event.action_type, "impersonation.issue_token")
+        return event
+
+    def test_success_records_who_impersonated_whom(self):
+        auth(self.client, self.admin)
+
+        self.client.post(impersonate_url(self.target.pk))
+
+        event = self._event()
+        self.assertEqual(event.status, AuditEventStatus.SUCCESS)
+        self.assertEqual(event.target_id, str(self.target.pk))
+        self.assertEqual(event.target_display, self.target.email)
+        self.assertEqual(event.summary, f"Issued impersonation token for {self.target.email}.")
+        self.assertEqual(event.metadata_json["impersonated_by"], self.admin.pk)
+
+    def test_non_admin_denial_is_recorded(self):
+        """Pins the event that used to be written by a hand-rolled admin check
+        and is now emitted from permission_denied()."""
+        auth(self.client, make_user("aud_owner", UserRole.ZEV_OWNER))
+
+        self.client.post(impersonate_url(self.target.pk))
+
+        event = self._event()
+        self.assertEqual(event.status, AuditEventStatus.DENIED)
+        self.assertEqual(event.summary, "Denied impersonation token issuance by non-admin.")
+        self.assertEqual(event.target_id, str(self.target.pk))
+
+    def test_role_guard_denial_is_recorded(self):
+        auth(self.client, self.admin)
+        other_admin = make_user("aud_other_admin", UserRole.ADMIN)
+
+        self.client.post(impersonate_url(other_admin.pk))
+
+        event = self._event()
+        self.assertEqual(event.status, AuditEventStatus.DENIED)
+        self.assertIn("due to role guard", event.summary)
+        self.assertEqual(event.metadata_json["role"], UserRole.ADMIN)
+
+    def test_unknown_target_is_recorded_as_failed(self):
+        auth(self.client, self.admin)
+
+        self.client.post(impersonate_url(999999))
+
+        event = self._event()
+        self.assertEqual(event.status, AuditEventStatus.FAILED)
+        self.assertEqual(event.summary, "Impersonation target user 999999 not found.")
+
+    def test_anonymous_attempt_is_not_audited(self):
+        """A 401 is not a governance event; only an authenticated non-admin is."""
+        self.client.credentials()
+
+        self.client.post(impersonate_url(self.target.pk))
+
+        self.assertFalse(AuditEvent.objects.exists())
+
+
+class ImpersonationCookieRoundTripTests(TestCase):
+    """The backup-and-restore cookie dance, driven the way a browser drives it.
+
+    Every pre-existing test authenticated with a Bearer header, which leaves
+    ``request.COOKIES`` empty and silently skips the backup branch entirely.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = make_user("ck_admin", UserRole.ADMIN)
+        self.target = make_user("ck_target", UserRole.PARTICIPANT)
+
+    def _login_as_admin(self):
+        resp = self.client.post(TOKEN, {"username": self.admin.username, "password": "pass1234"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(ACCESS_COOKIE, resp.cookies)
+        return resp.cookies[ACCESS_COOKIE].value, resp.cookies[REFRESH_COOKIE].value
+
+    def test_impersonating_parks_the_admin_tokens_and_swaps_in_the_targets(self):
+        admin_access, admin_refresh = self._login_as_admin()
+
+        resp = self.client.post(impersonate_url(self.target.pk))
+
+        self.assertEqual(resp.status_code, 200)
+        # The admin's own pair is preserved untouched under the backup names...
+        self.assertEqual(resp.cookies[ADMIN_ACCESS_COOKIE].value, admin_access)
+        self.assertEqual(resp.cookies[ADMIN_REFRESH_COOKIE].value, admin_refresh)
+        # ...and the main pair now belongs to the impersonated user.
+        self.assertNotEqual(resp.cookies[ACCESS_COOKIE].value, admin_access)
+        claims = AccessToken(resp.cookies[ACCESS_COOKIE].value)
+        self.assertEqual(claims["user_id"], str(self.target.pk))
+        self.assertEqual(claims["impersonated_by"], self.admin.pk)
+
+    def test_auth_cookies_are_httponly(self):
+        self._login_as_admin()
+
+        resp = self.client.post(impersonate_url(self.target.pk))
+
+        for name in (ACCESS_COOKIE, REFRESH_COOKIE, ADMIN_ACCESS_COOKIE, ADMIN_REFRESH_COOKIE):
+            with self.subTest(cookie=name):
+                self.assertTrue(resp.cookies[name]["httponly"])
+
+    def test_stopping_restores_the_admin_tokens_and_clears_the_backup(self):
+        admin_access, admin_refresh = self._login_as_admin()
+        self.client.post(impersonate_url(self.target.pk))
+
+        resp = self.client.post(STOP)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.cookies[ACCESS_COOKIE].value, admin_access)
+        self.assertEqual(resp.cookies[REFRESH_COOKIE].value, admin_refresh)
+        # The backup pair is expired rather than left lying around.
+        self.assertEqual(resp.cookies[ADMIN_ACCESS_COOKIE].value, "")
+        self.assertEqual(resp.cookies[ADMIN_REFRESH_COOKIE].value, "")
+
+    def test_the_restored_session_is_the_admin_again(self):
+        self._login_as_admin()
+        self.client.post(impersonate_url(self.target.pk))
+        self.client.post(STOP)
+
+        me = self.client.get("/api/v1/auth/me/")
+
+        self.assertEqual(me.status_code, 200)
+        self.assertEqual(me.data["id"], self.admin.pk)
+
+
+class StopImpersonationTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_without_a_backup_pair_it_is_400(self):
+        auth(self.client, make_user("stop_admin", UserRole.ADMIN))
+
+        resp = self.client.post(STOP)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.data["detail"], "No active impersonation session.")
+
+    def test_half_a_backup_pair_is_not_enough(self):
+        auth(self.client, make_user("stop_half", UserRole.ADMIN))
+        self.client.cookies[ADMIN_ACCESS_COOKIE] = "access-only"
+
+        self.assertEqual(self.client.post(STOP).status_code, 400)
+
+    def test_anonymous_is_refused(self):
+        self.client.credentials()
+
+        self.assertEqual(self.client.post(STOP).status_code, 401)

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from .views import (
     CustomTokenObtainPairView, CookieTokenRefreshView, logout_view,
     UserListCreateView,
-    UserDetailView, me, change_password, impersonate_participant, stop_impersonation, app_settings,
+    UserDetailView, me, change_password, app_settings,
     VatRateListCreateView, VatRateDetailView,
     feature_flags_list, feature_flag_update,
     register, verify_email, set_initial_password,
@@ -13,6 +13,7 @@ from .views import (
     oauth_callback, oauth_token_exchange,
     social_accounts_list, social_account_delete,
 )
+from .views_impersonation import ImpersonateParticipantView, StopImpersonationView
 
 urlpatterns = [
     path("token/", CustomTokenObtainPairView.as_view(), name="token_obtain_pair"),
@@ -22,8 +23,8 @@ urlpatterns = [
     path("verify-email/", verify_email, name="verify-email"),
     path("users/", UserListCreateView.as_view(), name="user-list-create"),
     path("users/<int:pk>/", UserDetailView.as_view(), name="user-detail"),
-    path("users/<int:user_id>/impersonate/", impersonate_participant, name="impersonate-participant"),
-    path("users/stop-impersonation/", stop_impersonation, name="stop-impersonation"),
+    path("users/<int:user_id>/impersonate/", ImpersonateParticipantView.as_view(), name="impersonate-participant"),
+    path("users/stop-impersonation/", StopImpersonationView.as_view(), name="stop-impersonation"),
     path("me/", me, name="me"),
     path("me/change-password/", change_password, name="change-password"),
     path("me/set-initial-password/", set_initial_password, name="set-initial-password"),

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -34,7 +34,6 @@ from .serializers import (
 )
 from .models import AppSettings, FeatureFlag, VatRate
 from .cookies import (
-    ACCESS_COOKIE,
     ADMIN_ACCESS_COOKIE,
     ADMIN_REFRESH_COOKIE,
     REFRESH_COOKIE,
@@ -397,110 +396,6 @@ def feature_flag_update(request, pk: int):
         changes=build_diff(before, {"enabled": updated.enabled}, ["enabled"]),
     )
     return Response(serializer.data)
-
-
-@api_view(["POST"])
-@permission_classes([IsAuthenticated])
-def impersonate_participant(request, user_id: int):
-    if not request.user.is_admin:
-        record_audit_event(
-            request=request,
-            action_category=AuditActionCategory.AUTH,
-            action_type="impersonation.issue_token",
-            target_type="accounts.User",
-            target_id=str(user_id),
-            target_display=str(user_id),
-            summary="Denied impersonation token issuance by non-admin.",
-            status=AuditEventStatus.DENIED,
-        )
-        raise PermissionDenied("Only admins can impersonate participants.")
-
-    try:
-        target_user = User.objects.get(pk=user_id)
-    except User.DoesNotExist:
-        record_audit_event(
-            request=request,
-            action_category=AuditActionCategory.AUTH,
-            action_type="impersonation.issue_token",
-            target_type="accounts.User",
-            target_id=str(user_id),
-            target_display=str(user_id),
-            summary=f"Impersonation target user {user_id} not found.",
-            status=AuditEventStatus.FAILED,
-        )
-        return Response({"detail": "User not found."}, status=status.HTTP_404_NOT_FOUND)
-
-    if target_user.role not in (UserRole.PARTICIPANT, UserRole.ZEV_OWNER):
-        record_audit_event(
-            request=request,
-            action_category=AuditActionCategory.AUTH,
-            action_type="impersonation.issue_token",
-            target_type="accounts.User",
-            target=target_user,
-            target_id=str(target_user.pk),
-            target_display=target_user.email or target_user.username,
-            summary=f"Denied impersonation for {target_user.email or target_user.username} due to role guard.",
-            status=AuditEventStatus.DENIED,
-            metadata={"role": target_user.role},
-        )
-        return Response({"detail": "Only participant or ZEV owner users can be impersonated."}, status=status.HTTP_400_BAD_REQUEST)
-
-    refresh = RefreshToken.for_user(target_user)
-    refresh["role"] = target_user.role
-    refresh["email"] = target_user.email
-    refresh["full_name"] = target_user.get_full_name()
-    refresh["must_change_password"] = target_user.must_change_password
-    refresh["impersonated_by"] = request.user.id
-
-    record_audit_event(
-        request=request,
-        action_category=AuditActionCategory.AUTH,
-        action_type="impersonation.issue_token",
-        target_type="accounts.User",
-        target=target_user,
-        target_id=str(target_user.pk),
-        target_display=target_user.email or target_user.username,
-        summary=f"Issued impersonation token for {target_user.email or target_user.username}.",
-        metadata={"impersonated_by": request.user.id},
-    )
-
-    response = Response(
-        {
-            "impersonated_user": UserSerializer(target_user).data,
-            "impersonator": UserSerializer(request.user).data,
-        },
-        status=status.HTTP_200_OK,
-    )
-    # Preserve the current admin tokens in backup cookies so they can be
-    # restored when impersonation ends, then overwrite main cookies with the
-    # impersonation tokens.
-    current_access = request.COOKIES.get(ACCESS_COOKIE, "")
-    current_refresh = request.COOKIES.get(REFRESH_COOKIE, "")
-    if current_access and current_refresh:
-        set_auth_cookies(
-            response,
-            access=current_access,
-            refresh=current_refresh,
-            access_cookie=ADMIN_ACCESS_COOKIE,
-            refresh_cookie=ADMIN_REFRESH_COOKIE,
-        )
-    set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
-    return response
-
-
-@api_view(["POST"])
-@permission_classes([IsAuthenticated])
-def stop_impersonation(request):
-    """Restore the original admin tokens after ending an impersonation session."""
-    admin_access = request.COOKIES.get(ADMIN_ACCESS_COOKIE)
-    admin_refresh = request.COOKIES.get(ADMIN_REFRESH_COOKIE)
-    if not admin_access or not admin_refresh:
-        return Response({"detail": "No active impersonation session."}, status=status.HTTP_400_BAD_REQUEST)
-
-    response = Response({"detail": "Impersonation ended."})
-    set_auth_cookies(response, access=admin_access, refresh=admin_refresh)
-    clear_auth_cookies(response, access_cookie=ADMIN_ACCESS_COOKIE, refresh_cookie=ADMIN_REFRESH_COOKIE)
-    return response
 
 
 @api_view(["POST"])

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -33,56 +33,20 @@ from .serializers import (
     VatRateSerializer,
 )
 from .models import AppSettings, FeatureFlag, VatRate
+from .cookies import (
+    ACCESS_COOKIE,
+    ADMIN_ACCESS_COOKIE,
+    ADMIN_REFRESH_COOKIE,
+    REFRESH_COOKIE,
+    clear_auth_cookies,
+    set_auth_cookies,
+)
 from .permissions import IsAdmin
 from audit.models import AuditActionCategory, AuditEventStatus
 from audit.mixins import AuditedUpdateMixin
 from audit.services import build_diff, record_audit_event
 
 logger = logging.getLogger(__name__)
-
-# ── Auth cookie helpers ───────────────────────────────────────────────────────
-
-_ACCESS_COOKIE = "openzev_access"
-_REFRESH_COOKIE = "openzev_refresh"
-_ADMIN_ACCESS_COOKIE = "openzev_admin_access"
-_ADMIN_REFRESH_COOKIE = "openzev_admin_refresh"
-
-
-def _cookie_kwargs() -> dict:
-    """Shared kwargs for all auth cookies: httpOnly, Secure in prod, SameSite=Lax."""
-    return {
-        "httponly": True,
-        "samesite": "Lax",
-        "secure": not settings.DEBUG,
-        "path": "/",
-    }
-
-
-def _set_auth_cookies(
-    response,
-    *,
-    access: str,
-    refresh: str,
-    access_cookie: str = _ACCESS_COOKIE,
-    refresh_cookie: str = _REFRESH_COOKIE,
-) -> None:
-    from datetime import timedelta
-    jwt_settings = settings.SIMPLE_JWT
-    access_max_age = int(jwt_settings.get("ACCESS_TOKEN_LIFETIME", timedelta(minutes=60)).total_seconds())
-    refresh_max_age = int(jwt_settings.get("REFRESH_TOKEN_LIFETIME", timedelta(days=7)).total_seconds())
-    kw = _cookie_kwargs()
-    response.set_cookie(access_cookie, access, max_age=access_max_age, **kw)
-    response.set_cookie(refresh_cookie, refresh, max_age=refresh_max_age, **kw)
-
-
-def _clear_auth_cookies(
-    response,
-    access_cookie: str = _ACCESS_COOKIE,
-    refresh_cookie: str = _REFRESH_COOKIE,
-) -> None:
-    response.delete_cookie(access_cookie, path="/")
-    response.delete_cookie(refresh_cookie, path="/")
-
 
 class CustomTokenObtainPairView(TokenObtainPairView):
     """JWT login — sets httpOnly cookies and returns a minimal JSON body."""
@@ -91,7 +55,7 @@ class CustomTokenObtainPairView(TokenObtainPairView):
     def post(self, request, *args, **kwargs):
         response = super().post(request, *args, **kwargs)
         if response.status_code == 200:
-            _set_auth_cookies(response, access=response.data["access"], refresh=response.data["refresh"])
+            set_auth_cookies(response, access=response.data["access"], refresh=response.data["refresh"])
             response.data = {"detail": "Login successful."}
         return response
 
@@ -102,7 +66,7 @@ class CookieTokenRefreshView(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request, *args, **kwargs):
-        refresh_token = request.COOKIES.get(_REFRESH_COOKIE)
+        refresh_token = request.COOKIES.get(REFRESH_COOKIE)
         if not refresh_token:
             return Response({"detail": "Refresh token not found."}, status=status.HTTP_401_UNAUTHORIZED)
 
@@ -111,13 +75,13 @@ class CookieTokenRefreshView(APIView):
             serializer.is_valid(raise_exception=True)
         except (TokenError, ValidationError):
             response = Response({"detail": "Token is invalid or expired."}, status=status.HTTP_401_UNAUTHORIZED)
-            _clear_auth_cookies(response)
+            clear_auth_cookies(response)
             return response
 
         new_access = serializer.validated_data["access"]
         new_refresh = serializer.validated_data.get("refresh", refresh_token)
         response = Response({"detail": "Token refreshed."})
-        _set_auth_cookies(response, access=new_access, refresh=new_refresh)
+        set_auth_cookies(response, access=new_access, refresh=new_refresh)
         return response
 
 
@@ -127,9 +91,9 @@ class CookieTokenRefreshView(APIView):
 def logout_view(request):
     """Clear auth cookies and end the session, even if the access cookie is expired."""
     response = Response({"detail": "Logged out."})
-    _clear_auth_cookies(response)
+    clear_auth_cookies(response)
     # Also clear any active impersonation cookies
-    _clear_auth_cookies(response, access_cookie=_ADMIN_ACCESS_COOKIE, refresh_cookie=_ADMIN_REFRESH_COOKIE)
+    clear_auth_cookies(response, access_cookie=ADMIN_ACCESS_COOKIE, refresh_cookie=ADMIN_REFRESH_COOKIE)
     return response
 
 
@@ -510,17 +474,17 @@ def impersonate_participant(request, user_id: int):
     # Preserve the current admin tokens in backup cookies so they can be
     # restored when impersonation ends, then overwrite main cookies with the
     # impersonation tokens.
-    current_access = request.COOKIES.get(_ACCESS_COOKIE, "")
-    current_refresh = request.COOKIES.get(_REFRESH_COOKIE, "")
+    current_access = request.COOKIES.get(ACCESS_COOKIE, "")
+    current_refresh = request.COOKIES.get(REFRESH_COOKIE, "")
     if current_access and current_refresh:
-        _set_auth_cookies(
+        set_auth_cookies(
             response,
             access=current_access,
             refresh=current_refresh,
-            access_cookie=_ADMIN_ACCESS_COOKIE,
-            refresh_cookie=_ADMIN_REFRESH_COOKIE,
+            access_cookie=ADMIN_ACCESS_COOKIE,
+            refresh_cookie=ADMIN_REFRESH_COOKIE,
         )
-    _set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
+    set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
     return response
 
 
@@ -528,14 +492,14 @@ def impersonate_participant(request, user_id: int):
 @permission_classes([IsAuthenticated])
 def stop_impersonation(request):
     """Restore the original admin tokens after ending an impersonation session."""
-    admin_access = request.COOKIES.get(_ADMIN_ACCESS_COOKIE)
-    admin_refresh = request.COOKIES.get(_ADMIN_REFRESH_COOKIE)
+    admin_access = request.COOKIES.get(ADMIN_ACCESS_COOKIE)
+    admin_refresh = request.COOKIES.get(ADMIN_REFRESH_COOKIE)
     if not admin_access or not admin_refresh:
         return Response({"detail": "No active impersonation session."}, status=status.HTTP_400_BAD_REQUEST)
 
     response = Response({"detail": "Impersonation ended."})
-    _set_auth_cookies(response, access=admin_access, refresh=admin_refresh)
-    _clear_auth_cookies(response, access_cookie=_ADMIN_ACCESS_COOKIE, refresh_cookie=_ADMIN_REFRESH_COOKIE)
+    set_auth_cookies(response, access=admin_access, refresh=admin_refresh)
+    clear_auth_cookies(response, access_cookie=ADMIN_ACCESS_COOKIE, refresh_cookie=ADMIN_REFRESH_COOKIE)
     return response
 
 
@@ -652,7 +616,7 @@ def verify_email(request):
 
     refresh = RefreshToken.for_user(user)
     response = Response({"detail": "Email verified."})
-    _set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
+    set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
     return response
 
 
@@ -706,7 +670,7 @@ def set_initial_password(request):
     # Issue fresh tokens so the updated claims (must_change_password=False) take effect
     refresh = RefreshToken.for_user(user)
     response = Response({"detail": "Password set successfully."})
-    _set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
+    set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
     return response
 
 
@@ -976,7 +940,7 @@ def oauth_token_exchange(request):
 
     tokens = _make_jwt_for_user(user)
     response = Response({"detail": "Login successful."})
-    _set_auth_cookies(response, access=tokens["access"], refresh=tokens["refresh"])
+    set_auth_cookies(response, access=tokens["access"], refresh=tokens["refresh"])
     return response
 
 

--- a/backend/accounts/views_impersonation.py
+++ b/backend/accounts/views_impersonation.py
@@ -1,0 +1,172 @@
+"""Admin impersonation: issue a token as another user, and hand it back.
+
+Split out of ``accounts.views`` because this is the most security-sensitive
+surface in that module — it mints a JWT *as somebody else* — and it was the
+only concern in there whose admin check was hand-written inside the handler
+while ``IsAdmin`` sat unused two imports away.
+
+Admin-ness is now declarative, and the DENIED audit event that the hand-written
+check used to write is emitted from ``permission_denied`` so it cannot be
+forgotten. Impersonation is also deliberately *not* self-service: the guard
+that only participants and ZEV owners may be impersonated is what stops an
+admin minting a token for another admin.
+"""
+
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from audit.models import AuditActionCategory, AuditEventStatus
+from audit.services import record_audit_event
+
+from .cookies import (
+    ACCESS_COOKIE,
+    ADMIN_ACCESS_COOKIE,
+    ADMIN_REFRESH_COOKIE,
+    REFRESH_COOKIE,
+    clear_auth_cookies,
+    set_auth_cookies,
+)
+from .models import User, UserRole
+from .permissions import IsAdmin
+from .serializers import UserSerializer
+
+#: Only these roles may be impersonated. Admins are excluded on purpose — an
+#: admin minting a token for another admin would be a privilege transfer with
+#: no trace of which human was behind it.
+IMPERSONATABLE_ROLES = (UserRole.PARTICIPANT, UserRole.ZEV_OWNER)
+
+ACTION_TYPE = "impersonation.issue_token"
+
+
+def _record(request, *, summary, event_status=AuditEventStatus.SUCCESS, target=None,
+            target_id="", target_display="", metadata=None):
+    record_audit_event(
+        request=request,
+        action_category=AuditActionCategory.AUTH,
+        action_type=ACTION_TYPE,
+        target_type="accounts.User",
+        target=target,
+        target_id=target_id,
+        target_display=target_display,
+        summary=summary,
+        status=event_status,
+        metadata=metadata,
+    )
+
+
+class ImpersonateParticipantView(APIView):
+    """Issue tokens as ``user_id`` while parking the caller's own tokens."""
+
+    permission_classes = [IsAuthenticated, IsAdmin]
+
+    def permission_denied(self, request, message=None, code=None):
+        # Matches the event the hand-written admin check used to write. Only an
+        # authenticated non-admin is recorded; an anonymous caller gets a 401
+        # and is not a governance event.
+        if request.user.is_authenticated:
+            user_id = self.kwargs.get("user_id")
+            _record(
+                request,
+                summary="Denied impersonation token issuance by non-admin.",
+                event_status=AuditEventStatus.DENIED,
+                target_id=str(user_id),
+                target_display=str(user_id),
+            )
+        super().permission_denied(request, message=message, code=code)
+
+    def post(self, request, user_id: int, *args, **kwargs):
+        try:
+            target_user = User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            _record(
+                request,
+                summary=f"Impersonation target user {user_id} not found.",
+                event_status=AuditEventStatus.FAILED,
+                target_id=str(user_id),
+                target_display=str(user_id),
+            )
+            return Response({"detail": "User not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        display = target_user.email or target_user.username
+
+        if target_user.role not in IMPERSONATABLE_ROLES:
+            _record(
+                request,
+                summary=f"Denied impersonation for {display} due to role guard.",
+                event_status=AuditEventStatus.DENIED,
+                target=target_user,
+                target_id=str(target_user.pk),
+                target_display=display,
+                metadata={"role": target_user.role},
+            )
+            return Response(
+                {"detail": "Only participant or ZEV owner users can be impersonated."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        refresh = RefreshToken.for_user(target_user)
+        refresh["role"] = target_user.role
+        refresh["email"] = target_user.email
+        refresh["full_name"] = target_user.get_full_name()
+        refresh["must_change_password"] = target_user.must_change_password
+        refresh["impersonated_by"] = request.user.id
+
+        _record(
+            request,
+            summary=f"Issued impersonation token for {display}.",
+            target=target_user,
+            target_id=str(target_user.pk),
+            target_display=display,
+            metadata={"impersonated_by": request.user.id},
+        )
+
+        response = Response(
+            {
+                "impersonated_user": UserSerializer(target_user).data,
+                "impersonator": UserSerializer(request.user).data,
+            },
+            status=status.HTTP_200_OK,
+        )
+        # Park the caller's current tokens in the backup cookies so
+        # stop-impersonation can restore them, then overwrite the main pair.
+        current_access = request.COOKIES.get(ACCESS_COOKIE, "")
+        current_refresh = request.COOKIES.get(REFRESH_COOKIE, "")
+        if current_access and current_refresh:
+            set_auth_cookies(
+                response,
+                access=current_access,
+                refresh=current_refresh,
+                access_cookie=ADMIN_ACCESS_COOKIE,
+                refresh_cookie=ADMIN_REFRESH_COOKIE,
+            )
+        set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
+        return response
+
+
+class StopImpersonationView(APIView):
+    """Restore the original admin tokens after ending an impersonation session.
+
+    Deliberately only ``IsAuthenticated``: the caller here is holding the
+    *impersonated* user's token, so requiring admin would make it impossible to
+    get back. The authority comes from the backup cookies, which are httpOnly
+    and only ever written by :class:`ImpersonateParticipantView`.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        admin_access = request.COOKIES.get(ADMIN_ACCESS_COOKIE)
+        admin_refresh = request.COOKIES.get(ADMIN_REFRESH_COOKIE)
+        if not admin_access or not admin_refresh:
+            return Response(
+                {"detail": "No active impersonation session."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        response = Response({"detail": "Impersonation ended."})
+        set_auth_cookies(response, access=admin_access, refresh=admin_refresh)
+        clear_auth_cookies(response, access_cookie=ADMIN_ACCESS_COOKIE, refresh_cookie=ADMIN_REFRESH_COOKIE)
+        return response

--- a/backend/accounts/views_impersonation.py
+++ b/backend/accounts/views_impersonation.py
@@ -153,6 +153,9 @@ class StopImpersonationView(APIView):
     *impersonated* user's token, so requiring admin would make it impossible to
     get back. The authority comes from the backup cookies, which are httpOnly
     and only ever written by :class:`ImpersonateParticipantView`.
+
+    Ending a session is audited so the impersonation window can be bounded; a
+    no-op call with no backup pair is not, since it changes nothing.
     """
 
     permission_classes = [IsAuthenticated]
@@ -165,6 +168,25 @@ class StopImpersonationView(APIView):
                 {"detail": "No active impersonation session."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        # request.user here is the *impersonated* user; the admin behind the
+        # session is only recoverable from the claim the issuing view stamped
+        # on the token.
+        impersonated = request.user
+        display = impersonated.email or impersonated.username
+        impersonator_id = request.auth.get("impersonated_by") if request.auth is not None else None
+
+        record_audit_event(
+            request=request,
+            action_category=AuditActionCategory.AUTH,
+            action_type="impersonation.end",
+            target_type="accounts.User",
+            target=impersonated,
+            target_id=str(impersonated.pk),
+            target_display=display,
+            summary=f"Ended impersonation of {display}.",
+            metadata={"impersonated_by": impersonator_id} if impersonator_id else None,
+        )
 
         response = Response({"detail": "Impersonation ended."})
         set_auth_cookies(response, access=admin_access, refresh=admin_refresh)


### PR DESCRIPTION
First slice of the `accounts/views.py` split (999 lines, nine unrelated concerns). Three commits, separable on purpose.

## Why impersonation first, not the biggest block

It's the most security-sensitive surface in the file — it mints a JWT **as another user** — and it sat behind a hand-written admin check.

The file is *split-brain* on this: `IsAdmin` is declared on five views and hand-rolled inside the handler on four others ([115](backend/accounts/views.py#L115), [310](backend/accounts/views.py#L310), [365](backend/accounts/views.py#L365), and impersonation). Mixed convention is worse than a uniformly bad one — a reader can't tell which applies, so an endpoint copied from the wrong neighbour silently gets no check.

## Commit 1 — cookie helpers to `accounts/cookies.py`

Prerequisite, not cleanup. The cookie names and set/clear helpers are used by login, refresh, logout, registration, email verification, OAuth **and** impersonation — four of the nine concerns — so whichever moves out first would otherwise have to reach back into `views.py` for an underscore-prefixed name (which is backlog item #10, cross-module private imports). Underscores dropped, since it's now a deliberate boundary.

Pure move, verified by the probe below.

## Commit 2 — the extraction

Both views become `APIView`s with `permission_classes = [IsAuthenticated, IsAdmin]`, and the DENIED audit event the hand-written check used to write is emitted from `permission_denied()` so it can't be forgotten. The role guard is named `IMPERSONATABLE_ROLES` with a note on why admins are excluded.

URLs unchanged — `accounts/urls.py` already lists every route explicitly, so it's a one-line import swap per route.

**Verification:** a 29-row probe (4 actor roles × 4 target roles, missing target, three cookie states, across both endpoints) run before and after — status codes, response keys, emitted cookies **and audit events** identical.

### The existing tests never ran the code that matters

The four pre-existing tests all drove the endpoint with an `Authorization: Bearer` header — despite the helper being named `_cookie_auth` ([tests.py:58](backend/accounts/tests.py#L58) sets a Bearer header). That leaves `request.COOKIES` empty, so **the admin-token backup branch — the entire point of the feature — was never executed by any test.** `stop-impersonation` had none at all.

New `test_impersonation.py` drives the real cookie flow through `/auth/token/`: impersonating parks the admin's pair under the backup names untouched and swaps in a target token carrying `impersonated_by`; all four cookies are httpOnly; stopping restores the admin pair, expires the backup, and the restored session really is the admin again (checked via `/me/`); half a backup pair isn't enough; plus every audit event including the denial paths and that an anonymous 401 is deliberately *not* audited.

**All 18 pass on `main` too** — they pin pre-existing behaviour, not this refactor.

## Commit 3 — a gap the probe exposed (an addition, easy to drop)

Starting an impersonation is audited four ways. **Ending one wrote nothing**, so the trail showed sessions opening and never closing, with no way to bound how long an admin had been acting as someone else.

Now records `impersonation.end`. The subtlety: by then `request.user` *is* the impersonated user, so the admin behind the session is only recoverable from the `impersonated_by` claim stamped on the token — the event targets the impersonated user and carries the impersonator's id in metadata. A no-op call with no backup pair is deliberately not audited.

This is an addition rather than part of the extraction, hence the separate commit. Worth being explicit: **the 29-row probe can't speak to it either way**, because it doesn't query audit events for the stop endpoint. It's covered by tests instead.

`ruff check .` clean; suite 498 → 519 passed, no existing test modified.

*(Aside: ruff caught a genuine bug in my own edit here — a naive rename turned `ADMIN_ACCESS_COOKIE` into `ADMINACCESS_COOKIE` because it contains `_ACCESS_COOKIE`. Exactly the class of thing the CI linter from #334 was added for.)*

## Next in this file

`accounts/views.py` is 999 → 858. The OAuth block (~282 lines, its own helpers and its own threat model — there's already a CWE-601 note at [line 849](backend/accounts/views.py#L849)) is the natural next slice. `VatRate`/`AppSettings`/`FeatureFlag` (~166 lines) aren't accounts-domain at all, but moving them properly means moving models and migrations — an architecture call worth deciding before any code moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)