### PR TITLE
feat(accounts): audit the OAuth flows and provider configuration

### DIFF
--- a/backend/accounts/test_oauth.py
+++ b/backend/accounts/test_oauth.py
@@ -427,3 +427,205 @@ class SocialAccountTests(OAuthTestCase):
         self.client.credentials()
 
         self.assertEqual(self.client.get(SOCIAL_ACCOUNTS).status_code, 401)
+
+
+class ProviderConfigAuditTests(OAuthTestCase):
+    """Provider configuration is the highest-leverage thing an admin can change
+    here: repointing token_url or userinfo_url redirects authentication itself.
+    It is audited under GOVERNANCE, like the other admin-only config endpoints.
+    """
+
+    def setUp(self):
+        super().setUp()
+        auth(self.client, make_user("prov_admin", UserRole.ADMIN))
+
+    def _payload(self, **overrides):
+        payload = {
+            "name": "newidp",
+            "display_name": "New IdP",
+            "client_id": "new-client",
+            "client_secret": "new-secret",
+            "authorization_url": "https://new.example/authorize",
+            "token_url": "https://new.example/token",
+            "userinfo_url": "https://new.example/userinfo",
+            "redirect_url": "https://app.example/callback",
+            "scope": "openid email",
+            "enabled": True,
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_creating_a_provider_is_audited(self):
+        resp = self.client.post(PROVIDERS_CONFIG, self._payload(), format="json")
+
+        self.assertEqual(resp.status_code, 201)
+        event = AuditEvent.objects.get(action_type="oauth_provider.create")
+        self.assertEqual(event.action_category, AuditActionCategory.GOVERNANCE)
+        self.assertEqual(event.target_display, "newidp")
+        self.assertEqual(event.changes_json["token_url"]["after"], "https://new.example/token")
+
+    def test_a_created_providers_secret_is_never_stored_in_the_event(self):
+        self.client.post(PROVIDERS_CONFIG, self._payload(), format="json")
+
+        event = AuditEvent.objects.get(action_type="oauth_provider.create")
+        self.assertNotIn("new-secret", json.dumps(event.changes_json))
+        self.assertNotIn("new-secret", json.dumps(event.metadata_json))
+
+    def test_repointing_the_token_url_shows_before_and_after(self):
+        url = f"{PROVIDERS_CONFIG}{self.provider.pk}/"
+
+        resp = self.client.patch(url, {"token_url": "https://attacker.example/token"}, format="json")
+
+        self.assertEqual(resp.status_code, 200)
+        event = AuditEvent.objects.get(action_type="oauth_provider.update")
+        self.assertEqual(
+            event.changes_json["token_url"],
+            {"before": "https://idp.example/token", "after": "https://attacker.example/token"},
+        )
+
+    def test_a_secret_rotation_is_recorded_as_a_flag_not_a_value(self):
+        """The secret must not reach the audit trail, but rotating it is
+        exactly the kind of change worth being able to see after the fact."""
+        url = f"{PROVIDERS_CONFIG}{self.provider.pk}/"
+
+        self.client.patch(url, {"client_secret": "rotated-secret"}, format="json")
+
+        event = AuditEvent.objects.get(action_type="oauth_provider.update")
+        self.assertTrue(event.metadata_json["client_secret_rotated"])
+        self.assertNotIn("rotated-secret", json.dumps(event.metadata_json))
+        self.assertNotIn("rotated-secret", json.dumps(event.changes_json))
+
+    def test_an_unrelated_edit_does_not_claim_the_secret_rotated(self):
+        url = f"{PROVIDERS_CONFIG}{self.provider.pk}/"
+
+        self.client.patch(url, {"scope": "openid"}, format="json")
+
+        self.assertFalse(AuditEvent.objects.get(action_type="oauth_provider.update")
+                         .metadata_json["client_secret_rotated"])
+
+    def test_deleting_a_provider_records_how_many_links_it_took_with_it(self):
+        user = make_user("linked_to_doomed", UserRole.PARTICIPANT)
+        SocialAccount.objects.create(provider=self.provider, uid="doomed", user=user)
+
+        resp = self.client.delete(f"{PROVIDERS_CONFIG}{self.provider.pk}/")
+
+        self.assertEqual(resp.status_code, 204)
+        event = AuditEvent.objects.get(action_type="oauth_provider.delete")
+        self.assertEqual(event.action_category, AuditActionCategory.GOVERNANCE)
+        self.assertEqual(event.target_display, "testidp")
+        self.assertEqual(event.metadata_json["unlinked_social_accounts"], 1)
+
+
+class OAuthFlowAuditTests(OAuthTestCase):
+    def _event(self, action_type):
+        return AuditEvent.objects.get(action_type=action_type)
+
+    def test_a_successful_login_is_audited(self):
+        user = make_user("audit_login", UserRole.ZEV_OWNER)
+        SocialAccount.objects.create(provider=self.provider, uid="uid-login", user=user)
+        self.start_state("s")
+
+        with fake_provider_http({"access_token": "at"}, {"sub": "uid-login", "email": user.email}):
+            self.callback(code="c", state="s")
+
+        event = self._event("oauth.login")
+        self.assertEqual(event.action_category, AuditActionCategory.AUTH)
+        self.assertEqual(event.status, AuditEventStatus.SUCCESS)
+        self.assertEqual(event.target_id, str(user.pk))
+        self.assertEqual(event.metadata_json["provider"], "testidp")
+
+    def test_provisioning_a_new_account_is_audited_separately_from_the_login(self):
+        """Account creation deserves its own event — it is the moment a new
+        principal appears, not just a session."""
+        self.start_state("s")
+
+        with fake_provider_http({"access_token": "at"}, {"sub": "uid-p", "email": "brand@example.com"}):
+            self.callback(code="c", state="s")
+
+        provision = self._event("oauth.provision")
+        self.assertEqual(provision.metadata_json["role"], UserRole.PARTICIPANT)
+        self.assertEqual(provision.target_display, "brand@example.com")
+        self.assertTrue(AuditEvent.objects.filter(action_type="oauth.login").exists())
+
+    def test_claiming_an_existing_account_with_a_verified_email_is_audited_as_a_link(self):
+        user = make_user("audit_claim", UserRole.ZEV_OWNER)
+        self.start_state("s")
+
+        with fake_provider_http(
+            {"access_token": "at"},
+            {"sub": "uid-claim", "email": user.email, "email_verified": True},
+        ):
+            self.callback(code="c", state="s")
+
+        self.assertEqual(self._event("oauth.link").metadata_json["matched_by"], "verified_email")
+
+    def test_an_invalid_state_is_audited_as_a_failure(self):
+        """The clearest CSRF/replay signal the flow produces."""
+        self.callback(code="c", state="forged")
+
+        event = self._event("oauth.login_failed")
+        self.assertEqual(event.status, AuditEventStatus.FAILED)
+        self.assertEqual(event.metadata_json["reason"], "invalid_state")
+
+    def test_an_inactive_account_is_audited_against_that_account(self):
+        user = make_user("audit_inactive", UserRole.PARTICIPANT)
+        User.objects.filter(pk=user.pk).update(is_active=False)
+        SocialAccount.objects.create(provider=self.provider, uid="uid-inactive", user=user)
+        self.start_state("s")
+
+        with fake_provider_http({"access_token": "at"}, {"sub": "uid-inactive", "email": user.email}):
+            self.callback(code="c", state="s")
+
+        event = self._event("oauth.login_failed")
+        self.assertEqual(event.status, AuditEventStatus.DENIED)
+        self.assertEqual(event.target_id, str(user.pk))
+        self.assertEqual(event.metadata_json["reason"], "account_inactive")
+
+    def test_a_token_exchange_failure_is_audited(self):
+        self.start_state("s")
+
+        def explode(request, timeout=None):
+            raise OSError("boom")
+
+        with patch("urllib.request.urlopen", explode):
+            self.callback(code="c", state="s")
+
+        self.assertEqual(self._event("oauth.login_failed").metadata_json["reason"],
+                         "token_exchange_failed")
+
+    def test_normal_user_cancellation_is_not_audited(self):
+        """Declining consent at the provider, and bare GETs from crawlers, are
+        ordinary traffic — auditing them would bury the real signals."""
+        self.callback(error="access_denied")
+        self.callback()
+
+        self.assertFalse(AuditEvent.objects.exists())
+
+    def test_linking_and_unlinking_are_audited(self):
+        user = make_user("audit_link", UserRole.PARTICIPANT)
+        self.start_state("s", user=user)
+        with fake_provider_http({"access_token": "at"}, {"sub": "uid-l", "email": user.email}):
+            self.callback(code="c", state="s")
+        self.assertEqual(self._event("oauth.link").target_id, str(user.pk))
+
+        auth(self.client, user)
+        account = SocialAccount.objects.get(uid="uid-l")
+        self.client.delete(f"{SOCIAL_ACCOUNTS}{account.pk}/")
+
+        unlink = self._event("oauth.unlink")
+        self.assertEqual(unlink.target_id, str(user.pk))
+        self.assertEqual(unlink.metadata_json["provider"], "testidp")
+
+    def test_linking_an_identity_owned_by_someone_else_is_audited_as_denied(self):
+        holder = make_user("audit_holder", UserRole.PARTICIPANT)
+        SocialAccount.objects.create(provider=self.provider, uid="uid-held", user=holder)
+        claimer = make_user("audit_claimer", UserRole.PARTICIPANT)
+        self.start_state("s", user=claimer)
+
+        with fake_provider_http({"access_token": "at"}, {"sub": "uid-held", "email": claimer.email}):
+            self.callback(code="c", state="s")
+
+        event = self._event("oauth.link_refused")
+        self.assertEqual(event.status, AuditEventStatus.DENIED)
+        self.assertEqual(event.target_id, str(claimer.pk))
+        self.assertEqual(event.metadata_json["reason"], "already_linked_other")

--- a/backend/accounts/views_oauth.py
+++ b/backend/accounts/views_oauth.py
@@ -27,7 +27,7 @@ from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
 
 from audit.models import AuditActionCategory, AuditEventStatus
-from audit.services import record_audit_event
+from audit.services import build_diff, record_audit_event
 
 from .cookies import set_auth_cookies
 from .models import (
@@ -46,6 +46,88 @@ from .serializers import (
 )
 
 logger = logging.getLogger(__name__)
+
+#: Provider config fields worth diffing on update. ``client_secret`` is
+#: deliberately absent — ``redact_metadata`` would strip it from the diff
+#: anyway, so a rotation is reported as a boolean instead of a redacted key
+#: that silently vanishes.
+PROVIDER_TRACKED_FIELDS = (
+    "name",
+    "client_id",
+    "authorization_url",
+    "token_url",
+    "userinfo_url",
+    "redirect_url",
+    "scope",
+    "enabled",
+)
+
+
+def _provider_snapshot(provider: OAuthProvider) -> dict:
+    return {field: getattr(provider, field) for field in PROVIDER_TRACKED_FIELDS}
+
+
+def _record_auth_event(request, *, action_type, summary, event_status=AuditEventStatus.SUCCESS,
+                       user=None, metadata=None):
+    """Record an OAuth flow event.
+
+    The callback is an unauthenticated view, so ``request.user`` is anonymous
+    for most of these; the account the flow concerns is passed explicitly and
+    becomes the target rather than the actor.
+    """
+    record_audit_event(
+        request=request,
+        action_category=AuditActionCategory.AUTH,
+        action_type=action_type,
+        target_type="accounts.User",
+        target=user,
+        target_id=str(user.pk) if user else "",
+        target_display=(user.email or user.username) if user else "",
+        summary=summary,
+        status=event_status,
+        metadata=metadata,
+    )
+
+
+def _record_login_failure(request, provider_slug: str, reason: str) -> None:
+    """Record a callback that could not be resolved to a session.
+
+    Only failures that carry signal are recorded. A ``provider_error`` (the
+    user declined consent at the provider) and ``missing_params`` (a bare GET
+    at the callback URL, which any crawler produces) are normal traffic and
+    would drown the AUTH trail; everything else here means a replayed or forged
+    state, a misconfigured provider, or a provider returning an unusable
+    profile.
+    """
+    _record_auth_event(
+        request,
+        action_type="oauth.login_failed",
+        summary=f"OAuth login via {provider_slug} failed: {reason}.",
+        event_status=AuditEventStatus.FAILED,
+        metadata={"provider": provider_slug, "reason": reason},
+    )
+
+
+def _record_provider_event(request, *, action_type, provider, summary, changes=None, metadata=None):
+    """Record a change to an identity provider's configuration.
+
+    GOVERNANCE rather than AUTH, matching how the other admin-only
+    configuration endpoints are audited: repointing ``token_url`` or rotating
+    ``client_secret`` redirects authentication itself, so it belongs in the
+    same trail as the other privileged config changes.
+    """
+    record_audit_event(
+        request=request,
+        action_category=AuditActionCategory.GOVERNANCE,
+        action_type=action_type,
+        target_type="accounts.OAuthProvider",
+        target=provider,
+        target_id=str(provider.pk),
+        target_display=provider.name,
+        summary=summary,
+        changes=changes,
+        metadata=metadata,
+    )
 
 
 def _make_jwt_for_user(user: User) -> dict:
@@ -112,12 +194,51 @@ class OAuthProviderListCreateView(generics.ListCreateAPIView):
     serializer_class = OAuthProviderSerializer
     permission_classes = [IsAdmin]
 
+    def perform_create(self, serializer):
+        provider = serializer.save()
+        _record_provider_event(
+            self.request,
+            action_type="oauth_provider.create",
+            provider=provider,
+            summary=f"Created OAuth provider {provider.name}.",
+            changes=build_diff({}, _provider_snapshot(provider), PROVIDER_TRACKED_FIELDS),
+        )
+
 
 class OAuthProviderDetailView(generics.RetrieveUpdateDestroyAPIView):
     """Admin: retrieve, update or delete an OAuth provider configuration."""
     queryset = OAuthProvider.objects.all()
     serializer_class = OAuthProviderSerializer
     permission_classes = [IsAdmin]
+
+    def perform_update(self, serializer):
+        before = _provider_snapshot(self.get_object())
+        old_secret = self.get_object().client_secret
+        provider = serializer.save()
+        _record_provider_event(
+            self.request,
+            action_type="oauth_provider.update",
+            provider=provider,
+            summary=f"Updated OAuth provider {provider.name}.",
+            changes=build_diff(before, _provider_snapshot(provider), PROVIDER_TRACKED_FIELDS),
+            metadata={"client_secret_rotated": provider.client_secret != old_secret},
+        )
+
+    def perform_destroy(self, instance):
+        provider_id = str(instance.pk)
+        name = instance.name
+        linked_accounts = instance.social_accounts.count()
+        instance.delete()
+        record_audit_event(
+            request=self.request,
+            action_category=AuditActionCategory.GOVERNANCE,
+            action_type="oauth_provider.delete",
+            target_type="accounts.OAuthProvider",
+            target_id=provider_id,
+            target_display=name,
+            summary=f"Deleted OAuth provider {name}.",
+            metadata={"unlinked_social_accounts": linked_accounts},
+        )
 
 
 # ── public provider list ──────────────────────────────────────────────────────
@@ -196,10 +317,14 @@ def oauth_callback(request, provider_slug: str):
             state=state_value, provider__name=provider_slug
         )
     except OAuthState.DoesNotExist:
+        # No matching in-flight request: a replayed, forged or cross-provider
+        # state. The clearest CSRF signal this flow produces.
+        _record_login_failure(request, provider_slug, "invalid_state")
         return HttpResponseRedirect(f"{frontend_url}/login?oauth_error=invalid_state")
 
     if not state_obj.is_valid():
         state_obj.delete()
+        _record_login_failure(request, provider_slug, "state_expired")
         return HttpResponseRedirect(f"{frontend_url}/login?oauth_error=state_expired")
 
     linking_user = state_obj.user
@@ -213,11 +338,13 @@ def oauth_callback(request, provider_slug: str):
         user_info = _fetch_user_info(provider, token_data["access_token"])
     except Exception:
         logger.exception("OAuth token exchange failed for provider %s", provider_slug)
+        _record_login_failure(request, provider_slug, "token_exchange_failed")
         return HttpResponseRedirect(f"{frontend_url}/login?oauth_error=token_exchange_failed")
 
     # Derive a stable identifier for the provider account
     provider_uid = str(user_info.get("sub") or user_info.get("id") or "")
     if not provider_uid:
+        _record_login_failure(request, provider_slug, "missing_uid")
         return HttpResponseRedirect(f"{frontend_url}/login?oauth_error=missing_uid")
 
     email = (user_info.get("email") or "").strip().lower()
@@ -226,14 +353,30 @@ def oauth_callback(request, provider_slug: str):
         # ── Link flow: attach to the (already authenticated) user ────────
         if SocialAccount.objects.filter(provider=provider, uid=provider_uid).exclude(user=linking_user).exists():
             # The provider account is already linked to a different user
+            _record_auth_event(
+                request,
+                action_type="oauth.link_refused",
+                summary=f"Refused to link an OAuth identity to {linking_user.email or linking_user.username}: already linked to another account.",
+                event_status=AuditEventStatus.DENIED,
+                user=linking_user,
+                metadata={"provider": provider_slug, "reason": "already_linked_other"},
+            )
             return HttpResponseRedirect(
                 f"{frontend_url}/account?oauth_error=already_linked_other"
             )
-        SocialAccount.objects.get_or_create(
+        _social, created = SocialAccount.objects.get_or_create(
             provider=provider,
             uid=provider_uid,
             defaults={"user": linking_user, "extra_data": user_info},
         )
+        if created:
+            _record_auth_event(
+                request,
+                action_type="oauth.link",
+                summary=f"Linked OAuth identity from {provider_slug} to {linking_user.email or linking_user.username}.",
+                user=linking_user,
+                metadata={"provider": provider_slug},
+            )
         return HttpResponseRedirect(f"{frontend_url}/account?oauth_linked=true")
 
     # ── Login flow: find or create the local user ─────────────────────────
@@ -243,7 +386,9 @@ def oauth_callback(request, provider_slug: str):
         )
         user = social.user
     except SocialAccount.DoesNotExist:
+        provisioned = False
         if not email:
+            _record_login_failure(request, provider_slug, "no_email")
             return HttpResponseRedirect(f"{frontend_url}/login?oauth_error=no_email")
 
         try:
@@ -261,6 +406,7 @@ def oauth_callback(request, provider_slug: str):
                 is_active=True,
                 role=UserRole.PARTICIPANT,
             )
+            provisioned = True
         else:
             # A provider identity we have never seen is claiming an account
             # that already exists — and inheriting it means inheriting its
@@ -272,16 +418,17 @@ def oauth_callback(request, provider_slug: str):
                     "Refused OAuth account takeover: provider %s asserted unverified email for an existing user",
                     provider_slug,
                 )
-                record_audit_event(
-                    action_category=AuditActionCategory.AUTH,
+                _record_auth_event(
+                    request,
                     action_type="oauth.link_refused",
-                    target_type="accounts.User",
-                    target=user,
-                    target_id=str(user.pk),
-                    target_display=user.email or user.username,
                     summary="Refused to link an OAuth identity to an existing account: email not verified by the provider.",
-                    status=AuditEventStatus.DENIED,
-                    metadata={"provider": provider_slug, "email_verified": user_info.get("email_verified")},
+                    event_status=AuditEventStatus.DENIED,
+                    user=user,
+                    metadata={
+                        "provider": provider_slug,
+                        "reason": "email_not_verified",
+                        "email_verified": user_info.get("email_verified"),
+                    },
                 )
                 return HttpResponseRedirect(f"{frontend_url}/login?oauth_error=email_not_verified")
 
@@ -291,13 +438,45 @@ def oauth_callback(request, provider_slug: str):
             user=user,
             extra_data=user_info,
         )
+        if provisioned:
+            _record_auth_event(
+                request,
+                action_type="oauth.provision",
+                summary=f"Provisioned a new account for {user.email} from {provider_slug}.",
+                user=user,
+                metadata={"provider": provider_slug, "role": user.role},
+            )
+        else:
+            _record_auth_event(
+                request,
+                action_type="oauth.link",
+                summary=f"Linked OAuth identity from {provider_slug} to existing account {user.email or user.username}.",
+                user=user,
+                metadata={"provider": provider_slug, "matched_by": "verified_email"},
+            )
 
     if not user.is_active:
+        # Valid provider credentials presented for a disabled account.
+        _record_auth_event(
+            request,
+            action_type="oauth.login_failed",
+            summary=f"OAuth login refused for {user.email or user.username}: account is inactive.",
+            event_status=AuditEventStatus.DENIED,
+            user=user,
+            metadata={"provider": provider_slug, "reason": "account_inactive"},
+        )
         return HttpResponseRedirect(f"{frontend_url}/login?oauth_error=account_inactive")
 
     # Issue a short-lived exchange code for the frontend to convert to JWT
     exchange_code = secrets.token_urlsafe(32)
     OAuthExchangeCode.objects.create(code=exchange_code, user=user)
+    _record_auth_event(
+        request,
+        action_type="oauth.login",
+        summary=f"OAuth login succeeded for {user.email or user.username} via {provider_slug}.",
+        user=user,
+        metadata={"provider": provider_slug},
+    )
     return HttpResponseRedirect(f"{frontend_url}/oauth/callback?code={exchange_code}")
 
 
@@ -353,5 +532,13 @@ def social_accounts_list(request):
 def social_account_delete(request, pk: int):
     """Unlink a social account from the current user."""
     account = get_object_or_404(SocialAccount, pk=pk, user=request.user)
+    provider_name = account.provider.name
     account.delete()
+    _record_auth_event(
+        request,
+        action_type="oauth.unlink",
+        summary=f"Unlinked OAuth identity from {provider_name} for {request.user.email or request.user.username}.",
+        user=request.user,
+        metadata={"provider": provider_name},
+    )
     return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
> **Stacked on #341** — review/merge that first; this targets its branch so the diff stays clean. I'll retarget to `main` once #341 lands.

Follow-up to the observation at the end of #341: the OAuth module recorded nothing except the single takeover refusal added there. Logins, provisioning, links, unlinks and every failure mode were invisible in the AUTH trail — and provider configuration changes were invisible in the GOVERNANCE trail.

## GOVERNANCE — provider configuration

This is the gap that mattered most. `OAuthProvider` holds `token_url`, `userinfo_url` and `client_secret`; **repointing those redirects authentication itself**, and until now an admin could do it silently. Every other admin-only config endpoint in this app (`VatRate`, PDF and email templates) is already audited this way, so OAuth was the outlier.

- `oauth_provider.create` / `update` / `delete`, with a field diff

**On the secret:** `client_secret` is deliberately *not* in the tracked fields. `redact_metadata` would strip it from the diff anyway — which means a rotation would vanish entirely rather than merely be redacted. Instead the update event carries a `client_secret_rotated` boolean, so the *fact* of a rotation is auditable without the value ever reaching the trail. Tested both ways: the secret never appears in `changes_json` or `metadata_json`, and an unrelated edit doesn't falsely claim a rotation.

Deletion records how many linked social accounts it took with it.

## AUTH — the flow

| Event | Records |
|---|---|
| `oauth.login` | a session was issued |
| `oauth.provision` | a brand-new local account appeared, with its role |
| `oauth.link` | an identity was attached, and how it was matched (explicit link flow vs verified email) |
| `oauth.unlink` | an identity was detached |
| `oauth.link_refused` | extended to cover an identity already owned by another account, alongside #341's unverified-email case |
| `oauth.login_failed` | `invalid_state`, `state_expired`, `token_exchange_failed`, `missing_uid`, `no_email`, `account_inactive` |

`oauth.provision` is separate from `oauth.login` on purpose — account creation is the moment a new principal appears, not just a session, and it's worth being able to alert on independently.

The callback is unauthenticated, so `request.user` is anonymous for most of these. The account the flow concerns is passed explicitly and becomes the event **target** rather than the actor.

## What is deliberately *not* audited

`provider_error` (the user declined consent at the provider) and `missing_params` (any bare GET at the callback URL, which crawlers produce) are ordinary traffic. Recording them would bury the signals that matter — `invalid_state` in particular is the clearest CSRF/replay indicator this flow produces. Pinned by a test asserting those two paths write nothing.

## Checks

`ruff check .` clean; suite 554 → 569 (15 new tests). No frontend change needed — the audit log page renders `action_type` as raw text and only translates `action_category`, and both categories used here already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)