### PR TITLE
refactor(invoices): extract the solar allocation arithmetic from generate_invoice

### DIFF
--- a/backend/invoices/engine.py
+++ b/backend/invoices/engine.py
@@ -11,6 +11,7 @@ Algorithm:
 import logging
 from datetime import date, datetime, timezone as tz, timedelta
 from decimal import Decimal, ROUND_HALF_UP
+from typing import NamedTuple
 
 from django.db import models, transaction
 
@@ -21,6 +22,68 @@ from metering.models import MeterReading, ReadingDirection
 from .models import Invoice, InvoiceItem, InvoiceStatus
 
 logger = logging.getLogger(__name__)
+
+
+# ─── Allocation ───────────────────────────────────────────────────────────────
+#
+# How the community's solar output is divided between its members at a single
+# timestamp. Pure arithmetic, deliberately free of the ORM: this is the part of
+# the engine that decides who pays for what, and it should be readable and
+# testable without building a metering fixture.
+
+
+class ConsumptionSplit(NamedTuple):
+    local_kwh: Decimal
+    grid_kwh: Decimal
+
+
+class ProductionSplit(NamedTuple):
+    local_sold_kwh: Decimal
+    exported_kwh: Decimal
+
+
+def split_consumption(
+    participant_kwh: Decimal,
+    zev_consumption_kwh: Decimal,
+    zev_production_kwh: Decimal,
+) -> ConsumptionSplit:
+    """Divide one consumer's draw into a solar part and a grid part.
+
+    The community can only share what it both produced *and* consumed in the
+    interval; that pool is handed out in proportion to each member's share of
+    total consumption, and whatever is left over is drawn from the grid.
+
+    The ``min`` against ``participant_kwh`` can only ever tie, never bite —
+    the pool is itself capped at total consumption, so a member's proportional
+    slice cannot exceed their own draw. It is kept as a guard against a caller
+    passing inconsistent totals.
+    """
+    local_pool = min(zev_production_kwh, zev_consumption_kwh)
+    if zev_consumption_kwh > 0 and local_pool > 0:
+        participant_share = participant_kwh / zev_consumption_kwh
+        local_kwh = min(participant_kwh, local_pool * participant_share)
+    else:
+        local_kwh = Decimal("0")
+    return ConsumptionSplit(local_kwh, max(participant_kwh - local_kwh, Decimal("0")))
+
+
+def split_production(
+    produced_kwh: Decimal,
+    zev_production_kwh: Decimal,
+    zev_consumption_kwh: Decimal,
+) -> ProductionSplit:
+    """Divide one producer's output into what the community used and what was exported.
+
+    Both pools are shared on the producer's contribution to total production,
+    so a member who supplied 30% of the solar earns 30% of the local sales and
+    carries 30% of the export.
+    """
+    if zev_production_kwh <= 0:
+        return ProductionSplit(Decimal("0"), Decimal("0"))
+    local_pool = min(zev_production_kwh, zev_consumption_kwh)
+    export_pool = max(zev_production_kwh - zev_consumption_kwh, Decimal("0"))
+    producer_share = produced_kwh / zev_production_kwh
+    return ProductionSplit(local_pool * producer_share, export_pool * producer_share)
 
 
 def _period_to_dt(d: date) -> datetime:
@@ -430,14 +493,10 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
         participant_kwh = reading.energy_kwh
         zev_consumption_at_ts = zev_consumption_by_ts.get(ts, Decimal("0"))
         zev_production_at_ts = zev_production_by_ts.get(ts, Decimal("0"))
-        local_pool_at_ts = min(zev_production_at_ts, zev_consumption_at_ts)
 
-        if zev_consumption_at_ts > 0 and local_pool_at_ts > 0:
-            participant_share = participant_kwh / zev_consumption_at_ts
-            r_local = min(participant_kwh, local_pool_at_ts * participant_share)
-        else:
-            r_local = Decimal("0")
-        r_grid = max(participant_kwh - r_local, Decimal("0"))
+        r_local, r_grid = split_consumption(
+            participant_kwh, zev_consumption_at_ts, zev_production_at_ts
+        )
 
         local_kwh_acc += r_local
         grid_kwh_acc += r_grid
@@ -482,16 +541,10 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
         zev_production_at_ts = zev_production_by_ts.get(ts, Decimal("0"))
         zev_consumption_at_ts = zev_consumption_by_ts.get(ts, Decimal("0"))
-        local_pool_at_ts = min(zev_production_at_ts, zev_consumption_at_ts)
-        export_pool_at_ts = max(zev_production_at_ts - zev_consumption_at_ts, Decimal("0"))
 
-        if zev_production_at_ts > 0:
-            producer_share = produced_kwh / zev_production_at_ts
-            local_sold_kwh = local_pool_at_ts * producer_share
-            exported_kwh = export_pool_at_ts * producer_share
-        else:
-            local_sold_kwh = Decimal("0")
-            exported_kwh = Decimal("0")
+        local_sold_kwh, exported_kwh = split_production(
+            produced_kwh, zev_production_at_ts, zev_consumption_at_ts
+        )
 
         exported_kwh_acc += exported_kwh
 

--- a/backend/invoices/test_allocation_units.py
+++ b/backend/invoices/test_allocation_units.py
@@ -1,0 +1,150 @@
+"""Unit tests for the allocation arithmetic in ``engine``.
+
+``split_consumption`` and ``split_production`` decide how a community's solar
+output is divided between its members. They were previously inline in
+``generate_invoice`` and reachable only by building a ZEV, participants,
+metering points, assignments, readings and tariffs — which is why the awkward
+cases below had no coverage at all.
+
+The end-to-end behaviour is pinned separately in ``test_engine_allocation.py``;
+these are the same rules stated as arithmetic.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from .engine import split_consumption, split_production
+
+
+def D(value) -> Decimal:
+    return Decimal(str(value))
+
+
+# ---------------------------------------------------------------------------
+# split_consumption
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("participant", "zev_consumption", "zev_production", "local", "grid"),
+    [
+        # Scarce pool: 6 kWh of solar shared across 8 kWh of demand.
+        ("6", "8", "6", "4.5", "1.5"),
+        ("2", "8", "6", "1.5", "0.5"),
+        # Solar covers demand exactly -> everything local.
+        ("6", "8", "8", "6", "0"),
+        # Surplus solar: pool is capped at consumption, so still fully local.
+        ("6", "8", "50", "6", "0"),
+        # No solar at all.
+        ("5", "5", "0", "0", "5"),
+        # Solar exists but nobody is consuming (the caller's own reading is 0).
+        ("0", "0", "10", "0", "0"),
+        # Sole consumer takes the whole pool and grids the rest.
+        ("10", "10", "3", "3", "7"),
+    ],
+)
+def test_split_consumption_table(participant, zev_consumption, zev_production, local, grid):
+    result = split_consumption(D(participant), D(zev_consumption), D(zev_production))
+
+    assert result.local_kwh == D(local)
+    assert result.grid_kwh == D(grid)
+
+
+def test_local_and_grid_always_reconstruct_the_reading():
+    """Exact by construction: grid is *defined* as the remainder after local,
+    so no multiplication rounding can creep between them."""
+    for participant, consumption, production in (
+        ("7.3", "11.6", "4.2"), ("0.4", "0.4", "9"), ("15", "15", "0"), ("2.5", "9", "9"),
+    ):
+        result = split_consumption(D(participant), D(consumption), D(production))
+
+        assert result.local_kwh + result.grid_kwh == D(participant)
+
+
+def test_a_share_is_never_more_than_the_participants_own_draw():
+    """The guard against an inconsistent caller: a pool larger than total
+    consumption must not hand somebody more solar than they actually used."""
+    result = split_consumption(D("2"), D("4"), D("999"))
+
+    assert result.local_kwh == D("2")
+    assert result.grid_kwh == D("0")
+
+
+def test_zero_consumption_is_not_a_division_by_zero():
+    assert split_consumption(D("0"), D("0"), D("0")) == (D("0"), D("0"))
+
+
+def test_an_indivisible_pool_leaves_a_remainder_on_the_grid_side():
+    """Three equal consumers against 1 kWh: each share is 1/3, which does not
+    terminate, so the local parts do not sum back to the pool. The shortfall
+    stays on the grid side rather than being silently absorbed."""
+    shares = [split_consumption(D("1"), D("3"), D("1")) for _ in range(3)]
+
+    total_local = sum((s.local_kwh for s in shares), Decimal("0"))
+    assert total_local < D("1")
+    assert D("1") - total_local < D("0.000000000000000000000000001")
+
+
+# ---------------------------------------------------------------------------
+# split_production
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("produced", "zev_production", "zev_consumption", "local_sold", "exported"),
+    [
+        # Two producers (9 and 3) against 4 kWh of demand: pool 4, export 8.
+        ("9", "12", "4", "3", "6"),
+        ("3", "12", "4", "1", "2"),
+        # Demand exceeds production -> everything is sold locally, nothing exported.
+        ("6", "6", "10", "6", "0"),
+        # Nobody consuming -> all of it is exported.
+        ("5", "5", "0", "0", "5"),
+        # Producer contributed nothing.
+        ("0", "10", "4", "0", "0"),
+    ],
+)
+def test_split_production_table(produced, zev_production, zev_consumption, local_sold, exported):
+    result = split_production(D(produced), D(zev_production), D(zev_consumption))
+
+    assert result.local_sold_kwh == D(local_sold)
+    assert result.exported_kwh == D(exported)
+
+
+def test_no_production_is_not_a_division_by_zero():
+    assert split_production(D("0"), D("0"), D("5")) == (D("0"), D("0"))
+
+
+def test_local_sold_is_capped_by_what_the_community_consumed():
+    """Not by what was produced — this is the cap that is invisible from the
+    consumer side, where the per-participant clamp hides it."""
+    result = split_production(D("12"), D("12"), D("4"))
+
+    assert result.local_sold_kwh == D("4")
+    assert result.exported_kwh == D("8")
+
+
+def test_the_two_pools_reconstruct_the_producers_output_when_the_share_is_exact():
+    for produced, production, consumption in (
+        ("9", "12", "4"), ("0.1", "10", "10"), ("5", "5", "0"),
+    ):
+        result = split_production(D(produced), D(production), D(consumption))
+
+        assert result.local_sold_kwh + result.exported_kwh == D(produced)
+
+
+def test_a_recurring_share_reconstructs_only_to_within_decimal_precision():
+    """Unlike the consumption split — where grid is *defined* as the remainder
+    and so reconstruction is exact by construction — both production pools are
+    computed by multiplying a share. When that share does not terminate, the
+    two parts sum to slightly less than the producer's output.
+
+    Asserted with a tolerance rather than exact equality, because exact
+    equality here holds only for inputs that happen to round favourably, and a
+    test that passes by luck is worse than no test.
+    """
+    for produced, production, consumption in (("1", "3", "1"), ("7.3", "11.6", "4.2")):
+        result = split_production(D(produced), D(production), D(consumption))
+        total = result.local_sold_kwh + result.exported_kwh
+
+        assert total != D(produced)
+        assert abs(total - D(produced)) < D("1e-26")


### PR DESCRIPTION
PR 2 of 4 on `generate_invoice` (#8). Builds on the safety net from #344.

Lifts the two blocks that decide how a community's solar output is divided between its members into pure functions — `split_consumption` and `split_production`, returning named tuples. They were inline in a 375-line function and reachable only by building a ZEV, participants, metering points, assignments, readings and tariffs, which is why the awkward cases had no coverage at all.

## Equivalence is verified, not assumed

A golden fingerprint of a six-participant scenario — three consumers, two producers, one bidirectional meter, HT/NT grid pricing, a percentage-of-energy surcharge, three kinds of fixed fee, heavy export, and an interval that divides into thirds — dumps **every invoice field and every line item**. 44 lines, **byte-identical** before and after.

No `quantize` call is added, removed, or moved.

## Mutation counts

| mutation | new unit tests | end-to-end (#344) |
|---|---|---|
| drop the proportional share | 3 fail | 4 fail |
| share vs production, not consumption | 6 fail | 7 fail |
| **local pool ignores the consumption cap** | **6 fail** | **1 fail** |
| producer share inverted | 7 fail | 1 fail |

The third row is the argument for extracting at all. That cap is *invisible* from the consumer side end-to-end — the per-participant `min()` clamps a too-large pool away, making it mathematically unobservable. As plain arithmetic it's directly checkable.

The 20 new unit tests need **no database**.

## Two mistakes I made and caught

Worth flagging because both would have shipped something misleading:

**The golden harness disagreed with itself.** My first draft ordered line items by primary key — but `InvoiceItem.id` is a `UUID4`, so tied items came back in random order and consecutive runs of *identical code* produced different fingerprints. I nearly read that as a real regression. Now ordered on a canonical key.

**A test asserted a false invariant.** I'd written "a producer's two pools always sum back to their output". They don't: both are computed by multiplying a share, so a non-terminating share loses precision — `("1","3","1")` reconstructs to `0.9999…`. It passed only because all four cases I'd picked happened to round favourably. Now split into an exact-share test and one documenting the rounding with a tolerance. (The consumption split genuinely *is* exact, because `grid` is defined as the remainder after `local` — a real asymmetry, now stated.)

## Pre-existing finding, not touched here

Two line items from the same tariff — a bidirectional participant's charge and credit — tie on **all three** keys of `InvoiceItem.Meta.ordering` (`sort_order`, `item_type`, `description`). Their rendered order is therefore database-defined and can differ between regenerations of the same invoice. Totals are unaffected; it's cosmetic. Wants a tiebreak in `Meta.ordering`, which is a separate one-line PR.

`ruff check .` clean; suite 578 → 598.

## Next

3. `TariffResolver` + `ItemAccumulator` replacing the three stateful closures
4. split the remaining phases; `generate_invoice` becomes orchestration

🤖 Generated with [Claude Code](https://claude.com/claude-code)