### PR TITLE
refactor(invoices): give the pricing state real objects

### DIFF
--- a/backend/invoices/engine.py
+++ b/backend/invoices/engine.py
@@ -11,7 +11,7 @@ Algorithm:
 import logging
 from datetime import date, datetime, timezone as tz, timedelta
 from decimal import Decimal, ROUND_HALF_UP
-from typing import NamedTuple
+from typing import Iterable, NamedTuple
 
 from django.db import models, transaction
 
@@ -84,6 +84,93 @@ def split_production(
     export_pool = max(zev_production_kwh - zev_consumption_kwh, Decimal("0"))
     producer_share = produced_kwh / zev_production_kwh
     return ProductionSplit(local_pool * producer_share, export_pool * producer_share)
+
+
+# ─── Pricing state ────────────────────────────────────────────────────────────
+
+
+class TariffResolver:
+    """Answers "which tariffs apply on this day" without rescanning the list.
+
+    The pricing loops ask that question once per reading, so the tariffs are
+    bucketed by billing mode and energy type up front and the per-day validity
+    filter is memoised. Only the two energy-priced modes are bucketed; fixed
+    fees are handled separately and once, not per reading.
+    """
+
+    def __init__(self, tariffs: Iterable[Tariff]):
+        self._energy: dict[str, list[Tariff]] = {}
+        self._percentage: dict[str, list[Tariff]] = {}
+        for tariff in tariffs:
+            if tariff.billing_mode == BillingMode.ENERGY:
+                self._energy.setdefault(tariff.energy_type, []).append(tariff)
+            elif tariff.billing_mode == BillingMode.PERCENTAGE_OF_ENERGY and tariff.percentage:
+                self._percentage.setdefault(tariff.energy_type, []).append(tariff)
+        self._active_cache: dict[tuple[str, str, date], list[Tariff]] = {}
+
+    def _active(self, bucket: str, buckets: dict, energy_type: str, day: date) -> list[Tariff]:
+        key = (bucket, energy_type, day)
+        if key not in self._active_cache:
+            self._active_cache[key] = [
+                tariff for tariff in buckets.get(energy_type, []) if _tariff_is_active(tariff, day)
+            ]
+        return self._active_cache[key]
+
+    def energy(self, energy_type: str, day: date) -> list[Tariff]:
+        """Tariffs priced per kWh of ``energy_type`` and valid on ``day``."""
+        return self._active("energy", self._energy, energy_type, day)
+
+    def percentage(self, energy_type: str, day: date) -> list[Tariff]:
+        """Tariffs charging a percentage of the grid rate, valid on ``day``."""
+        return self._active("pct", self._percentage, energy_type, day)
+
+
+class ItemAccumulator:
+    """Collects priced quantities per tariff until the invoice is written.
+
+    One tariff can produce more than one invoice line: a participant with a
+    bidirectional meter is charged for what they drew and credited for what
+    they sold under the same tariff, which is what ``bucket`` separates.
+
+    Iteration yields entries in the order they were first seen, which the
+    caller's stable sort relies on to break ties.
+    """
+
+    def __init__(self):
+        self._entries: dict[str, dict] = {}
+
+    def add(
+        self,
+        *,
+        tariff: Tariff,
+        quantity: Decimal,
+        total: Decimal,
+        unit: str,
+        base_total: Decimal | None = None,
+        bucket: str = "default",
+    ) -> None:
+        if quantity == 0 and total == 0:
+            return
+        key = f"{tariff.id}:{bucket}"
+        entry = self._entries.get(key)
+        if entry is None:
+            entry = self._entries[key] = {
+                "tariff": tariff,
+                "quantity": Decimal("0"),
+                "total": Decimal("0"),
+                "unit": unit,
+                "base_total": Decimal("0"),
+            }
+        entry["quantity"] += quantity
+        entry["total"] += total
+        if base_total is not None:
+            entry["base_total"] += base_total
+
+    def __iter__(self):
+        return iter(self._entries.values())
+
+    def __len__(self) -> int:
+        return len(self._entries)
 
 
 def _period_to_dt(d: date) -> datetime:
@@ -430,63 +517,12 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
     tariffs_list = list(
         Tariff.objects.filter(zev=zev).prefetch_related("periods")
     )
-    # Pre-bucket tariffs by billing mode + energy type so the per-reading
-    # loops below don't re-filter the full tariff list for every timestamp.
-    energy_tariffs_by_type: dict[str, list[Tariff]] = {}
-    pct_tariffs_by_type: dict[str, list[Tariff]] = {}
-    for t in tariffs_list:
-        if t.billing_mode == BillingMode.ENERGY:
-            energy_tariffs_by_type.setdefault(t.energy_type, []).append(t)
-        elif t.billing_mode == BillingMode.PERCENTAGE_OF_ENERGY and t.percentage:
-            pct_tariffs_by_type.setdefault(t.energy_type, []).append(t)
-
-    _active_cache: dict[tuple[str, str, date], list[Tariff]] = {}
-
-    def active_energy_tariffs_for(energy_type: str, day: date) -> list[Tariff]:
-        key = ("energy", energy_type, day)
-        if key not in _active_cache:
-            _active_cache[key] = [
-                t for t in energy_tariffs_by_type.get(energy_type, []) if _tariff_is_active(t, day)
-            ]
-        return _active_cache[key]
-
-    def active_pct_tariffs_for(energy_type: str, day: date) -> list[Tariff]:
-        key = ("pct", energy_type, day)
-        if key not in _active_cache:
-            _active_cache[key] = [
-                t for t in pct_tariffs_by_type.get(energy_type, []) if _tariff_is_active(t, day)
-            ]
-        return _active_cache[key]
+    tariffs = TariffResolver(tariffs_list)
     # ─── 7. Per-reading HT/NT-aware pricing with timestamp allocation ─────
     local_kwh_acc = Decimal("0")
     grid_kwh_acc = Decimal("0")
 
-    item_accumulators: dict[str, dict[str, Decimal | str | Tariff]] = {}
-
-    def accumulate_item(
-        *,
-        tariff: Tariff,
-        quantity: Decimal,
-        total: Decimal,
-        unit: str,
-        base_total: Decimal | None = None,
-        bucket: str = "default",
-    ) -> None:
-        if quantity == 0 and total == 0:
-            return
-        key = f"{tariff.id}:{bucket}"
-        if key not in item_accumulators:
-            item_accumulators[key] = {
-                "tariff": tariff,
-                "quantity": Decimal("0"),
-                "total": Decimal("0"),
-                "unit": unit,
-                "base_total": Decimal("0"),
-            }
-        item_accumulators[key]["quantity"] += quantity
-        item_accumulators[key]["total"] += total
-        if base_total is not None:
-            item_accumulators[key]["base_total"] += base_total
+    items_accumulator = ItemAccumulator()
 
     for reading in participant_readings.order_by("timestamp").iterator():
         ts = reading.timestamp
@@ -506,15 +542,15 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
         # what a participant would normally pay for grid energy.
         grid_base_price_sum = sum(
             (_get_tariff_price(t, ts) or Decimal("0"))
-            for t in active_energy_tariffs_for(EnergyType.GRID, ts.date())
+            for t in tariffs.energy(EnergyType.GRID, ts.date())
         )
 
         for energy_type, quantity in ((EnergyType.LOCAL, r_local), (EnergyType.GRID, r_grid)):
             if quantity <= 0:
                 continue
-            for tariff in active_energy_tariffs_for(energy_type, ts.date()):
+            for tariff in tariffs.energy(energy_type, ts.date()):
                 price = _get_tariff_price(tariff, ts) or Decimal("0")
-                accumulate_item(
+                items_accumulator.add(
                     tariff=tariff,
                     quantity=quantity,
                     total=quantity * price,
@@ -523,9 +559,9 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
             # Percentage-of-energy tariffs: base is always the GRID rate sum,
             # applied to whichever energy_type the tariff is configured for.
-            for tariff in active_pct_tariffs_for(energy_type, ts.date()):
+            for tariff in tariffs.percentage(energy_type, ts.date()):
                 effective_price = grid_base_price_sum * (tariff.percentage / Decimal("100"))
-                accumulate_item(
+                items_accumulator.add(
                     tariff=tariff,
                     quantity=quantity,
                     total=quantity * effective_price,
@@ -550,13 +586,13 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
         grid_base_price_sum = sum(
             (_get_tariff_price(t, ts) or Decimal("0"))
-            for t in active_energy_tariffs_for(EnergyType.GRID, ts.date())
+            for t in tariffs.energy(EnergyType.GRID, ts.date())
         )
 
         if local_sold_kwh > 0:
-            for tariff in active_energy_tariffs_for(EnergyType.LOCAL, ts.date()):
+            for tariff in tariffs.energy(EnergyType.LOCAL, ts.date()):
                 price = _get_tariff_price(tariff, ts) or Decimal("0")
-                accumulate_item(
+                items_accumulator.add(
                     tariff=tariff,
                     quantity=local_sold_kwh,
                     total=-(local_sold_kwh * price),
@@ -564,9 +600,9 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
                     bucket="producer_credit",
                 )
 
-            for tariff in active_pct_tariffs_for(EnergyType.LOCAL, ts.date()):
+            for tariff in tariffs.percentage(EnergyType.LOCAL, ts.date()):
                 effective_price = grid_base_price_sum * (tariff.percentage / Decimal("100"))
-                accumulate_item(
+                items_accumulator.add(
                     tariff=tariff,
                     quantity=local_sold_kwh,
                     total=-(local_sold_kwh * effective_price),
@@ -576,9 +612,9 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
                 )
 
         if exported_kwh > 0:
-            for tariff in active_energy_tariffs_for(EnergyType.FEED_IN, ts.date()):
+            for tariff in tariffs.energy(EnergyType.FEED_IN, ts.date()):
                 price = _get_tariff_price(tariff, ts) or Decimal("0")
-                accumulate_item(
+                items_accumulator.add(
                     tariff=tariff,
                     quantity=exported_kwh,
                     total=-(exported_kwh * price),
@@ -608,7 +644,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
                 continue
             unit_price = (tariff.fixed_price_chf or Decimal("0")) / Decimal("12")
 
-        accumulate_item(
+        items_accumulator.add(
             tariff=tariff,
             quantity=quantity,
             total=quantity * unit_price,
@@ -621,7 +657,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
     item_payloads = []
     subtotal = Decimal("0")
-    for accumulator in item_accumulators.values():
+    for accumulator in items_accumulator:
         tariff = accumulator["tariff"]
         quantity = Decimal(accumulator["quantity"])
         total = Decimal(accumulator["total"])

--- a/backend/invoices/test_pricing_state.py
+++ b/backend/invoices/test_pricing_state.py
@@ -1,0 +1,229 @@
+"""Unit tests for ``TariffResolver`` and ``ItemAccumulator``.
+
+Both were closures inside ``generate_invoice``, capturing mutable state that
+nothing outside the function could reach. As objects their behaviour can be
+stated directly — in particular the two properties the caller silently depends
+on: that the resolver's memoisation is keyed on day as well as energy type, and
+that the accumulator preserves first-seen order, which the caller's stable sort
+uses to break ties between lines from the same tariff.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from tariffs.models import BillingMode, EnergyType, TariffCategory
+from testing import factories
+
+from .engine import ItemAccumulator, TariffResolver
+
+pytestmark = pytest.mark.django_db
+
+JAN = date(2026, 1, 15)
+JUN = date(2026, 6, 15)
+
+
+def energy_tariff(zev, *, energy_type=EnergyType.GRID, valid_from=date(2026, 1, 1), valid_to=None):
+    return factories.TariffFactory(
+        zev=zev, category=TariffCategory.ENERGY, billing_mode=BillingMode.ENERGY,
+        energy_type=energy_type, valid_from=valid_from, valid_to=valid_to,
+    )
+
+
+def percentage_tariff(zev, *, percentage="25", energy_type=EnergyType.LOCAL):
+    tariff = factories.TariffFactory(
+        zev=zev, category=TariffCategory.LEVIES,
+        billing_mode=BillingMode.PERCENTAGE_OF_ENERGY,
+        energy_type=energy_type, valid_from=date(2026, 1, 1),
+    )
+    tariff.percentage = Decimal(percentage) if percentage is not None else None
+    tariff.save()
+    return tariff
+
+
+# ---------------------------------------------------------------------------
+# TariffResolver
+# ---------------------------------------------------------------------------
+
+def test_energy_and_percentage_tariffs_land_in_separate_buckets():
+    zev = factories.ZevFactory()
+    energy = energy_tariff(zev, energy_type=EnergyType.LOCAL)
+    percentage = percentage_tariff(zev, energy_type=EnergyType.LOCAL)
+
+    resolver = TariffResolver([energy, percentage])
+
+    assert resolver.energy(EnergyType.LOCAL, JAN) == [energy]
+    assert resolver.percentage(EnergyType.LOCAL, JAN) == [percentage]
+
+
+def test_tariffs_are_separated_by_energy_type():
+    zev = factories.ZevFactory()
+    local = energy_tariff(zev, energy_type=EnergyType.LOCAL)
+    grid = energy_tariff(zev, energy_type=EnergyType.GRID)
+
+    resolver = TariffResolver([local, grid])
+
+    assert resolver.energy(EnergyType.LOCAL, JAN) == [local]
+    assert resolver.energy(EnergyType.GRID, JAN) == [grid]
+    assert resolver.energy(EnergyType.FEED_IN, JAN) == []
+
+
+def test_validity_is_evaluated_per_day_not_once():
+    """The cache is keyed on the day too. Getting this wrong would price a
+    whole period at whatever tariffs happened to be live on the first day."""
+    zev = factories.ZevFactory()
+    expiring = energy_tariff(zev, valid_to=date(2026, 3, 31))
+    later = energy_tariff(zev, valid_from=date(2026, 4, 1))
+
+    resolver = TariffResolver([expiring, later])
+
+    assert resolver.energy(EnergyType.GRID, JAN) == [expiring]
+    assert resolver.energy(EnergyType.GRID, JUN) == [later]
+
+
+def test_repeated_lookups_return_the_same_answer():
+    zev = factories.ZevFactory()
+    tariff = energy_tariff(zev)
+
+    resolver = TariffResolver([tariff])
+
+    assert resolver.energy(EnergyType.GRID, JAN) == [tariff]
+    assert resolver.energy(EnergyType.GRID, JAN) == [tariff]
+
+
+def test_a_percentage_tariff_without_a_percentage_is_ignored():
+    """A half-configured surcharge would otherwise price everything at zero."""
+    zev = factories.ZevFactory()
+    unconfigured = percentage_tariff(zev, percentage=None)
+
+    resolver = TariffResolver([unconfigured])
+
+    assert resolver.percentage(EnergyType.LOCAL, JAN) == []
+
+
+def test_fixed_fee_tariffs_are_not_bucketed_at_all():
+    """They are billed once per period, not per reading, so the per-reading
+    loops must never see them."""
+    zev = factories.ZevFactory()
+    fee = factories.TariffFactory(
+        zev=zev, category=TariffCategory.METERING, billing_mode=BillingMode.MONTHLY_FEE,
+        fixed_price_chf=Decimal("5.00"), valid_from=date(2026, 1, 1),
+    )
+
+    resolver = TariffResolver([fee])
+
+    assert resolver.energy(fee.energy_type, JAN) == []
+    assert resolver.percentage(fee.energy_type, JAN) == []
+
+
+def test_an_empty_tariff_list_resolves_to_nothing():
+    resolver = TariffResolver([])
+
+    assert resolver.energy(EnergyType.GRID, JAN) == []
+    assert resolver.percentage(EnergyType.LOCAL, JAN) == []
+
+
+# ---------------------------------------------------------------------------
+# ItemAccumulator
+# ---------------------------------------------------------------------------
+
+def test_repeated_adds_for_one_tariff_accumulate_into_a_single_entry():
+    zev = factories.ZevFactory()
+    tariff = energy_tariff(zev)
+    accumulator = ItemAccumulator()
+
+    accumulator.add(tariff=tariff, quantity=Decimal("2"), total=Decimal("0.40"), unit="kWh")
+    accumulator.add(tariff=tariff, quantity=Decimal("3"), total=Decimal("0.60"), unit="kWh")
+
+    entry, = list(accumulator)
+    assert entry["quantity"] == Decimal("5")
+    assert entry["total"] == Decimal("1.00")
+
+
+def test_buckets_keep_a_charge_and_a_credit_apart():
+    """A bidirectional participant is billed and credited under one tariff."""
+    zev = factories.ZevFactory()
+    tariff = energy_tariff(zev, energy_type=EnergyType.LOCAL)
+    accumulator = ItemAccumulator()
+
+    accumulator.add(tariff=tariff, quantity=Decimal("6"), total=Decimal("0.78"), unit="kWh")
+    accumulator.add(tariff=tariff, quantity=Decimal("3"), total=Decimal("-0.39"), unit="kWh",
+                    bucket="producer_credit")
+
+    assert len(accumulator) == 2
+    assert [entry["total"] for entry in accumulator] == [Decimal("0.78"), Decimal("-0.39")]
+
+
+def test_different_tariffs_never_share_an_entry():
+    zev = factories.ZevFactory()
+    accumulator = ItemAccumulator()
+
+    for energy_type in (EnergyType.LOCAL, EnergyType.GRID):
+        accumulator.add(tariff=energy_tariff(zev, energy_type=energy_type),
+                        quantity=Decimal("1"), total=Decimal("0.2"), unit="kWh")
+
+    assert len(accumulator) == 2
+
+
+def test_entries_come_back_in_first_seen_order():
+    """The caller sorts these with a stable sort and relies on this order to
+    break ties between lines that are otherwise indistinguishable."""
+    zev = factories.ZevFactory()
+    first = energy_tariff(zev, energy_type=EnergyType.LOCAL)
+    second = energy_tariff(zev, energy_type=EnergyType.GRID)
+    accumulator = ItemAccumulator()
+
+    accumulator.add(tariff=second, quantity=Decimal("1"), total=Decimal("1"), unit="kWh")
+    accumulator.add(tariff=first, quantity=Decimal("1"), total=Decimal("2"), unit="kWh")
+    accumulator.add(tariff=second, quantity=Decimal("1"), total=Decimal("3"), unit="kWh")
+
+    assert [entry["tariff"] for entry in accumulator] == [second, first]
+
+
+def test_a_wholly_empty_add_is_dropped():
+    """Keeps zero-value lines off the invoice."""
+    zev = factories.ZevFactory()
+    accumulator = ItemAccumulator()
+
+    accumulator.add(tariff=energy_tariff(zev), quantity=Decimal("0"), total=Decimal("0"), unit="kWh")
+
+    assert len(accumulator) == 0
+
+
+def test_a_zero_quantity_carrying_a_total_is_kept():
+    """A fee can be charged without a metered quantity behind it."""
+    zev = factories.ZevFactory()
+    accumulator = ItemAccumulator()
+
+    accumulator.add(tariff=energy_tariff(zev), quantity=Decimal("0"), total=Decimal("5"), unit="month")
+
+    assert len(accumulator) == 1
+
+
+def test_base_total_accumulates_only_when_supplied():
+    """Percentage tariffs carry the grid rate they were derived from; energy
+    tariffs pass nothing and must not be given a spurious base."""
+    zev = factories.ZevFactory()
+    tariff = percentage_tariff(zev)
+    accumulator = ItemAccumulator()
+
+    accumulator.add(tariff=tariff, quantity=Decimal("2"), total=Decimal("0.1"), unit="kWh",
+                    base_total=Decimal("0.4"))
+    accumulator.add(tariff=tariff, quantity=Decimal("2"), total=Decimal("0.1"), unit="kWh")
+
+    entry, = list(accumulator)
+    assert entry["base_total"] == Decimal("0.4")
+    assert entry["quantity"] == Decimal("4")
+
+
+def test_the_unit_of_the_first_add_wins():
+    zev = factories.ZevFactory()
+    tariff = energy_tariff(zev)
+    accumulator = ItemAccumulator()
+
+    accumulator.add(tariff=tariff, quantity=Decimal("1"), total=Decimal("1"), unit="kWh")
+    accumulator.add(tariff=tariff, quantity=Decimal("1"), total=Decimal("1"), unit="month")
+
+    entry, = list(accumulator)
+    assert entry["unit"] == "kWh"


### PR DESCRIPTION
PR 3 of 4 on `generate_invoice` (#8). Replaces the three closures inside it — `active_energy_tariffs_for`, `active_pct_tariffs_for`, `accumulate_item` — with `TariffResolver` and `ItemAccumulator`.

They were closures only because a function had nowhere else to keep state. Between them they captured a tariff bucketing, a memoisation cache and the item dictionary, none of which anything outside `generate_invoice` could reach or test.

`generate_invoice` is now **316 lines**, down from 375 before PR 2.

## Equivalence

The six-participant golden fingerprint from #345 — every invoice field, every line item — is **byte-identical**. No `quantize` call is added, removed, or moved.

## Mutation counts

| mutation | new unit tests | end-to-end engine suite |
|---|---|---|
| cache key drops the day | 1 fail | 1 fail |
| **percentage tariff needs no percentage set** | **1 fail** | **0 fail** |
| accumulator ignores the bucket | 1 fail | 2 fail |
| **empty adds are kept** | **1 fail** | **0 fail** |

Two are invisible end-to-end: a percentage tariff with no `percentage` configured — which would price a surcharge at zero — and zero-value invoice lines, which would simply start appearing on invoices.

## Two properties the caller depends on silently

Both now pinned, neither previously checked:

- **The resolver's cache is keyed on the day**, not just the energy type. Losing that would price an entire period at whatever tariffs happened to be live on its first day — a whole-period mispricing from a one-token change.
- **The accumulator yields entries in first-seen order**, which the caller's stable sort relies on to break ties between lines from the same tariff.

## One mutant survived, and it should have

Accumulating `base_total or Decimal("0")` unconditionally instead of guarding on `None` survives **both** suites. That's an *equivalent mutant*, not a gap: `None` and `Decimal("0")` are both falsy, so adding zero and skipping the add are indistinguishable. Recorded in the commit message so the next person doesn't go hunting for a missing test.

`ruff check .` clean; suite 598 → 613.

## Next

4. split the remaining phases — data gathering into a dataclass, fixed-fee pricing, totals — leaving `generate_invoice` as orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)