### PR TITLE
fix(settings): reject insecure SECRET_KEY placeholders in production

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -76,6 +76,9 @@ jobs:
             - name: Lint
               run: ruff check .
 
+            - name: Create .env from example
+              run: cp .env.example .env
+
             - name: Django system check
               run: python manage.py check
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
 # Copy this file to .env and adjust values
+# The SECRET_KEY placeholder below is rejected at startup when DEBUG=False.
 SECRET_KEY=change-me-in-production-use-a-long-random-string
 DEBUG=True
 ALLOWED_HOSTS=localhost,127.0.0.1

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -4,6 +4,7 @@ All sensitive values are read from environment variables (or a .env file).
 """
 from pathlib import Path
 import environ
+from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -12,9 +13,18 @@ env = environ.Env(
 )
 environ.Env.read_env(BASE_DIR / ".env")
 
-SECRET_KEY = env("SECRET_KEY", default="dev-insecure-key-change-in-production")
+SECRET_KEY = env("SECRET_KEY", default="change-me-in-production-use-a-long-random-string")
 DEBUG = env("DEBUG")
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
+
+# Fail fast if the insecure placeholder reaches a DEBUG=False deployment.
+_INSECURE_SECRET_KEY = "change-me-in-production-use-a-long-random-string"  # default above, .env.example & Helm
+if not DEBUG and SECRET_KEY == _INSECURE_SECRET_KEY:
+    raise ImproperlyConfigured(
+        "SECRET_KEY is an insecure placeholder; generate a long random key "
+        '(e.g. python -c "import secrets; print(secrets.token_urlsafe(64))") '
+        "and set it in the environment when DEBUG=False."
+    )
 
 # ── Applications ─────────────────────────────────────────────────────────────
 INSTALLED_APPS = [


### PR DESCRIPTION
Fail fast at startup when DEBUG=False and SECRET_KEY is the insecure placeholder instead of silently running with a guessable key. The fallback default, .env.example and the Helm chart share one placeholder (change-me-in-production-use-a-long-random-string). The .env.example notes that the placeholder is rejected.

CI has no .env, so create one from .env.example before running checks and tests; its DEBUG=True keeps the guard quiet while exercising the real config-loading path.