### PR TITLE
fix(accounts): make IsZevOwnerOrAdmin check admin role explicitly

### DIFF
--- a/backend/accounts/permissions.py
+++ b/backend/accounts/permissions.py
@@ -8,7 +8,9 @@ class IsAdmin(BasePermission):
 
 class IsZevOwnerOrAdmin(BasePermission):
     def has_permission(self, request, view):
-        return request.user.is_authenticated and request.user.is_zev_owner
+        return request.user.is_authenticated and (
+            request.user.is_zev_owner or request.user.is_admin
+        )
 
 
 class IsParticipantOrAbove(BasePermission):

--- a/docs/specs/2026-03-community-and-access.md
+++ b/docs/specs/2026-03-community-and-access.md
@@ -166,7 +166,7 @@ Defined in `accounts/permissions.py` and `zev/permissions.py`.
 | Class | Location | Logic |
 |---|---|---|
 | `IsAdmin` | `accounts` | `user.is_authenticated AND user.is_admin` |
-| `IsZevOwnerOrAdmin` | `accounts` | `user.is_authenticated AND user.is_zev_owner` (note: `is_zev_owner` is true for both admin and zev_owner roles) |
+| `IsZevOwnerOrAdmin` | `accounts` | `user.is_authenticated AND (user.is_zev_owner OR user.is_admin)` |
 | `IsParticipantOrAbove` | `accounts` | `user.is_authenticated` |
 | `BaseZevScopedPermission` | `zev` | Base class for ZEV-tenant-aware permissions; checks `has_permission` (role gate) and `has_object_permission` (ZEV ownership check) |
 | `ZevManagementPermission` | `zev` | Extends `BaseZevScopedPermission`; POST restricted to admin only |


### PR DESCRIPTION
The permission relied on is_zev_owner implicitly including admins. Check is_admin directly so the class honors its name even if the is_zev_owner property is refactored.