### PR TITLE
fix(invoices): close unauthorized invoice creation via generic POST endpoint

### DIFF
--- a/backend/invoices/serializers.py
+++ b/backend/invoices/serializers.py
@@ -38,7 +38,28 @@ class InvoiceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Invoice
         fields = "__all__"
-        read_only_fields = ["id", "invoice_number", "created_at", "updated_at", "pdf_file"]
+        read_only_fields = [
+            "id",
+            "invoice_number",
+            "created_at",
+            "updated_at",
+            "pdf_file",
+            # Managed by workflow actions / billing engine, never by client input:
+            "status",
+            "total_local_kwh",
+            "total_grid_kwh",
+            "total_feed_in_kwh",
+            "subtotal_chf",
+            "vat_rate",
+            "vat_chf",
+            "total_chf",
+            "period_start",
+            "period_end",
+            "zev",
+            "participant",
+            "sent_at",
+            "due_date",
+        ]
 
     def get_pdf_url(self, obj):
         if obj.pdf_file:

--- a/backend/invoices/tests.py
+++ b/backend/invoices/tests.py
@@ -249,6 +249,55 @@ class InvoiceRBACTests(TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertTrue(Invoice.objects.filter(pk=inv.pk).exists())
 
+    def test_generic_create_returns_405(self):
+        """The generic POST create endpoint is removed; only generate() creates invoices."""
+        auth(self.client, self.admin)
+        resp = self.client.post(
+            "/api/v1/invoices/invoices/",
+            {"zev": str(self.zev1.pk), "participant": str(self.p1.pk)},
+        )
+        self.assertEqual(resp.status_code, 405)
+
+    def test_participant_cannot_create_invoice_via_generic_endpoint(self):
+        """Participants get 405 (endpoint doesn't exist) rather than a 403."""
+        auth(self.client, self.puser)
+        resp = self.client.post(
+            "/api/v1/invoices/invoices/",
+            {"zev": str(self.zev1.pk), "participant": str(self.p1.pk)},
+        )
+        self.assertEqual(resp.status_code, 405)
+
+    def test_serializer_ignores_forged_billing_fields(self):
+        """Defense-in-depth: billing/workflow fields are read-only on the serializer."""
+        from invoices.serializers import InvoiceSerializer
+
+        s = InvoiceSerializer(
+            data={
+                "zev": str(self.zev1.pk),
+                "participant": str(self.p1.pk),
+                "status": InvoiceStatus.PAID,
+                "total_chf": "9999.99",
+                "subtotal_chf": "9999.99",
+                "vat_chf": "0.00",
+                "period_start": "2026-01-01",
+                "period_end": "2026-01-31",
+                "notes": "legit note",
+            }
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+        for field in (
+            "zev",
+            "participant",
+            "status",
+            "total_chf",
+            "subtotal_chf",
+            "vat_chf",
+            "period_start",
+            "period_end",
+        ):
+            self.assertNotIn(field, s.validated_data)
+        self.assertEqual(s.validated_data.get("notes"), "legit note")
+
 class InvoiceBillingIntegrationTests(TestCase):
     def setUp(self):
         self.client = APIClient()

--- a/backend/invoices/views.py
+++ b/backend/invoices/views.py
@@ -52,7 +52,6 @@ def _record_invoice_event(*, invoice: Invoice | None = None, target_id: str = ""
 
 class InvoiceViewSet(
     ZevScopedQuerySetMixin,
-    mixins.CreateModelMixin,
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
     mixins.DestroyModelMixin,
@@ -60,10 +59,10 @@ class InvoiceViewSet(
 ):
     """Invoices are mutated only through the dedicated workflow actions below
     (generate/approve/mark-sent/mark-paid/cancel etc.), each of which is
-    permission-checked and audit-logged. Generic update/partial_update is
-    intentionally not exposed — it would let any caller with read access to
-    an invoice overwrite status, totals, or participant/zev directly, bypassing
-    those workflow guards and leaving no audit trail.
+    permission-checked and audit-logged. Generic create/update/partial_update
+    are intentionally not exposed — they would let any caller with read access
+    to an invoice overwrite status, totals, or participant/zev directly,
+    bypassing those workflow guards and leaving no audit trail.
     """
 
     serializer_class = InvoiceSerializer

--- a/docs/specs/2026-03-invoice-lifecycle-and-communication.md
+++ b/docs/specs/2026-03-invoice-lifecycle-and-communication.md
@@ -180,7 +180,7 @@ Engine regeneration operates inside `@transaction.atomic`.  The match key is
 
 ## 5. API endpoints
 
-All invoice endpoints are routed under `/api/v1/invoices/invoices/` via a DRF `ModelViewSet` + custom actions.
+All invoice endpoints are routed under `/api/v1/invoices/invoices/` via a DRF `GenericViewSet` (list/retrieve/destroy mixins) + custom actions.
 
 ### 5.1 CRUD
 
@@ -479,7 +479,7 @@ Returns all invoice fields plus:
 - `participant_name`: derived from `participant.full_name`.
 - `pdf_url`: absolute URL to PDF file (or `null`).
 
-Read-only fields: `id`, `invoice_number`, `created_at`, `updated_at`, `pdf_file`.
+Read-only fields: `id`, `invoice_number`, `created_at`, `updated_at`, `pdf_file`, plus all billing-engine/workflow fields that never come from client input: `status`, `total_local_kwh`, `total_grid_kwh`, `total_feed_in_kwh`, `subtotal_chf`, `vat_rate`, `vat_chf`, `total_chf`, `period_start`, `period_end`, `zev`, `participant`, `sent_at`, `due_date`. Generic create/update/partial_update endpoints are not exposed; creation happens only via `generate`/`generate-all`, mutations only via the workflow actions.
 
 ### 9.2 InvoiceItemSerializer
 
@@ -532,7 +532,7 @@ Strips legacy period suffixes from `description` on serialization.
 
 | Test class | Validates |
 |---|---|
-| `InvoiceRBACTests` | §6: admin sees all, owner sees own ZEV, participant sees own invoices; participant cannot approve/cancel; PDF template access restricted to admin; deletion rules by role and status |
+| `InvoiceRBACTests` | §6: admin sees all, owner sees own ZEV, participant sees own invoices; participant cannot approve/cancel; PDF template access restricted to admin; deletion rules by role and status; generic POST create returns 405 (creation only via generate); serializer ignores forged billing/workflow fields |
 | `InvoiceWorkflowTests` | §4.2: approve draft ✓, approve non-draft ✗, mark-sent from approved ✓, mark-sent from draft ✗, mark-paid from sent ✓, mark-paid from draft ✗, cancel from draft/approved/sent ✓, cancel from paid ✗, cancel already-cancelled ✗ |
 | `InvoiceEngineGuardTests` | §4.4: regenerate approved/paid → 409, regenerate draft/cancelled → success |
 | `InvoiceBillingIntegrationTests` | §5.2: end-to-end generation via API with metering data |


### PR DESCRIPTION
InvoiceViewSet inherited CreateModelMixin with base IsAuthenticated permission, letting any authenticated user POST forged invoices (arbitrary zev/participant/status/totals) and bypass the workflow actions and their ownership guards. Invoice creation is meant to happen only via the generate/generate-all actions.

- Remove CreateModelMixin so POST /api/v1/invoices/invoices/ returns 405
- Mark billing-engine/workflow fields read-only on InvoiceSerializer (status, totals, vat, period, zev, participant, sent_at, due_date) as defense-in-depth. No generic update endpoint is exposed either, so in practice no invoice field is client-writable via the API.
- Update viewset docstring
- Add regression tests: 405 for admin/participant create, and serializer drops forged billing fields
- Update baseline spec (invoice lifecycle): read-only field list (§9.1), viewset type (§5), RBAC test coverage map (§10)