### PR TITLE
fix(accounts): stop exposing feature flags to anonymous callers

### DIFF
--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -3,6 +3,8 @@ from django.core import mail
 from django.test.utils import override_settings
 from rest_framework.test import APIClient
 from urllib.parse import parse_qs, urlparse
+import os
+from unittest import mock
 
 from .models import (
 	AppSettings,
@@ -183,14 +185,65 @@ class RegistrationTests(TestCase):
 
 
 class FeatureFlagsApiTests(TestCase):
-	def test_feature_flags_list_is_public_and_contains_self_registration_flag(self):
+	def test_feature_flags_list_requires_admin(self):
 		client = APIClient()
+		# Anonymous callers are rejected with 401 (unauthenticated).
 		resp = client.get("/api/v1/auth/feature-flags/")
+		self.assertEqual(resp.status_code, 401)
 
+		# Non-admin authenticated callers are denied with 403.
+		User.objects.create_user(username="owner_ff", password="pass1234", role=UserRole.ZEV_OWNER)
+		_cookie_auth(client, "owner_ff", "pass1234")
+		resp = client.get("/api/v1/auth/feature-flags/")
+		self.assertEqual(resp.status_code, 403)
+
+	def test_feature_flags_list_visible_to_admin(self):
+		client = APIClient()
+		User.objects.create_user(username="admin_ff", password="pass1234", role=UserRole.ADMIN)
+		_cookie_auth(client, "admin_ff", "pass1234")
+
+		resp = client.get("/api/v1/auth/feature-flags/")
 		self.assertEqual(resp.status_code, 200)
 		self.assertTrue(
 			any(flag["name"] == FeatureFlag.ZEV_SELF_REGISTRATION_ENABLED for flag in resp.data)
 		)
+
+	def test_registration_enabled_is_public_and_minimal(self):
+		client = APIClient()
+		resp = client.get("/api/v1/auth/registration-enabled/")
+
+		self.assertEqual(resp.status_code, 200)
+		# Only a boolean is exposed — no flag names/descriptions leak.
+		self.assertEqual(set(resp.data.keys()), {"enabled"})
+		self.assertIsInstance(resp.data["enabled"], bool)
+
+	def test_registration_enabled_reflects_disabled_flag(self):
+		# Guard against a FEATURE_* env-var override shadowing the DB value.
+		env_key = f"FEATURE_{FeatureFlag.ZEV_SELF_REGISTRATION_ENABLED.upper()}"
+		with mock.patch.dict("os.environ"):
+			os.environ.pop(env_key, None)
+			FeatureFlag.sync_defaults()
+			flag = FeatureFlag.objects.get(name=FeatureFlag.ZEV_SELF_REGISTRATION_ENABLED)
+			flag.enabled = False
+			flag.save(update_fields=["enabled"])
+
+			resp = APIClient().get("/api/v1/auth/registration-enabled/")
+
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data, {"enabled": False})
+
+	def test_anonymous_access_does_not_write_feature_flags(self):
+		# The public endpoint must be read-only: no default-sync writes.
+		self.assertEqual(FeatureFlag.objects.count(), 0)
+
+		resp = APIClient().get("/api/v1/auth/registration-enabled/")
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(FeatureFlag.objects.count(), 0)
+
+		# The admin-only list is denied before its body (and sync) runs.
+		resp = APIClient().get("/api/v1/auth/feature-flags/")
+		self.assertEqual(resp.status_code, 401)
+		self.assertEqual(FeatureFlag.objects.count(), 0)
 
 
 class ImpersonationTests(TestCase):

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -4,7 +4,7 @@ from .views import (
     UserListCreateView,
     UserDetailView, me, change_password, app_settings,
     VatRateListCreateView, VatRateDetailView,
-    feature_flags_list, feature_flag_update,
+    feature_flags_list, feature_flag_update, registration_enabled,
     register, verify_email, set_initial_password,
 )
 from .views_oauth import (
@@ -40,6 +40,7 @@ urlpatterns = [
     path("vat-rates/<int:pk>/", VatRateDetailView.as_view(), name="vat-rate-detail"),
     path("feature-flags/", feature_flags_list, name="feature-flags-list"),
     path("feature-flags/<int:pk>/", feature_flag_update, name="feature-flag-update"),
+    path("registration-enabled/", registration_enabled, name="registration-enabled"),
     # OAuth provider config (admin)
     path("oauth/providers/config/", OAuthProviderListCreateView.as_view(), name="oauth-provider-list-create"),
     path("oauth/providers/config/<int:pk>/", OAuthProviderDetailView.as_view(), name="oauth-provider-detail"),

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -342,12 +342,31 @@ def app_settings(request):
 
 
 @api_view(["GET"])
-@permission_classes([AllowAny])
+@permission_classes([IsAuthenticated, IsAdmin])
 def feature_flags_list(request):
-    """Return all feature flags. Public read access is allowed."""
+    """Return all feature flags. Admin-only.
+
+    Anonymous callers must not be able to enumerate internal flags; the
+    login page uses the dedicated ``registration-enabled`` endpoint instead.
+    Syncing defaults here is safe because only admins reach this view, so the
+    unauthenticated write-amplification concern no longer applies.
+    """
     FeatureFlag.sync_defaults()
     flags = FeatureFlag.objects.all()
     return Response(FeatureFlagSerializer(flags, many=True).data)
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def registration_enabled(request):
+    """Public, minimal endpoint exposing only whether self-registration is on.
+
+    Returns a single boolean so the login page can decide whether to show the
+    registration link, without enumerating the feature-flag table.
+    """
+    return Response(
+        {"enabled": FeatureFlag.is_enabled(FeatureFlag.ZEV_SELF_REGISTRATION_ENABLED)}
+    )
 
 
 @api_view(["PATCH"])

--- a/docs/specs/2026-03-community-and-access.md
+++ b/docs/specs/2026-03-community-and-access.md
@@ -552,6 +552,9 @@ The sidebar (`Layout.tsx`) shows sections conditionally:
 | GET / PATCH | `/app-settings/` | IsAuthenticated (update: admin only) | Application settings singleton |
 | GET / POST | `/vat-rates/` | IsAdmin | VAT rate management |
 | GET / PATCH / DELETE | `/vat-rates/{id}/` | IsAdmin | VAT rate detail |
+| GET | `/feature-flags/` | IsAuthenticated, IsAdmin | List all feature flags (admin-only; syncs defaults on read) |
+| PATCH | `/feature-flags/{id}/` | IsAuthenticated (admin only) | Toggle a feature flag |
+| GET | `/registration-enabled/` | AllowAny | Public, minimal `{enabled: bool}` — self-registration status for the login page (no flag enumeration) |
 
 ### 10.2 ZEV endpoints (`/api/v1/zev/`)
 

--- a/docs/user-guide/14-admin-console.md
+++ b/docs/user-guide/14-admin-console.md
@@ -251,7 +251,13 @@ This ensures the feature is disabled in both UI and API layers.
 #### Read feature flags
 
 - `GET /api/v1/auth/feature-flags/`
-- Public read access (used by login page)
+- Admin only (returns the full flag list; used by the admin console)
+
+#### Read self-registration status (public)
+
+- `GET /api/v1/auth/registration-enabled/`
+- Public, returns only `{"enabled": bool}` (used by the login page; does not
+  enumerate the flag table)
 
 #### Update a feature flag
 
@@ -288,4 +294,6 @@ if FeatureFlag.is_enabled("my_new_feature"):
     ...
 ```
 
-Frontend code can read current states via `GET /api/v1/auth/feature-flags/`.
+Frontend admin pages read the full list via `GET /api/v1/auth/feature-flags/`
+(admin only). Public, unauthenticated code (e.g. the login page) must use the
+minimal `GET /api/v1/auth/registration-enabled/` endpoint instead.

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -65,6 +65,11 @@ export async function fetchFeatureFlags(): Promise<FeatureFlag[]> {
   return data
 }
 
+export async function fetchRegistrationEnabled(): Promise<boolean> {
+  const { data } = await api.get<{ enabled: boolean }>('/auth/registration-enabled/')
+  return data.enabled
+}
+
 export async function updateFeatureFlag(id: number, payload: FeatureFlagInput): Promise<FeatureFlag> {
   const { data } = await api.patch<FeatureFlag>(`/auth/feature-flags/${id}/`, payload)
   return data

--- a/frontend/src/lib/api/queryKeys.ts
+++ b/frontend/src/lib/api/queryKeys.ts
@@ -4,6 +4,7 @@ export const queryKeys = {
     appSettings: () => ['auth', 'app-settings'] as const,
     users: () => ['auth', 'users'] as const,
     featureFlags: () => ['auth', 'feature-flags'] as const,
+    registrationEnabled: () => ['auth', 'registration-enabled'] as const,
     vatRates: () => ['auth', 'vat-rates'] as const,
     oauthProviders: () => ['auth', 'oauth-providers'] as const,
     socialAccounts: () => ['auth', 'social-accounts'] as const,

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,7 +4,7 @@ import AppFooter from '../components/AppFooter'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../lib/auth'
-import { fetchFeatureFlags, fetchOAuthProviders, oauthLoginInitiate, register as apiRegister } from '../lib/api/auth'
+import { fetchRegistrationEnabled, fetchOAuthProviders, oauthLoginInitiate, register as apiRegister } from '../lib/api/auth'
 import { formatApiError } from '../lib/api/errors'
 import { queryKeys } from '../lib/api/queryKeys'
 
@@ -13,8 +13,8 @@ export function LoginPage() {
     const navigate = useNavigate()
     const { login } = useAuth()
     const featureFlagsQuery = useQuery({
-        queryKey: queryKeys.auth.featureFlags(),
-        queryFn: fetchFeatureFlags,
+        queryKey: queryKeys.auth.registrationEnabled(),
+        queryFn: fetchRegistrationEnabled,
         staleTime: 60_000,
     })
     const oauthProvidersQuery = useQuery({
@@ -36,9 +36,10 @@ export function LoginPage() {
     const [regError, setRegError] = useState<string | null>(null)
     const [regLoading, setRegLoading] = useState(false)
     const [regSuccess, setRegSuccess] = useState<string | null>(null)
-    const selfRegistrationEnabled = featureFlagsQuery.data?.find(
-        (flag) => flag.name === 'zev_self_registration_enabled',
-    )?.enabled ?? true
+    // Fail closed: if the registration-enabled request is missing, errored, or
+    // blocked, do not advertise self-registration. The backend still enforces
+    // the flag, so this only affects UI/operational correctness.
+    const selfRegistrationEnabled = featureFlagsQuery.data === true
 
     const oauthProviders = oauthProvidersQuery.data ?? []
 


### PR DESCRIPTION
The feature-flag list endpoint was AllowAny and returned the entire FeatureFlag table, so any anonymous caller could enumerate internal capability flags and their descriptions (OWASP excessive data exposure). Only the login page needs public access, and only for a single boolean.

- Gate /auth/feature-flags/ behind IsAuthenticated + IsAdmin
- Add /auth/registration-enabled/ (AllowAny) returning just {enabled} via FeatureFlag.is_enabled(), which is read-only and writes nothing
- Point LoginPage at the new minimal endpoint and fail closed (data === true) so an errored request does not advertise registration
- Update tests: admin-only list (401 anon / 403 non-admin), disabled-flag contract, and anonymous-read-only (no default-sync writes) regression
- Document the endpoints in the access baseline spec and user guide