### PR TITLE
test(backend): isolate MEDIA_ROOT via session fixture

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -11,10 +11,24 @@ fixtures are additive and only apply to pytest-style test functions.
 from __future__ import annotations
 
 import pytest
+from django.test import override_settings
 from rest_framework.test import APIClient
-
 from testing import factories
 from testing.helpers import authenticate
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _isolated_media(tmp_path_factory):
+    """Redirect MEDIA_ROOT to a temporary directory for the entire test run.
+
+    Prevents tests that call ``FileField.save()`` from writing into the
+    project's ``media/`` directory.  The directory is removed after all tests
+    finish.  ``override_settings`` (rather than direct assignment) fires the
+    ``setting_changed`` signal so cached storage locations are reset.
+    """
+    tmp = tmp_path_factory.mktemp("media")
+    with override_settings(MEDIA_ROOT=str(tmp)):
+        yield
 
 
 @pytest.fixture

--- a/backend/invoices/test_email_formatting.py
+++ b/backend/invoices/test_email_formatting.py
@@ -1,9 +1,9 @@
+from accounts.models import AppSettings, UserRole
 from django.core import mail
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from accounts.models import AppSettings, UserRole
 from invoices.models import InvoiceStatus
 from invoices.tasks import send_invoice_email_task
 from invoices.test_helpers import make_invoice, make_participant, make_user, make_zev
@@ -11,7 +11,6 @@ from invoices.test_helpers import make_invoice, make_participant, make_user, mak
 
 @override_settings(
     EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    MEDIA_ROOT="/tmp/openzev_test_media",
 )
 class InvoiceEmailFormattingTests(TestCase):
     def test_email_uses_configured_short_date_format(self):


### PR DESCRIPTION
5 tests fail in CI with `PermissionError: [Errno 13] Permission denied: '/app'` because `FileField.save()` writes to `MEDIA_ROOT=/app/media` which is non-writable on the GitHub Actions runner.

**Failing tests** (e.g. [#349](https://github.com/splattner/openzev/pull/349)):
- `invoices/test_batch_actions.py::TestInvoiceBatchActions::test_download_pdfs_returns_zip_for_available_pdfs`
- `invoices/test_email_task.py::test_no_recipient_skips_and_logs_failed`
- `invoices/test_email_task.py::test_successful_send_records_sent_log_and_transitions_status`
- `invoices/test_email_task.py::test_send_failure_marks_log_failed_and_retries`
- `invoices/test_email_task.py::test_draft_invoice_stays_draft_after_send`

Adds a session-scoped, autouse `_isolated_media` fixture that redirects `MEDIA_ROOT` to a pytest temp directory via `override_settings`, which fires the `setting_changed` signal to reset cached storage locations.

Also removes the now-redundant hardcoded `MEDIA_ROOT` override from `InvoiceEmailFormattingTests`.