### PR TITLE
refactor(frontend): unify admin summary stats on StatCard and fix collapsed labels

### DIFF
--- a/docs/specs/2026-03-admin-governance-and-settings.md
+++ b/docs/specs/2026-03-admin-governance-and-settings.md
@@ -361,6 +361,7 @@ redirect to the matching tab on this page.
 **File:** `frontend/src/pages/AdminVatSettingsPage.tsx`
 
 - Query: `useQuery({ queryKey: ['vat-rates'], queryFn: fetchVatRates })`.
+- **Summary cards:** three `StatCard` components above the form — configured rate count, today's active rate (percentage, or the translated "none" label), and count of scheduled rates with `valid_from` in the future.
 - **Create/Edit form:** 3 fields (rate %, valid_from date, valid_to date optional). Default rate: `8.1`. The frontend converts percentage to fraction before sending (`(percentage / 100).toFixed(4)`).
 - **Rate table:** displays rate as percentage (`(rate × 100).toFixed(2)%`), valid_from (formatted), valid_to (formatted or "Open"), with Edit/Delete buttons.
 - **Delete:** Uses `ConfirmDialog` component for destructive confirmation.

--- a/docs/specs/2026-04-frontend-management-page-design.md
+++ b/docs/specs/2026-04-frontend-management-page-design.md
@@ -42,7 +42,7 @@ in the frontend.
 | Action hierarchy | Primary, secondary, overflow, destructive, modal footer actions |
 | Icon treatment | Font Awesome icon + label buttons, fixed-width icon alignment |
 | Page grouping patterns | When to use sections, nested cards, tables, DataGrid, or tabs |
-| Shared primitives | `ActionMenu`, `ConfirmDialog`, `FormModal`, `BillingPeriodSelector` |
+| Shared primitives | `ActionMenu`, `ConfirmDialog`, `FormModal`, `BillingPeriodSelector`, `StatCard` |
 | I18n constraints | User-facing text in locale files only; translated labels must not encode visual symbols |
 | Responsive behaviour | Management pages must remain usable on mobile and reduced-width layouts |
 | Reference pages | `ParticipantsPage`, `MeteringPointsPage`, `InvoicesPage`, `ImportsPage`, `TariffsPage` |
@@ -93,6 +93,7 @@ defined by shared frontend primitives and CSS contracts.
 | `frontend/src/components/ConfirmDialog.tsx` | `useConfirmDialog`, `ConfirmDialog` | Required wrapper for destructive or high-impact actions. Supports `title`, `message`, `confirmText`, `cancelText`, `isDangerous`, and async confirm handlers. |
 | `frontend/src/components/FormModal.tsx` | `FormModal` | Generic modal shell for CRUD forms and small workflow dialogs. |
 | `frontend/src/components/BillingPeriodSelector.tsx` | `BillingPeriodSelector` | Specialized period-navigation control for invoice workflows; uses the same button language as management-page actions. |
+| `frontend/src/components/StatCard.tsx` | `StatCard` | Summary-stat card for page-level counts and metrics. Renders a `stat-label`, an `h3` value, and an optional muted `hint`. Pages must use it instead of hand-rolled `.stat-card` markup so summary stats stay visually consistent. |
 
 ### 4.2 CSS contracts
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -945,6 +945,20 @@ label {
   flex-direction: column;
   align-items: flex-start;
   padding: 1.25rem;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 55px rgba(15, 23, 42, 0.13);
+}
+
+.stat-card h3 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+  color: #0f172a;
 }
 
 .stat-label {
@@ -953,7 +967,6 @@ label {
   color: #475569;
 }
 
-.stat-card h3,
 h2,
 h3 {
   margin: 0;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -941,6 +941,9 @@ label {
 }
 
 .stat-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   padding: 1.25rem;
 }
 

--- a/frontend/src/pages/AdminAccountsPage.tsx
+++ b/frontend/src/pages/AdminAccountsPage.tsx
@@ -4,6 +4,7 @@ import { faCheck, faCopy, faEllipsis, faLink, faPen, faPlus, faTrash, faUser, fa
 import { useState, type FormEvent } from 'react'
 import { ActionMenu } from '../components/ActionMenu'
 import { ConfirmDialog, useConfirmDialog } from '../components/ConfirmDialog'
+import { StatCard } from '../components/StatCard'
 import { FormModal } from '../components/FormModal'
 import {
     createParticipantAccount,
@@ -254,18 +255,9 @@ export function AdminAccountsPage() {
             </header>
 
             <section style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
-                <article className="stat-card">
-                    <div className="muted">{t('pages.accounts.stats.totalParticipants')}</div>
-                    <h3>{participants.length}</h3>
-                </article>
-                <article className="stat-card">
-                    <div className="muted">{t('pages.accounts.stats.linkedParticipants')}</div>
-                    <h3>{linkedParticipantsCount}</h3>
-                </article>
-                <article className="stat-card">
-                    <div className="muted">{t('pages.accounts.stats.standaloneAccounts')}</div>
-                    <h3>{standaloneAccountsCount}</h3>
-                </article>
+                <StatCard label={t('pages.accounts.stats.totalParticipants')} value={participants.length} />
+                <StatCard label={t('pages.accounts.stats.linkedParticipants')} value={linkedParticipantsCount} />
+                <StatCard label={t('pages.accounts.stats.standaloneAccounts')} value={standaloneAccountsCount} />
             </section>
 
             {credentialsNotice && (

--- a/frontend/src/pages/AdminVatSettingsPage.tsx
+++ b/frontend/src/pages/AdminVatSettingsPage.tsx
@@ -9,6 +9,7 @@ import { formatShortDate, useAppSettings } from '../lib/appSettings'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '../lib/toast'
 import { ConfirmDialog, useConfirmDialog } from '../components/ConfirmDialog'
+import { StatCard } from '../components/StatCard'
 import type { VatRateInput } from '../types/api'
 
 type VatRateFormState = {
@@ -108,20 +109,12 @@ export function AdminVatSettingsPage() {
                     gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
                 }}
             >
-                <article className="stat-card">
-                    <span className="eyebrow">{t('adminVatSettings.stats.total')}</span>
-                    <strong>{vatRates.length}</strong>
-                </article>
-                <article className="stat-card">
-                    <span className="eyebrow">{t('adminVatSettings.stats.active')}</span>
-                    <strong>
-                        {activeVatRate ? `${(Number(activeVatRate.rate) * 100).toFixed(2)}%` : t('adminVatSettings.stats.none')}
-                    </strong>
-                </article>
-                <article className="stat-card">
-                    <span className="eyebrow">{t('adminVatSettings.stats.scheduled')}</span>
-                    <strong>{futureVatRatesCount}</strong>
-                </article>
+                <StatCard label={t('adminVatSettings.stats.total')} value={vatRates.length} />
+                <StatCard
+                    label={t('adminVatSettings.stats.active')}
+                    value={activeVatRate ? `${(Number(activeVatRate.rate) * 100).toFixed(2)}%` : t('adminVatSettings.stats.none')}
+                />
+                <StatCard label={t('adminVatSettings.stats.scheduled')} value={futureVatRatesCount} />
             </section>
 
             <section className="card page-stack" style={{ maxWidth: 860 }}>


### PR DESCRIPTION
Two commits: a user-visible layout fix, then the consistency refactor
that builds on it.

---

fix(frontend): keep stat card labels and values on separate lines

.stat-card children were inline elements, so label and value collapsed
into one run of text. Make .stat-card a flex column so children stack.

---

refactor(frontend): unify admin summary stats on StatCard

Replace hand-rolled stat card markup in AdminVatSettingsPage and
AdminAccountsPage with the shared StatCard component. Add a value type
scale and hover lift to .stat-card; update affected specs.

---

Specs updated:
- docs/specs/2026-03-admin-governance-and-settings.md (§9.5 — VAT settings summary cards)
- docs/specs/2026-04-frontend-management-page-design.md (§2 shared primitives, §4.1 component table)

Note: `npm run test:unit` shows 2 pre-existing failures in `api-client-refresh.test.ts` when a local `.env` sets an absolute `VITE_API_BASE_URL`; they are fixed by #358.