### PR TITLE
docs: rework PR template and align validation commands with CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,19 @@
 ## Summary
-
-Describe what changed and why.
+<!-- What changed and why. Link issue: Closes #123 -->
 
 ## Linked spec
-
 - Spec: <!-- e.g. docs/specs/2026-03-foo.md -->
 - ADR (if architecture decision changed): <!-- e.g. docs/adr/0009-... -->
-
-If this PR is small and does not need a spec, explain why:
-
-<!-- e.g. isolated bugfix, no API or workflow impact -->
+- No spec needed because: <!-- e.g. isolated bugfix, no API or workflow impact -->
 
 ## Validation
-
-- Backend tests run: `python -m pytest metering/ accounts/ invoices/ -q`
-- Frontend build run: `npm run build`
-- Manual checks done:
-  - [ ] Role and ZEV scope behavior
-  - [ ] Billing/invoice correctness (if applicable)
-  - [ ] i18n coverage for user-facing frontend changes
+- Backend tests run: <!-- e.g. python -m pytest -q -->
+- Frontend build run: <!-- e.g. npm run build -->
+- Frontend tests run: <!-- e.g. npm run test:unit -->
+- Manual checks: <!-- e.g. role/ZEV scope, billing correctness, i18n -->
+- Screenshots: <!-- for user-facing frontend changes -->
 
 ## Checklist
-
-- [ ] I updated or linked a spec for larger/risky/cross-cutting changes
-- [ ] I updated or linked ADRs for architecture-level decisions
-- [ ] I updated backend and frontend together where API contracts changed
+- [ ] Spec updated/linked for larger or risky changes
+- [ ] ADR updated/linked for architecture decisions
+- [ ] Backend and frontend updated together where API contracts changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ This file gives coding agents the minimum project-specific context needed to wor
 From `backend/`:
 
 - Activate venv: `source ../.venv/bin/activate`
-- Run tests: `python -m pytest metering/ accounts/ invoices/ -q`
+- Run tests: `python -m pytest -q`
 - Run invoice tests only: `python -m pytest invoices/tests.py -q`
 
 ### Frontend
@@ -101,8 +101,8 @@ For detailed guidance, see `docs/specs/README.md` and `docs/adr/README.md`.
 
 After relevant changes:
 
-- Backend: run `python -m pytest metering/ accounts/ invoices/ -q`
-- Frontend: run `npm run build`
+- Backend: run `python -m pytest -q`
+- Frontend: run `npm run test:unit` and `npm run build`
 
 ## Safe Editing Guidance
 

--- a/docs/specs/2026-03-metering-point-management.md
+++ b/docs/specs/2026-03-metering-point-management.md
@@ -406,7 +406,7 @@ Tests are distributed across `metering/tests.py` and the invoice test suite.
 
 Test commands:
 ```
-python -m pytest metering/ accounts/ invoices/ -q
+python -m pytest -q
 ```
 
 ### Frontend


### PR DESCRIPTION
## Summary
Rework the PR template so authors record the validation they actually ran
(command placeholders instead of fixed, scope-mismatched commands), add
frontend test and screenshot lines, and make the "no spec needed"
rationale an explicit entry instead of an invisible comment.

Also fix the documented validation commands, which had drifted from CI
(`pr-quality.yml` runs the full backend suite and `npm run test:unit`):
the per-app pytest list in `AGENTS.md` and one baseline spec silently
skipped the `audit/`, `feasibility/`, `tariffs/`, and `zev/` test suites.

## Linked spec
- No spec needed because: docs-only change to contribution tooling; no API, workflow, or behavior impact.

## Validation
- Backend tests run: n/a (docs only)
- Frontend build run: n/a (docs only)
- Frontend tests run: n/a (docs only)
- Manual checks: grepped the repo for remaining references to the old per-app pytest command — none left
- Screenshots: n/a

## Checklist
- [x] Spec updated/linked for larger or risky changes — n/a
- [x] ADR updated/linked for architecture decisions — n/a
- [x] Backend and frontend updated together where API contracts changed — n/a