### PR TITLE
feat(audit): show event details in a side drawer with a real diff

### DIFF
--- a/frontend/src/features/audit/AuditEventDrawer.tsx
+++ b/frontend/src/features/audit/AuditEventDrawer.tsx
@@ -1,0 +1,155 @@
+import { useEffect } from 'react'
+import { Drawer } from '@mui/material'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faXmark } from '@fortawesome/free-solid-svg-icons'
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { fetchAuditEvent } from '../../lib/api/audit'
+import { queryKeys } from '../../lib/api/queryKeys'
+import { formatDateTime, useAppSettings } from '../../lib/appSettings'
+import type { AuditEventStatus } from '../../types/api'
+import { ChangesDiff } from './ChangesDiff'
+
+type AuditEventDrawerProps = {
+    eventId: string | null
+    onClose: () => void
+    statusBadgeClass: (status: AuditEventStatus) => string
+}
+
+function Field({ label, children }: { label: string, children: React.ReactNode }) {
+    return (
+        <div className="audit-detail-field">
+            <strong>{label}</strong>
+            <div>{children}</div>
+        </div>
+    )
+}
+
+export function AuditEventDrawer({ eventId, onClose, statusBadgeClass }: AuditEventDrawerProps) {
+    const { t } = useTranslation()
+    const { settings } = useAppSettings()
+
+    const eventQuery = useQuery({
+        queryKey: queryKeys.admin.auditEvent(eventId ?? ''),
+        queryFn: () => fetchAuditEvent(eventId ?? ''),
+        enabled: Boolean(eventId),
+    })
+
+    // The drawer is deliberately non-modal so the table behind it stays
+    // clickable — picking the next row swaps the contents in place, which is
+    // the whole point when stepping through a log. That costs us the Modal's
+    // own key handling, so Escape is wired up here.
+    useEffect(() => {
+        if (!eventId) return
+        function onKeyDown(event: KeyboardEvent) {
+            if (event.key === 'Escape') onClose()
+        }
+        document.addEventListener('keydown', onKeyDown)
+        return () => document.removeEventListener('keydown', onKeyDown)
+    }, [eventId, onClose])
+
+    const event = eventQuery.data
+
+    return (
+        <Drawer
+            anchor="right"
+            open={Boolean(eventId)}
+            onClose={onClose}
+            hideBackdrop
+            ModalProps={{ disableEnforceFocus: true, disableScrollLock: true }}
+            // Without a backdrop the Modal root still covers the viewport, so
+            // clicks would land on it instead of the table underneath.
+            sx={{
+                pointerEvents: 'none',
+                '& .MuiDrawer-paper': {
+                    pointerEvents: 'auto',
+                    width: { xs: '100%', sm: 460, lg: 560 },
+                    boxShadow: '-8px 0 24px -12px rgba(0, 0, 0, 0.35)',
+                },
+            }}
+        >
+            <div className="audit-drawer">
+                <header className="audit-drawer-header">
+                    <h3>{t('pages.auditLogs.detail.title')}</h3>
+                    <button
+                        type="button"
+                        className="button button-secondary"
+                        onClick={onClose}
+                        aria-label={t('pages.auditLogs.detail.close')}
+                    >
+                        <FontAwesomeIcon icon={faXmark} fixedWidth />
+                    </button>
+                </header>
+
+                <div className="audit-drawer-body page-stack">
+                    {eventQuery.isLoading && <p>{t('pages.auditLogs.detail.loading')}</p>}
+                    {eventQuery.isError && <p className="text-error">{t('pages.auditLogs.detail.loadError')}</p>}
+
+                    {event && (
+                        <>
+                            <p className="audit-drawer-summary">{event.summary}</p>
+
+                            <div className="audit-detail-grid">
+                                <Field label={t('pages.auditLogs.detail.createdAt')}>
+                                    {formatDateTime(event.created_at, settings)}
+                                </Field>
+                                <Field label={t('pages.auditLogs.detail.status')}>
+                                    <span className={statusBadgeClass(event.status)}>
+                                        {t(`pages.auditLogs.statuses.${event.status}`)}
+                                    </span>
+                                </Field>
+                                <Field label={t('pages.auditLogs.detail.category')}>
+                                    {t(`pages.auditLogs.categories.${event.action_category}`)}
+                                </Field>
+                                <Field label={t('pages.auditLogs.detail.action')}>
+                                    <code>{event.action_type}</code>
+                                </Field>
+                                <Field label={t('pages.auditLogs.detail.actor')}>
+                                    {event.actor_display || '—'}
+                                </Field>
+                                <Field label={t('pages.auditLogs.detail.source')}>
+                                    <code>{event.source}</code>
+                                </Field>
+                                <Field label={t('pages.auditLogs.detail.target')}>
+                                    {event.target_display || `${event.target_type}:${event.target_id || '-'}`}
+                                </Field>
+                                <Field label={t('pages.auditLogs.detail.requestId')}>
+                                    <code>{event.request_id || '—'}</code>
+                                </Field>
+                                <Field label={t('pages.auditLogs.detail.correlationId')}>
+                                    <code>{event.correlation_id || '—'}</code>
+                                </Field>
+                                <Field label={t('pages.auditLogs.detail.id')}>
+                                    <code>{event.id}</code>
+                                </Field>
+                            </div>
+
+                            {event.reason && (
+                                <div>
+                                    <strong>{t('pages.auditLogs.detail.reason')}</strong>
+                                    <p style={{ marginTop: '0.5rem' }}>{event.reason}</p>
+                                </div>
+                            )}
+
+                            <div>
+                                <strong>{t('pages.auditLogs.detail.changes')}</strong>
+                                <div style={{ marginTop: '0.5rem' }}>
+                                    <ChangesDiff changes={event.changes_json} />
+                                </div>
+                            </div>
+
+                            <div>
+                                <strong>{t('pages.auditLogs.detail.metadata')}</strong>
+                                <pre style={{ overflowX: 'auto' }}>
+                                    {event.metadata_json && Object.keys(event.metadata_json).length > 0
+                                        ? JSON.stringify(event.metadata_json, null, 2)
+                                        : '—'}
+                                </pre>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+        </Drawer>
+    )
+}

--- a/frontend/src/features/audit/ChangesDiff.tsx
+++ b/frontend/src/features/audit/ChangesDiff.tsx
@@ -1,0 +1,67 @@
+import { useTranslation } from 'react-i18next'
+
+/** One field's before/after pair, as produced by the backend's `build_diff`. */
+type FieldChange = { before: unknown; after: unknown }
+
+/**
+ * `changes_json` is a JSONField, so nothing guarantees its shape — hand-written
+ * call sites happen to follow `{field: {before, after}}` today, but old rows may
+ * hold anything. Only render the diff table when every entry actually matches;
+ * otherwise fall back to the raw JSON so no event becomes unreadable.
+ */
+function asFieldChanges(value: unknown): Record<string, FieldChange> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+    const entries = Object.entries(value as Record<string, unknown>)
+    if (entries.length === 0) return null
+
+    const conforms = entries.every(([, change]) =>
+        Boolean(change)
+        && typeof change === 'object'
+        && !Array.isArray(change)
+        && 'before' in (change as object)
+        && 'after' in (change as object),
+    )
+
+    return conforms ? (value as Record<string, FieldChange>) : null
+}
+
+function formatValue(value: unknown): string {
+    if (value === null || value === undefined || value === '') return '—'
+    if (typeof value === 'boolean') return value ? 'true' : 'false'
+    if (typeof value === 'object') return JSON.stringify(value)
+    return String(value)
+}
+
+export function ChangesDiff({ changes }: { changes: unknown }) {
+    const { t } = useTranslation()
+    const fieldChanges = asFieldChanges(changes)
+
+    if (!fieldChanges) {
+        const isEmpty = !changes
+            || (typeof changes === 'object' && Object.keys(changes as object).length === 0)
+        if (isEmpty) return <p className="muted">{t('pages.auditLogs.detail.noChanges')}</p>
+        return <pre style={{ overflowX: 'auto' }}>{JSON.stringify(changes, null, 2)}</pre>
+    }
+
+    return (
+        <table className="audit-diff">
+            <thead>
+                <tr>
+                    <th>{t('pages.auditLogs.detail.diffField')}</th>
+                    <th>{t('pages.auditLogs.detail.diffBefore')}</th>
+                    <th>{t('pages.auditLogs.detail.diffAfter')}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {Object.entries(fieldChanges).map(([field, change]) => (
+                    <tr key={field}>
+                        <td><code>{field}</code></td>
+                        <td className="audit-diff-before">{formatValue(change.before)}</td>
+                        <td className="audit-diff-after">{formatValue(change.after)}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    )
+}

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -480,6 +480,11 @@ export const de = {
                 reason: 'Begründung',
                 changes: 'Änderungen',
                 metadata: 'Metadaten',
+                close: 'Details schliessen',
+                noChanges: 'Für dieses Ereignis wurden keine Feldänderungen erfasst.',
+                diffField: 'Feld',
+                diffBefore: 'Vorher',
+                diffAfter: 'Nachher',
             },
         },
         feasibility: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -481,6 +481,11 @@ export const en = {
                 reason: 'Reason',
                 changes: 'Changes',
                 metadata: 'Metadata',
+                close: 'Close details',
+                noChanges: 'No field changes recorded for this event.',
+                diffField: 'Field',
+                diffBefore: 'Before',
+                diffAfter: 'After',
             },
         },
         feasibility: {

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -487,6 +487,11 @@ export const fr = {
                 reason: 'Motif',
                 changes: 'Modifications',
                 metadata: 'Métadonnées',
+                close: 'Fermer les détails',
+                noChanges: 'Aucune modification de champ enregistrée pour cet événement.',
+                diffField: 'Champ',
+                diffBefore: 'Avant',
+                diffAfter: 'Après',
             },
         },
         feasibility: {

--- a/frontend/src/i18n/locales/it.ts
+++ b/frontend/src/i18n/locales/it.ts
@@ -487,6 +487,11 @@ export const it = {
                 reason: 'Motivo',
                 changes: 'Modifiche',
                 metadata: 'Metadati',
+                close: 'Chiudi dettagli',
+                noChanges: 'Nessuna modifica di campo registrata per questo evento.',
+                diffField: 'Campo',
+                diffBefore: 'Prima',
+                diffAfter: 'Dopo',
             },
         },
         feasibility: {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2330,3 +2330,105 @@ h3 {
 .feature-toggle-state.is-off {
   color: #475569;
 }
+/* ── Audit log detail drawer ─────────────────────────────────────────────── */
+
+.audit-drawer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #f8fafc;
+}
+
+.audit-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem 1.4rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(255, 255, 255, 0.92);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.audit-drawer-header h3 {
+  margin: 0;
+}
+
+.audit-drawer-body {
+  padding: 1.3rem 1.4rem 2rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.audit-drawer-summary {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.45;
+}
+
+.audit-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem 1.2rem;
+}
+
+.audit-detail-field {
+  min-width: 0;
+}
+
+.audit-detail-field strong {
+  display: block;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #64748b;
+  margin-bottom: 0.2rem;
+}
+
+.audit-detail-field > div {
+  overflow-wrap: anywhere;
+}
+
+/* Diff table: before/after per changed field. */
+.audit-diff {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.audit-diff th {
+  text-align: left;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #64748b;
+  padding: 0.35rem 0.55rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.audit-diff td {
+  padding: 0.4rem 0.55rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+
+.audit-diff-before {
+  color: #b91c1c;
+  background: rgba(248, 113, 113, 0.08);
+  text-decoration: line-through;
+  text-decoration-color: rgba(185, 28, 28, 0.45);
+}
+
+.audit-diff-after {
+  color: #15803d;
+  background: rgba(74, 222, 128, 0.1);
+}
+
+@media (max-width: 640px) {
+  .audit-detail-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/AdminAuditLogsPage.tsx
+++ b/frontend/src/pages/AdminAuditLogsPage.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
-import { fetchAuditEvent, fetchAuditEvents } from '../lib/api/audit'
+import { fetchAuditEvents } from '../lib/api/audit'
 import { queryKeys } from '../lib/api/queryKeys'
 import { formatDateTime, useAppSettings } from '../lib/appSettings'
 import { useAuth } from '../lib/auth'
+import { AuditEventDrawer } from '../features/audit/AuditEventDrawer'
 import type { AuditActionCategory, AuditEvent, AuditEventFilters, AuditEventStatus } from '../types/api'
 
 type AuditLogsScope = 'admin' | 'owner'
@@ -56,10 +57,6 @@ function statusBadgeClass(status: AuditEventStatus): string {
     return 'badge badge-neutral'
 }
 
-function formatJsonBlock(value: Record<string, unknown>): string {
-    return JSON.stringify(value, null, 2)
-}
-
 export function AuditLogsPage({ scope }: AuditLogsPageProps) {
     const { t } = useTranslation()
     const { settings } = useAppSettings()
@@ -87,12 +84,6 @@ export function AuditLogsPage({ scope }: AuditLogsPageProps) {
     const eventsQuery = useQuery({
         queryKey: queryKeys.admin.auditEvents(apiFilters),
         queryFn: () => fetchAuditEvents(apiFilters),
-    })
-
-    const selectedEventQuery = useQuery({
-        queryKey: queryKeys.admin.auditEvent(selectedEventId ?? ''),
-        queryFn: () => fetchAuditEvent(selectedEventId ?? ''),
-        enabled: Boolean(selectedEventId),
     })
 
     const events = eventsQuery.data?.results ?? []
@@ -241,46 +232,11 @@ export function AuditLogsPage({ scope }: AuditLogsPageProps) {
                 )}
             </section>
 
-            {selectedEventId && (
-                <section className="card page-stack">
-                    <h3>{t('pages.auditLogs.detail.title')}</h3>
-                    {selectedEventQuery.isLoading && <p>{t('pages.auditLogs.detail.loading')}</p>}
-                    {selectedEventQuery.isError && <p className="text-error">{t('pages.auditLogs.detail.loadError')}</p>}
-                    {selectedEventQuery.data && (
-                        <>
-                            <div className="form-grid">
-                                <div><strong>{t('pages.auditLogs.detail.id')}</strong><div><code>{selectedEventQuery.data.id}</code></div></div>
-                                <div><strong>{t('pages.auditLogs.detail.createdAt')}</strong><div>{formatDateTime(selectedEventQuery.data.created_at, settings)}</div></div>
-                                <div><strong>{t('pages.auditLogs.detail.category')}</strong><div>{t(`pages.auditLogs.categories.${selectedEventQuery.data.action_category}`)}</div></div>
-                                <div><strong>{t('pages.auditLogs.detail.action')}</strong><div><code>{selectedEventQuery.data.action_type}</code></div></div>
-                                <div><strong>{t('pages.auditLogs.detail.status')}</strong><div><span className={statusBadgeClass(selectedEventQuery.data.status)}>{t(`pages.auditLogs.statuses.${selectedEventQuery.data.status}`)}</span></div></div>
-                                <div><strong>{t('pages.auditLogs.detail.source')}</strong><div><code>{selectedEventQuery.data.source}</code></div></div>
-                                <div><strong>{t('pages.auditLogs.detail.actor')}</strong><div>{selectedEventQuery.data.actor_display || '—'}</div></div>
-                                <div><strong>{t('pages.auditLogs.detail.target')}</strong><div>{selectedEventQuery.data.target_display || `${selectedEventQuery.data.target_type}:${selectedEventQuery.data.target_id || '-'}`}</div></div>
-                                <div><strong>{t('pages.auditLogs.detail.requestId')}</strong><div><code>{selectedEventQuery.data.request_id || '—'}</code></div></div>
-                                <div><strong>{t('pages.auditLogs.detail.correlationId')}</strong><div><code>{selectedEventQuery.data.correlation_id || '—'}</code></div></div>
-                            </div>
-
-                            {selectedEventQuery.data.reason && (
-                                <div>
-                                    <strong>{t('pages.auditLogs.detail.reason')}</strong>
-                                    <p style={{ marginTop: '0.5rem' }}>{selectedEventQuery.data.reason}</p>
-                                </div>
-                            )}
-
-                            <div>
-                                <strong>{t('pages.auditLogs.detail.changes')}</strong>
-                                <pre style={{ overflowX: 'auto' }}>{formatJsonBlock(selectedEventQuery.data.changes_json)}</pre>
-                            </div>
-
-                            <div>
-                                <strong>{t('pages.auditLogs.detail.metadata')}</strong>
-                                <pre style={{ overflowX: 'auto' }}>{formatJsonBlock(selectedEventQuery.data.metadata_json)}</pre>
-                            </div>
-                        </>
-                    )}
-                </section>
-            )}
+            <AuditEventDrawer
+                eventId={selectedEventId}
+                onClose={() => setSelectedEventId(null)}
+                statusBadgeClass={statusBadgeClass}
+            />
         </div>
     )
 }


### PR DESCRIPTION
## The problem

The detail panel was a `<section>` placed *after* the table in document flow, and `PAGE_SIZE` is **50**. So clicking the top row meant scrolling past fifty rows and the pagination controls to read the detail — then scrolling back up to pick the next one. Every inspection was a round trip, which is the worst possible shape for audit triage, where scanning and inspecting alternate constantly.

## The change

**Details move into a right-hand drawer.** The table no longer moves at all.

The drawer is deliberately **non-modal** — no backdrop, and the table behind stays interactive. Clicking the next row swaps the drawer contents in place rather than forcing close-and-reopen. That is the behaviour that makes stepping through a log fast, and it is what Sentry/Datadog/CloudWatch do. Escape closes it; a close button is in the header.

`@mui/material` was already a dependency (used for `Menu`, `Switch`, `Tabs`), so `Drawer` adds nothing to the bundle. Without a backdrop the Modal root still covers the viewport and would swallow clicks meant for the table, so the root is `pointer-events: none` with the paper set back to `auto`. Since a non-modal Modal no longer reliably receives key events, Escape is wired up explicitly rather than relied upon.

**`changes_json` renders as a real diff.** This is the highest-value content in an audit event and it was being dumped as raw JSON:

```
{                                    FIELD    BEFORE    AFTER
  "status": {                 →      status   draft  →  approved
    "before": "draft",
    "after": "approved"
  }
}
```

`changes_json` is a `JSONField`, so nothing guarantees its shape. Every call site happens to produce `{field: {before, after}}` today, but old rows may hold anything — so the renderer only builds the table when *every* entry conforms, and falls back to the raw JSON otherwise. An event can never become unreadable because its shape was unexpected.

Also reworked the field grid into a labelled two-column layout, moved the summary to the top where it belongs, and gave `metadata` an em-dash when empty instead of printing `{}`.

## Both views are covered

`/admin/audit-logs` and `/audit-logs` already render the same `AuditLogsPage` component with a different `scope` prop — `scope` only controls the eyebrow label and whether full-text search is enabled. One change covers both. Verified in the browser on both routes.

## Verification

Driven in a real browser against the dev stack, not just built:

| Check | Result |
|---|---|
| Drawer opens on row click | visible, no page scroll required |
| Backdrop elements present | **0** — table stays visible and interactive |
| Diff table rendered | `status │ draft │ approved` |
| Click a row *behind* the drawer | succeeds; drawer stays open and content swaps |
| Escape | closes |
| ZEV-owner route `/audit-logs` | identical behaviour |
| 420px viewport | drawer goes full-width, field grid collapses to one column |

`tsc` clean, eslint clean (one pre-existing unrelated warning), `npm run build` clean.

Translations added in all four locales.

## Noted, not changed

`AdminAuditLogsPage` and `OwnerAuditLogsPage` at the bottom of the file are exported but imported by nothing — `App.tsx` uses `AuditLogsPage` directly and passes `scope`. Dead since the scope prop was introduced. Left alone to keep this diff reviewable; happy to remove them separately, possibly along with renaming the file, since `AdminAuditLogsPage.tsx` serving both the admin and owner views is a naming trap.
