### PR TITLE
fix(frontend): localize date pickers via app-level LocalizationProvider

### DIFF
--- a/docs/specs/2026-03-admin-governance-and-settings.md
+++ b/docs/specs/2026-03-admin-governance-and-settings.md
@@ -362,7 +362,7 @@ redirect to the matching tab on this page.
 
 - Query: `useQuery({ queryKey: ['vat-rates'], queryFn: fetchVatRates })`.
 - **Summary cards:** three `StatCard` components above the form — configured rate count, today's active rate (percentage, or the translated "none" label), and count of scheduled rates with `valid_from` in the future.
-- **Create/Edit form:** 3 fields (rate %, valid_from date, valid_to date optional). Default rate: `8.1`. The frontend converts percentage to fraction before sending (`(percentage / 100).toFixed(4)`).
+- **Create/Edit form:** 3 fields (rate %, valid_from DatePicker with app-settings format, valid_to DatePicker optional). Default rate: `8.1`. The frontend converts percentage to fraction before sending (`(percentage / 100).toFixed(4)`). Date pickers are MUI X `DatePicker` components inheriting the app-level `LocalizationProvider` supplied by `DateLocaleProvider` (`frontend/src/components/DateLocaleProvider.tsx`, mounted in `main.tsx`): `adapterLocale` (dayjs calendar names/format) and `localeText` (picker UI text such as "Choose date", from `@mui/x-date-pickers/locales` de/fr/it bundles, mirroring `lib/dataGridLocale.ts`) both follow the active UI language. Submitting an empty valid_from is rejected client-side with a toast (`adminVatSettings.messages.missingValidFrom`).
 - **Rate table:** displays rate as percentage (`(rate × 100).toFixed(2)%`), valid_from (formatted), valid_to (formatted or "Open"), with Edit/Delete buttons.
 - **Delete:** Uses `ConfirmDialog` component for destructive confirmation.
 - **Validation feedback:** API errors (overlap, invalid range) displayed via toast.

--- a/frontend/src/components/DateLocaleProvider.tsx
+++ b/frontend/src/components/DateLocaleProvider.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react'
+import { DatesProvider } from '@mantine/dates'
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import { deDE, frFR, itIT } from '@mui/x-date-pickers/locales'
+import { useTranslation } from 'react-i18next'
+import 'dayjs/locale/de'
+import 'dayjs/locale/fr'
+import 'dayjs/locale/it'
+
+// MUI X localizes on two separate paths: the date library via `adapterLocale`
+// (dayjs month names, formats) and the picker component text via `localeText`
+// ("Choose date", "Clear", month navigation). English is MUI's built-in
+// default, so only the non-English bundles are mapped. Mirrors the DataGrid
+// pattern in lib/dataGridLocale.ts.
+const pickerLocaleTextByLanguage = {
+    de: deDE.components.MuiLocalizationProvider.defaultProps.localeText,
+    fr: frFR.components.MuiLocalizationProvider.defaultProps.localeText,
+    it: itIT.components.MuiLocalizationProvider.defaultProps.localeText,
+}
+
+/**
+ * Feeds the active UI language to the date pickers, which otherwise render
+ * English month names and button text: Mantine's calendars via `DatesProvider`
+ * and MUI X's pickers via a single app-level `LocalizationProvider` (so
+ * individual fields don't need their own, and all of them inherit
+ * `adapterLocale` and `localeText`).
+ */
+export function DateLocaleProvider({ children }: { children: ReactNode }) {
+    const { i18n } = useTranslation()
+    // dayjs locales are registered under the bare language code.
+    const locale = i18n.language?.split('-')[0] ?? 'en'
+
+    return (
+        <LocalizationProvider
+            dateAdapter={AdapterDayjs}
+            adapterLocale={locale}
+            localeText={pickerLocaleTextByLanguage[locale as keyof typeof pickerLocaleTextByLanguage]}
+        >
+            <DatesProvider settings={{ locale }}>{children}</DatesProvider>
+        </LocalizationProvider>
+    )
+}

--- a/frontend/src/components/ZevGeneralSettingsFields.tsx
+++ b/frontend/src/components/ZevGeneralSettingsFields.tsx
@@ -1,7 +1,5 @@
 import dayjs from 'dayjs'
 import { DatePicker } from '@mui/x-date-pickers/DatePicker'
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { useTranslation } from 'react-i18next'
 import { toDayJsDateFormat, useAppSettings } from '../lib/appSettings'
 import type { ZevInput } from '../types/api'
@@ -32,16 +30,14 @@ export function ZevGeneralSettingsFields({ form, onChange }: ZevGeneralSettingsF
                     </label>
                     <label>
                         <span>{t('pages.zevSettings.fields.startDate')}</span>
-                        <LocalizationProvider dateAdapter={AdapterDayjs}>
-                            <DatePicker
-                                format={toDayJsDateFormat(settings.date_format_short)}
-                                value={form.start_date ? dayjs(form.start_date) : null}
-                                onChange={(newValue) =>
-                                    onChange({ start_date: newValue ? newValue.format('YYYY-MM-DD') : '' })
-                                }
-                                slotProps={{ textField: { required: true, size: 'small' } }}
-                            />
-                        </LocalizationProvider>
+                        <DatePicker
+                            format={toDayJsDateFormat(settings.date_format_short)}
+                            value={form.start_date ? dayjs(form.start_date) : null}
+                            onChange={(newValue) =>
+                                onChange({ start_date: newValue ? newValue.format('YYYY-MM-DD') : '' })
+                            }
+                            slotProps={{ textField: { required: true, size: 'small' } }}
+                        />
                     </label>
                     <label>
                         <span>{t('pages.zevSettings.fields.zevType')}</span>

--- a/frontend/src/features/meteringPoints/MeteringAssignmentFormModal.tsx
+++ b/frontend/src/features/meteringPoints/MeteringAssignmentFormModal.tsx
@@ -1,7 +1,5 @@
 import dayjs from 'dayjs'
 import { DatePicker } from '@mui/x-date-pickers/DatePicker'
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { type Dispatch, type FormEvent, type SetStateAction } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FormModal } from '../../components/FormModal'
@@ -56,25 +54,21 @@ export function MeteringAssignmentFormModal({
 
         <label>
           <span>{t('pages.meteringPoints.assignForm.validFrom')}</span>
-          <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <DatePicker
-              format={toDayJsDateFormat(settings.date_format_short)}
-              value={form.valid_from ? dayjs(form.valid_from) : null}
-              onChange={(value) => setForm((previous) => ({ ...previous, valid_from: value ? value.format('YYYY-MM-DD') : '' }))}
-              slotProps={{ textField: { required: true, size: 'small' } }}
-            />
-          </LocalizationProvider>
+          <DatePicker
+            format={toDayJsDateFormat(settings.date_format_short)}
+            value={form.valid_from ? dayjs(form.valid_from) : null}
+            onChange={(value) => setForm((previous) => ({ ...previous, valid_from: value ? value.format('YYYY-MM-DD') : '' }))}
+            slotProps={{ textField: { required: true, size: 'small' } }}
+          />
         </label>
         <label>
           <span>{t('pages.meteringPoints.assignForm.validTo')}</span>
-          <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <DatePicker
-              format={toDayJsDateFormat(settings.date_format_short)}
-              value={form.valid_to ? dayjs(form.valid_to) : null}
-              onChange={(value) => setForm((previous) => ({ ...previous, valid_to: value ? value.format('YYYY-MM-DD') : null }))}
-              slotProps={{ textField: { size: 'small' } }}
-            />
-          </LocalizationProvider>
+          <DatePicker
+            format={toDayJsDateFormat(settings.date_format_short)}
+            value={form.valid_to ? dayjs(form.valid_to) : null}
+            onChange={(value) => setForm((previous) => ({ ...previous, valid_to: value ? value.format('YYYY-MM-DD') : null }))}
+            slotProps={{ textField: { size: 'small' } }}
+          />
         </label>
 
         <p className="muted" style={{ gridColumn: '1 / -1', margin: 0, fontSize: '0.82rem' }}>

--- a/frontend/src/features/tariffs/TariffFormModal.tsx
+++ b/frontend/src/features/tariffs/TariffFormModal.tsx
@@ -3,8 +3,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons'
 import dayjs from 'dayjs'
 import { DatePicker } from '@mui/x-date-pickers/DatePicker'
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { Controller, useForm, useWatch } from 'react-hook-form'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -129,37 +127,33 @@ export function TariffFormModal({
 
         <label>
           <span>{t('pages.tariffs.form.validFrom')}</span>
-          <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <Controller
-              control={form.control}
-              name="valid_from"
-              render={({ field }) => (
-                <DatePicker
-                  format={toDayJsDateFormat(settings.date_format_short)}
-                  value={field.value ? dayjs(field.value) : null}
-                  onChange={(val) => field.onChange(val ? val.format('YYYY-MM-DD') : '')}
-                  slotProps={{ textField: { size: 'small', fullWidth: true } }}
-                />
-              )}
-            />
-          </LocalizationProvider>
+          <Controller
+            control={form.control}
+            name="valid_from"
+            render={({ field }) => (
+              <DatePicker
+                format={toDayJsDateFormat(settings.date_format_short)}
+                value={field.value ? dayjs(field.value) : null}
+                onChange={(val) => field.onChange(val ? val.format('YYYY-MM-DD') : '')}
+                slotProps={{ textField: { size: 'small', fullWidth: true } }}
+              />
+            )}
+          />
         </label>
         <label>
           <span>{t('pages.tariffs.form.validTo')}</span>
-          <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <Controller
-              control={form.control}
-              name="valid_to"
-              render={({ field }) => (
-                <DatePicker
-                  format={toDayJsDateFormat(settings.date_format_short)}
-                  value={field.value ? dayjs(field.value) : null}
-                  onChange={(val) => field.onChange(val ? val.format('YYYY-MM-DD') : '')}
-                  slotProps={{ textField: { size: 'small', fullWidth: true } }}
-                />
-              )}
-            />
-          </LocalizationProvider>
+          <Controller
+            control={form.control}
+            name="valid_to"
+            render={({ field }) => (
+              <DatePicker
+                format={toDayJsDateFormat(settings.date_format_short)}
+                value={field.value ? dayjs(field.value) : null}
+                onChange={(val) => field.onChange(val ? val.format('YYYY-MM-DD') : '')}
+                slotProps={{ textField: { size: 'small', fullWidth: true } }}
+              />
+            )}
+          />
         </label>
         <label>
           <span>{t('pages.tariffs.form.notes')}</span>

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -1644,6 +1644,7 @@ export const de = {
             saveFailed: 'MwSt.-Satz konnte nicht gespeichert werden.',
             deleteFailed: 'MwSt.-Satz konnte nicht gelöscht werden.',
             invalidRate: 'Der Satz muss ein gültiger Prozentsatz zwischen 0 und 100 sein.',
+            missingValidFrom: 'Das Gültig-ab-Datum ist erforderlich.',
         },
     },
     adminInvoices: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1616,6 +1616,7 @@ export const en = {
             saveFailed: 'Failed to save VAT rate.',
             deleteFailed: 'Failed to delete VAT rate.',
             invalidRate: 'Rate must be a valid percentage between 0 and 100.',
+            missingValidFrom: 'Valid from date is required.',
         },
     },
     adminInvoices: {

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -1651,6 +1651,7 @@ export const fr = {
             saveFailed: 'Impossible d\'enregistrer le taux TVA.',
             deleteFailed: 'Impossible de supprimer le taux TVA.',
             invalidRate: 'Le taux doit être un pourcentage valide entre 0 et 100.',
+            missingValidFrom: 'La date de début de validité est requise.',
         },
     },
     adminInvoices: {

--- a/frontend/src/i18n/locales/it.ts
+++ b/frontend/src/i18n/locales/it.ts
@@ -1651,6 +1651,7 @@ export const it = {
             saveFailed: 'Impossibile salvare l\'aliquota IVA.',
             deleteFailed: 'Impossibile eliminare l\'aliquota IVA.',
             invalidRate: 'L\'aliquota deve essere una percentuale valida tra 0 e 100.',
+            missingValidFrom: 'La data di inizio validità è obbligatoria.',
         },
     },
     adminInvoices: {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,18 +1,14 @@
-import { StrictMode, type ReactNode } from 'react'
+import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MantineProvider, createTheme } from '@mantine/core'
-import { DatesProvider } from '@mantine/dates'
-import { useTranslation } from 'react-i18next'
-import 'dayjs/locale/de'
-import 'dayjs/locale/fr'
-import 'dayjs/locale/it'
 import '@fontsource-variable/inter/index.css'
 import '@mantine/core/styles.css'
 import '@mantine/dates/styles.css'
 import './index.css'
 import App from './App.tsx'
 import './i18n'
+import { DateLocaleProvider } from './components/DateLocaleProvider'
 import { AuthProvider } from './lib/auth'
 import { AppSettingsProvider } from './lib/appSettings'
 import { ToastProvider } from './lib/toast'
@@ -46,15 +42,6 @@ const mantineTheme = createTheme({
     },
 })
 
-/** Feeds the active UI language to Mantine's calendars, which otherwise render English month names. */
-function DatesLocaleProvider({ children }: { children: ReactNode }) {
-    const { i18n } = useTranslation()
-    // dayjs locales are registered under the bare language code.
-    const locale = i18n.language?.split('-')[0] ?? 'en'
-
-    return <DatesProvider settings={{ locale }}>{children}</DatesProvider>
-}
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
@@ -62,9 +49,9 @@ createRoot(document.getElementById('root')!).render(
         <AppSettingsProvider>
           <ToastProvider>
             <MantineProvider theme={mantineTheme}>
-              <DatesLocaleProvider>
+              <DateLocaleProvider>
                 <App />
-              </DatesLocaleProvider>
+              </DateLocaleProvider>
             </MantineProvider>
           </ToastProvider>
         </AppSettingsProvider>

--- a/frontend/src/pages/AdminVatSettingsPage.tsx
+++ b/frontend/src/pages/AdminVatSettingsPage.tsx
@@ -2,10 +2,12 @@ import { useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck, faPen, faPlus, faTrash, faXmark } from '@fortawesome/free-solid-svg-icons'
+import dayjs from 'dayjs'
+import { DatePicker } from '@mui/x-date-pickers/DatePicker'
 import { createVatRate, deleteVatRate, fetchVatRates, updateVatRate } from '../lib/api/auth'
 import { formatApiError } from '../lib/api/errors'
 import { queryKeys } from '../lib/api/queryKeys'
-import { formatShortDate, useAppSettings } from '../lib/appSettings'
+import { formatShortDate, toDayJsDateFormat, useAppSettings } from '../lib/appSettings'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '../lib/toast'
 import { ConfirmDialog, useConfirmDialog } from '../components/ConfirmDialog'
@@ -85,6 +87,10 @@ export function AdminVatSettingsPage() {
             pushToast(t('adminVatSettings.messages.invalidRate'), 'error')
             return null
         }
+        if (!values.valid_from) {
+            pushToast(t('adminVatSettings.messages.missingValidFrom'), 'error')
+            return null
+        }
         return {
             rate: (percentage / 100).toFixed(4),
             valid_from: values.valid_from,
@@ -145,20 +151,25 @@ export function AdminVatSettingsPage() {
                         </label>
                         <label>
                             <span>{t('adminVatSettings.form.validFrom')}</span>
-                            <input
-                                type="date"
-                                value={form.valid_from}
-                                onChange={(event) => setForm((prev) => ({ ...prev, valid_from: event.target.value }))}
-                                required
+                            <DatePicker
+                                format={toDayJsDateFormat(settings.date_format_short)}
+                                value={form.valid_from ? dayjs(form.valid_from) : null}
+                                onChange={(newValue) =>
+                                    setForm((prev) => ({ ...prev, valid_from: newValue ? newValue.format('YYYY-MM-DD') : '' }))
+                                }
+                                slotProps={{ textField: { required: true, size: 'small' } }}
                             />
                             <small className="muted">{t('adminVatSettings.form.validFromHint')}</small>
                         </label>
                         <label>
                             <span>{t('adminVatSettings.form.validTo')}</span>
-                            <input
-                                type="date"
-                                value={form.valid_to ?? ''}
-                                onChange={(event) => setForm((prev) => ({ ...prev, valid_to: event.target.value || null }))}
+                            <DatePicker
+                                format={toDayJsDateFormat(settings.date_format_short)}
+                                value={form.valid_to ? dayjs(form.valid_to) : null}
+                                onChange={(newValue) =>
+                                    setForm((prev) => ({ ...prev, valid_to: newValue ? newValue.format('YYYY-MM-DD') : null }))
+                                }
+                                slotProps={{ textField: { size: 'small' } }}
                             />
                             <small className="muted">{t('adminVatSettings.form.validToHint')}</small>
                         </label>

--- a/frontend/tests/date-locale-provider.test.ts
+++ b/frontend/tests/date-locale-provider.test.ts
@@ -1,0 +1,104 @@
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { act, createElement } from 'react'
+import dayjs from 'dayjs'
+import { DatePicker } from '@mui/x-date-pickers/DatePicker'
+import i18n from '../src/i18n'
+import { DateLocaleProvider } from '../src/components/DateLocaleProvider'
+
+describe('DateLocaleProvider', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot>
+
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  const renderPicker = () =>
+    act(() => {
+      root.render(
+        createElement(
+          DateLocaleProvider,
+          null,
+          // Without an explicit `format`, the field is formatted by the dayjs
+          // adapter's localized `L` format, so the rendered value proves which
+          // `adapterLocale` the app-level LocalizationProvider supplies.
+          createElement(DatePicker, {
+            value: dayjs('2026-01-15'),
+            onChange: () => undefined,
+          }),
+        ),
+      )
+    })
+
+  const inputValue = () => container.querySelector('input')?.value
+
+  it('formats picker values using the active UI language', async () => {
+    await act(async () => {
+      await i18n.changeLanguage('de')
+    })
+    renderPicker()
+
+    expect(inputValue()).toBe('15.01.2026') // German dayjs `L`: DD.MM.YYYY
+  })
+
+  it('re-localizes pickers when the language changes at runtime', async () => {
+    await act(async () => {
+      await i18n.changeLanguage('de')
+    })
+    renderPicker()
+    expect(inputValue()).toBe('15.01.2026')
+
+    await act(async () => {
+      await i18n.changeLanguage('fr')
+    })
+    expect(inputValue()).toBe('15/01/2026') // French dayjs `L`: DD/MM/YYYY
+  })
+
+  it('falls back to English formatting', async () => {
+    await act(async () => {
+      await i18n.changeLanguage('en')
+    })
+    renderPicker()
+
+    expect(inputValue()).toBe('01/15/2026') // English dayjs `L`: MM/DD/YYYY
+  })
+
+  // `adapterLocale` only covers dayjs-derived content; picker chrome (the
+  // "Choose date" aria-label, action bar, month navigation) comes from MUI's
+  // separate `localeText` bundles. Assert on the closed-state aria-label so
+  // this stays independent of popup interaction quirks in jsdom.
+  const expectLocalizedPickerChrome = (needle: string) =>
+    expect(container.querySelector(`[aria-label*="${needle}"]`), `expected aria-label containing "${needle}"`).not.toBeNull()
+
+  it('localizes MUI picker component text for every supported language', async () => {
+    await act(async () => {
+      await i18n.changeLanguage('de')
+    })
+    renderPicker()
+    expectLocalizedPickerChrome('Datum auswählen')
+
+    await act(async () => {
+      await i18n.changeLanguage('fr')
+    })
+    expectLocalizedPickerChrome('Choisir la date')
+
+    await act(async () => {
+      await i18n.changeLanguage('it')
+    })
+    expectLocalizedPickerChrome('Scegli la data')
+
+    await act(async () => {
+      await i18n.changeLanguage('en')
+    })
+    expectLocalizedPickerChrome('Choose date')
+  })
+})

--- a/frontend/tests/screenshot-blur-selector.test.ts
+++ b/frontend/tests/screenshot-blur-selector.test.ts
@@ -8,7 +8,9 @@ vi.mock('../src/lib/appSettings', async () => {
 })
 
 const { ZevGeneralSettingsFields } = await import('../src/components/ZevGeneralSettingsFields')
+const { DateLocaleProvider } = await import('../src/components/DateLocaleProvider')
 const { getDefaultZevForm } = await import('../src/lib/zevForm')
+await import('../src/i18n')
 
 /**
  * Guards the screenshot suite's PII blur for the ZEV settings page.
@@ -29,8 +31,14 @@ describe('screenshot PII blur selector', () => {
             bank_iban: 'CH00 1234 5678',
         }
 
+        // Mirrors the app root: the date picker inside the fields inherits the
+        // app-level LocalizationProvider from DateLocaleProvider (main.tsx).
         document.body.innerHTML = renderToStaticMarkup(
-            createElement(ZevGeneralSettingsFields, { form, onChange: () => {} }),
+            createElement(
+                DateLocaleProvider,
+                null,
+                createElement(ZevGeneralSettingsFields, { form, onChange: () => {} }),
+            ),
         )
 
         const matched = Array.from(document.querySelectorAll<HTMLInputElement>(BLUR_SELECTOR))


### PR DESCRIPTION
## Summary
- The admin VAT settings form used native `<input type="date">`, whose calendar UI follows the browser locale instead of the app language. Migrated to MUI X `DatePicker` with the app-settings date format (`dd.MM.yyyy`).
- New `DateLocaleProvider` (mounted in `main.tsx`) supplies a single `LocalizationProvider`: `adapterLocale` derived from i18n (dayjs calendar names/formats) plus `localeText` from the MUI de/fr/it bundles (picker UI text such as "Choose date"), mirroring `lib/dataGridLocale.ts`. The five per-field provider wrappers are removed; those pickers previously rendered component text in English.
- `toVatPayload` now rejects an empty `valid_from` with a toast (new i18n key in en/de/fr/it), restoring the guard the native `required` input provided.
- Vitest regression tests: adapter formatting (de/fr/en), runtime language switching, en fallback, localized picker chrome in all four languages.

## Follow-up (separate PR)
Migrate the remaining native `<input type="date">` fields (5 files) and the two Mantine date components (`PeriodSelector`, `MeteringDeleteDataModal`) to MUI X, then remove Mantine — nothing else uses it.

## Linked spec
- `docs/specs/2026-03-admin-governance-and-settings.md` (§9.5 updated)
- No ADR — no architecture decision changed

## Validation
- Backend: `python -m pytest metering/ accounts/ invoices/ -q` — 443 passed (no backend changes; run as regression check)
- Frontend: `npm run build` ✓, `npm run test:unit` 71/71 ✓, `npm run lint` 0 errors (1 pre-existing warning)
- Not done: browser-level language switch on the affected pages; the regression tests cover this at aria-label level

## Checklist
- [x] Spec updated/linked for larger or risky changes
- [ ] ADR updated/linked for architecture decisions — N/A
- [ ] Backend and frontend updated together where API contracts changed — N/A