### PR TITLE
fix(accounts): prevent deletion of the last admin

### DIFF
--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -16,6 +16,7 @@ from .models import (
 	UserRole,
 	VatRate,
 )
+from audit.models import AuditEvent
 from invoices.models import Invoice, InvoiceStatus
 from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
 from datetime import date, timedelta
@@ -55,6 +56,7 @@ class UserModelTests(TestCase):
 				password="super-secret",
 				role=UserRole.PARTICIPANT,
 			)
+
 
 
 def _cookie_auth(client, username, password="pass1234"):
@@ -345,6 +347,38 @@ class LinkedAccountSafetyTests(TestCase):
 
 		self.assertEqual(update_resp.status_code, 200)
 		self.assertEqual(delete_resp.status_code, 204)
+
+	def test_admin_cannot_delete_last_admin(self):
+		resp = self.client.delete(f"/api/v1/auth/users/{self.admin.id}/")
+		self.assertEqual(resp.status_code, 403)
+		self.assertTrue(User.objects.filter(pk=self.admin.pk).exists())
+		self.assertTrue(
+			AuditEvent.objects.filter(
+				action_type="user.delete",
+				status="denied",
+				target_id=str(self.admin.pk),
+			).exists()
+		)
+
+	def test_admin_can_delete_self_when_other_admin_exists(self):
+		User.objects.create_user(username="admin_two", password="pass1234", role=UserRole.ADMIN)
+		admin_pk = self.admin.pk
+		admin_display = self.admin.email or self.admin.username
+		resp = self.client.delete(f"/api/v1/auth/users/{admin_pk}/")
+		self.assertEqual(resp.status_code, 204)
+		self.assertFalse(User.objects.filter(pk=admin_pk).exists())
+		# Audit event survives self-deletion; actor FK is SET_NULL.
+		event = AuditEvent.objects.get(
+			action_type="user.delete", target_id=str(admin_pk), status="success",
+		)
+		self.assertEqual(event.target_display, admin_display)
+		self.assertIsNone(event.actor_user)
+
+	def test_admin_can_delete_other_admin_when_multiple_exist(self):
+		admin2 = User.objects.create_user(username="admin_two", password="pass1234", role=UserRole.ADMIN)
+		resp = self.client.delete(f"/api/v1/auth/users/{admin2.id}/")
+		self.assertEqual(resp.status_code, 204)
+		self.assertFalse(User.objects.filter(pk=admin2.pk).exists())
 
 	def test_admin_cannot_change_own_role_via_user_detail(self):
 		resp = self.client.patch(

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -146,6 +146,20 @@ class UserDetailView(AuditedUpdateMixin, generics.RetrieveUpdateDestroyAPIView):
         return instance.email or instance.username
 
     def perform_destroy(self, instance):
+        user_display = instance.email or instance.username
+        if instance.is_admin and not User.objects.filter(role=UserRole.ADMIN).exclude(pk=instance.pk).exists():
+            record_audit_event(
+                request=self.request,
+                action_category=AuditActionCategory.AUTH,
+                action_type="user.delete",
+                target_type="accounts.User",
+                target=instance,
+                target_id=str(instance.pk),
+                target_display=user_display,
+                summary=f"Denied deletion of last admin {user_display}.",
+                status=AuditEventStatus.DENIED,
+            )
+            raise PermissionDenied("Cannot delete the last admin account.")
         if instance.participations.exists():
             record_audit_event(
                 request=self.request,
@@ -154,14 +168,14 @@ class UserDetailView(AuditedUpdateMixin, generics.RetrieveUpdateDestroyAPIView):
                 target_type="accounts.User",
                 target=instance,
                 target_id=str(instance.pk),
-                target_display=instance.email or instance.username,
-                summary=f"Denied deletion of linked user {instance.email or instance.username}.",
+                target_display=user_display,
+                summary=f"Denied deletion of linked user {user_display}.",
                 status=AuditEventStatus.DENIED,
             )
             raise PermissionDenied("Linked participant accounts cannot be deleted.")
-        user_display = instance.email or instance.username
         user_id = str(instance.pk)
-        instance.delete()
+        # Record before delete so the actor FK is valid;
+        # on_delete=SET_NULL nullifies it when the user row goes.
         record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.AUTH,
@@ -171,6 +185,7 @@ class UserDetailView(AuditedUpdateMixin, generics.RetrieveUpdateDestroyAPIView):
             target_display=user_display,
             summary=f"Deleted user {user_display}.",
         )
+        instance.delete()
 
 
 class VatRateListCreateView(generics.ListCreateAPIView):

--- a/docs/specs/2026-03-community-and-access.md
+++ b/docs/specs/2026-03-community-and-access.md
@@ -330,9 +330,16 @@ Admin only. Passwords must match. Created via `User.objects.create_user()`.
 - PATCH: `UserSerializer` partial update. Role-change safety:
   - Admin cannot change own role away from admin.
   - Non-admin cannot change any role.
-- DELETE: blocked if user has linked participant records
-  (`instance.participations.exists()` → 403 "Linked participant accounts
-  cannot be deleted.").
+- DELETE: two guards:
+  1. **Last-admin guard** — blocked if the target `is_admin` and no other
+     user with `role=admin` exists (→ 403 "Cannot delete the last admin
+     account."). Self-deletion is allowed when another admin remains.
+  2. **Linked-account guard** — blocked if user has linked participant records
+     (→ 403 "Linked participant accounts cannot be deleted.").
+
+  Success audit is recorded before `instance.delete()` so the actor FK is
+  valid; `on_delete=SET_NULL` nullifies `actor_user` on self-deletion while
+  preserving `actor_display` and `target_id`.
 
 ---
 
@@ -547,7 +554,7 @@ The sidebar (`Layout.tsx`) shows sections conditionally:
 | POST | `/me/change-password/` | IsAuthenticated | Change password (requires old password) |
 | POST | `/me/set-initial-password/` | IsAuthenticated | Set password for first time (verification flow) |
 | GET / POST | `/users/` | IsAuthenticated (create: admin only) | List users (scoped by role) / Create user |
-| GET / PATCH / DELETE | `/users/{id}/` | IsAdmin | User detail (delete blocked if linked) |
+| GET / PATCH / DELETE | `/users/{id}/` | IsAdmin | User detail (delete blocked if linked or last admin) |
 | POST | `/users/{user_id}/impersonate/` | IsAuthenticated (admin only) | Impersonate participant/owner |
 | GET / PATCH | `/app-settings/` | IsAuthenticated (update: admin only) | Application settings singleton |
 | GET / POST | `/vat-rates/` | IsAdmin | VAT rate management |
@@ -754,10 +761,10 @@ interface ParticipantAccountCreateResult { participant: Participant; account: Us
 
 | Class | Tests | Description |
 |---|---|---|
-| `UserModelTests` | 1 | Role helper properties (`is_admin`, `is_zev_owner`) |
+| `UserModelTests` | 3 | Role helper properties; superuser creation sets `role=ADMIN`; superuser creation rejects non-admin role |
 | `PasswordChangeFlagTests` | 1 | `must_change_password` cleared on password change |
 | `ImpersonationTests` | 4 | Admin can impersonate participant/owner; non-admin blocked; admin cannot impersonate admin |
-| `LinkedAccountSafetyTests` | 5 | Admin can edit linked account; cannot delete linked; can delete unlinked; cannot change own role (via both detail and me endpoints) |
+| `LinkedAccountSafetyTests` | 8 | Admin can edit linked account; cannot delete linked; can delete unlinked; cannot delete last admin (with audit-denied assertion); can delete self when other admin exists (with audit actor SET_NULL assertion); can delete other admin when multiple exist; cannot change own role (via both detail and me endpoints) |
 | `AppSettingsTests` | 3 | Authenticated user reads settings; admin updates; non-admin cannot update |
 | `VatRateSettingsTests` | 4 | Admin CRUD; non-admin blocked; overlap rejection; valid_to validation |
 | `RbacEndpointMatrixTests` | 6 | Full list/create/update/action-delete/unauthenticated matrix across all endpoints |
@@ -809,7 +816,8 @@ interface ParticipantAccountCreateResult { participant: Participant; account: Us
 8. Participant creation auto-provisions a linked user account with temporary
    password.
 9. Account linking is admin-only; unlink demotes to `guest`; delete blocked for
-   linked accounts.
+   linked accounts and for the last admin. `create_superuser` enforces
+   `role=ADMIN`, so the `role` column is the canonical admin count.
 10. ZEV creation wizard atomically creates ZEV + owner user + owner participant
     + metering points + assignments.
 11. Owner transfer promotes new owner and demotes previous owner if they no

--- a/frontend/src/pages/AdminAccountsPage.tsx
+++ b/frontend/src/pages/AdminAccountsPage.tsx
@@ -32,7 +32,7 @@ const defaultEditUserForm: UserInput = {
 
 export function AdminAccountsPage() {
     const queryClient = useQueryClient()
-    const { user: currentUser, startImpersonation } = useAuth()
+    const { user: currentUser, startImpersonation, logout } = useAuth()
     const { pushToast } = useToast()
     const { t } = useTranslation()
     const { dialog, confirm, handleConfirm, handleCancel, isLoading: dialogLoading } = useConfirmDialog()
@@ -118,8 +118,12 @@ export function AdminAccountsPage() {
 
     const deleteUserMutation = useMutation({
         mutationFn: (userId: number) => deleteUser(userId),
-        onSuccess: () => {
+        onSuccess: (_data, deletedUserId) => {
             pushToast(t('pages.accounts.feedback.deleteSuccess'), 'success')
+            if (deletedUserId === currentUser?.id) {
+                logout()
+                return
+            }
             void queryClient.invalidateQueries({ queryKey: queryKeys.auth.users() })
             void queryClient.invalidateQueries({ queryKey: queryKeys.zev.participants() })
         },


### PR DESCRIPTION
## Summary

Deleting the sole admin account locks everyone out of admin functionality with no in-app recovery path. This adds a last-admin guard to `UserDetailView.perform_destroy` and fixes the frontend leaving a zombie session after self-deletion.

Backend:
- Reject `DELETE /auth/users/{id}/` with 403 when the target is the last `role=admin` user; denied attempt is recorded in the audit log.
- Self-deletion remains allowed when another admin exists.
- Success audit event is recorded before `instance.delete()` so the actor FK is valid; `on_delete=SET_NULL` preserves `actor_display` and `target_id` after self-deletion.

Frontend:
- `deleteUserMutation.onSuccess` detects self-deletion via mutation variables and calls `logout()`, which clears auth state and redirects to `/login` via `ProtectedRoute`.

## Linked spec
- Spec: `docs/specs/2026-03-community-and-access.md` (§6.3, endpoint table, test table, invariant 9)

## Validation
- Backend tests run: `python -m pytest accounts/ metering/ invoices/ -q` — all pass
- Frontend build run: `npm run build` — clean
- Frontend lint run: `npm run lint` — 0 errors (1 pre-existing warning)
- Manual checks: none — covered by 3 new backend tests (last-admin 403 + audit denied; self-delete 204 + audit actor SET_NULL; other-admin delete 204)

## Checklist
- [x] Spec updated/linked for larger or risky changes
- [ ] ADR updated/linked for architecture decisions
- [x] Backend and frontend updated together where API contracts changed