### PR TITLE
docs: align invoice docs with shipped batch endpoints

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,6 +96,7 @@ PVshare Cockpit is a closed, subscription-based SaaS (CHF ~30/participant/year) 
 | Batch approve / cancel / delete invoices | `shipped` | — | — |
 | Invoice PDF generation with Swiss QR-Rechnung, savings chart, and hourly profile | `shipped` | — | [spec](specs/2026-03-invoice-lifecycle-and-communication.md) |
 | DB-stored PDF template with admin editor and revert-to-default | `shipped` | — | [spec](specs/2026-03-invoice-lifecycle-and-communication.md) |
+| Invoice bulk export — ZIP download of all period PDFs (`POST /invoices/invoices/download-pdfs/`) | `shipped` | — | [spec](specs/2026-03-invoice-lifecycle-and-communication.md) |
 | Asynchronous invoice email delivery via Celery (3 retries, `EmailLog`) | `shipped` | — | [spec](specs/2026-03-invoice-lifecycle-and-communication.md) |
 | Email retry for failed `EmailLog` entries | `shipped` | — | — |
 | Per-ZEV customizable email subject/body templates with 6 interpolation variables | `shipped` | — | [spec](specs/2026-03-invoice-lifecycle-and-communication.md) |
@@ -112,7 +113,6 @@ PVshare Cockpit is a closed, subscription-based SaaS (CHF ~30/participant/year) 
 | vZEV feasibility / profitability calculator (aggregate or per-participant, energy-flow topology, self-consumption & internal-price sensitivity, payback/ROI/NPV, prefill of a real ZEV's participants, measured self-consumption, and all-in tariffs) | `shipped` | — | [guide](user-guide/13-feasibility-calculator.md) |
 | Scheduled invoice auto-generation (cron-triggered, per-ZEV billing interval) | `idea` | `medium` | Would remove the manual "generate all" step each month |
 | Payment reference number / ESR reference on invoice | `idea` | `medium` | Needed for automated bank reconciliation in Swiss setup |
-| Invoice bulk export — ZIP of all PDFs for a period | `idea` | `medium` | Useful for accountants and year-end archival |
 | Invoice data export — CSV export of invoice line items | `idea` | `low` | Useful for external accounting software |
 | Mark invoice as disputed / on-hold state | `idea` | `low` | Would require an extra lifecycle state and guard |
 | Credit note / corrective invoice generation | `idea` | `low` | Complex billing edge case; needs dedicated spec |

--- a/docs/specs/2026-03-invoice-lifecycle-and-communication.md
+++ b/docs/specs/2026-03-invoice-lifecycle-and-communication.md
@@ -223,6 +223,9 @@ the same module.
 | `POST` | `/invoices/{id}/generate-pdf/` | `IsZevOwnerOrAdmin` | Generate/regenerate PDF; returns `{pdf_url}` |
 | `POST` | `/invoices/{id}/send-email/` | `IsZevOwnerOrAdmin` | Queue email to participant (optional `email` override); returns `{detail}` |
 | `POST` | `/invoices/{id}/retry-email/{email_log_id}/` | `IsZevOwnerOrAdmin` | Re-queue a failed email; `400` if already sent |
+| `POST` | `/invoices/approve-all/` | `IsZevOwnerOrAdmin` | Approve all draft invoices for a ZEV period (`zev_id`, `period_start`, `period_end`); returns `{approved}`; audit-logged (`invoice.approve_all`) |
+| `POST` | `/invoices/send-all/` | `IsZevOwnerOrAdmin` | Queue emails for all approved invoices in a ZEV period; returns `{queued, skipped}`; audit-logged (`invoice.send_all`, status `queued`) |
+| `POST` | `/invoices/download-pdfs/` | `IsZevOwnerOrAdmin` | Download all period invoice PDFs as a single ZIP (`{invoice_number}.pdf` entries); `404` when the period has no PDFs |
 
 ### 5.5 Period overview
 


### PR DESCRIPTION
## Summary
The batch actions `approve-all`, `send-all`, and `download-pdfs` already exist on `InvoiceViewSet` (covered by `test_batch_actions.py`), but the invoice lifecycle spec's endpoint table omitted all three, and the ROADMAP still listed invoice bulk export as an `idea`.

- `docs/specs/2026-03-invoice-lifecycle-and-communication.md`: added the three missing rows to the endpoint table
- `docs/ROADMAP.md`: moved "Invoice bulk export" from `idea` to `shipped`

## Linked spec
- Spec: `docs/specs/2026-03-invoice-lifecycle-and-communication.md`
- N/A: ADR (no architecture decision)

## Validation
- Backend tests run: not run — docs-only change, no code touched
- Frontend build run: not run — docs-only change
- Frontend tests run: not run — docs-only change
- Manual checks: verified every claim in the new rows against `backend/invoices/views.py` on `main` — `approve_all` (POST, `IsZevOwnerOrAdmin`, filters `DRAFT`, body `zev_id`/`period_start`/`period_end`, returns `{approved}`, audit `invoice.approve_all`), `send_all` (filters `APPROVED`, skips missing recipient, returns `{queued, skipped}`, audit `invoice.send_all` with status `QUEUED`), `download_pdfs` (POST, `IsZevOwnerOrAdmin`, `404` when no PDFs, ZIP entries `{invoice_number}.pdf`)
- Screenshots: N/A (no frontend change)

## Checklist
- [x] Spec updated/linked for larger or risky changes
- N/A: ADR updated/linked (no architecture decision)
- N/A: backend/frontend updated together (docs-only, no API contract change)