### PR TITLE
feat(tariffs): show tariff validity as a badge on the card header

### DIFF
--- a/frontend/src/features/tariffs/TariffCategorySections.tsx
+++ b/frontend/src/features/tariffs/TariffCategorySections.tsx
@@ -10,10 +10,19 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { formatShortDate } from '../../lib/appSettings'
 import type { AppSettings, Tariff, TariffPeriod } from '../../types/api'
+import { todayIso, validityState, type ValidityState } from './validity'
 
 type TariffSection = {
     category: Tariff['category']
     tariffs: Tariff[]
+}
+
+// Amber rather than blue for scheduled: blue is already the billing-mode badge
+// sitting right next to it, and two adjacent blue badges read as one group.
+const VALIDITY_BADGE_CLASS: Record<ValidityState, string> = {
+    active: 'badge badge-success',
+    scheduled: 'badge badge-warning',
+    expired: 'badge badge-neutral',
 }
 
 type TariffCategorySectionsProps = {
@@ -45,6 +54,7 @@ export function TariffCategorySections({
 }: TariffCategorySectionsProps) {
     const { t } = useTranslation()
     const [expandedTariffIds, setExpandedTariffIds] = useState<Set<string>>(new Set())
+    const today = todayIso()
 
     const toggleExpanded = (tariffId: string) => {
         setExpandedTariffIds((current) => {
@@ -95,6 +105,22 @@ export function TariffCategorySections({
                             const notes = tariff.notes?.trim()
                             const isExpanded = expandedTariffIds.has(tariff.id)
 
+                            // The badge names the date that matters for the
+                            // tariff's current state, so the state is carried by
+                            // the wording as well as the colour. The full window
+                            // stays available as a tooltip.
+                            const validity = validityState(tariff, today)
+                            const validFrom = formatShortDate(tariff.valid_from, settings)
+                            const validTo = tariff.valid_to ? formatShortDate(tariff.valid_to, settings) : null
+                            const validityLabel = validity === 'scheduled'
+                                ? t('pages.tariffs.validity.starts', { date: validFrom })
+                                : validity === 'expired'
+                                    ? t('pages.tariffs.validity.ended', { date: validTo })
+                                    : validTo
+                                        ? t('pages.tariffs.validity.until', { date: validTo })
+                                        : t('pages.tariffs.validity.since', { date: validFrom })
+                            const validityTooltip = `${validFrom} - ${validTo ?? t('pages.tariffs.openEnded')}`
+
                             return (
                                 <article key={tariff.id} className="tariff-card">
                                     <div className="tariff-card-header">
@@ -110,6 +136,9 @@ export function TariffCategorySections({
                                                             {t(`pages.tariffs.energyTypes.${tariff.energy_type}` as Parameters<typeof t>[0])}
                                                         </span>
                                                     )}
+                                                    <span className={VALIDITY_BADGE_CLASS[validity]} title={validityTooltip}>
+                                                        {validityLabel}
+                                                    </span>
                                                 </div>
                                             </div>
                                         </div>
@@ -156,20 +185,16 @@ export function TariffCategorySections({
 
                                     {isExpanded && (
                                         <>
-                                            <div className="tariff-card-details">
-                                                <div className="tariff-detail-card">
-                                                    <span className="tariff-detail-label">{t('pages.tariffs.col.validity')}</span>
-                                                    <span className="tariff-detail-value">
-                                                        {formatShortDate(tariff.valid_from, settings)} - {tariff.valid_to ? formatShortDate(tariff.valid_to, settings) : t('pages.tariffs.openEnded')}
-                                                    </span>
-                                                </div>
-                                                {notes && (
+                                            {/* Validity moved to a badge on the header; notes are all
+                                                that is left here, so the block is skipped when empty. */}
+                                            {notes && (
+                                                <div className="tariff-card-details">
                                                     <div className="tariff-detail-card tariff-detail-card-wide">
                                                         <span className="tariff-detail-label">{t('pages.tariffs.form.notes')}</span>
                                                         <span className="tariff-detail-value">{notes}</span>
                                                     </div>
-                                                )}
-                                            </div>
+                                                </div>
+                                            )}
 
                                             {usesPeriods && (
                                                 <div className="tariff-period-section">

--- a/frontend/src/features/tariffs/validity.ts
+++ b/frontend/src/features/tariffs/validity.ts
@@ -1,0 +1,38 @@
+import type { Tariff } from '../../types/api'
+
+export type ValidityState = 'active' | 'scheduled' | 'expired'
+
+/**
+ * Today as `YYYY-MM-DD` in the viewer's own timezone.
+ *
+ * Deliberately not `new Date().toISOString().slice(0, 10)`: that yields the UTC
+ * date, so anywhere east of UTC (Switzerland included) the first hour or two
+ * after midnight reports yesterday — long enough for a tariff that starts today
+ * to be treated as not yet in force.
+ */
+export function todayIso(): string {
+    const now = new Date()
+    const month = String(now.getMonth() + 1).padStart(2, '0')
+    const day = String(now.getDate()).padStart(2, '0')
+    return `${now.getFullYear()}-${month}-${day}`
+}
+
+/**
+ * Where a tariff sits relative to `today`.
+ *
+ * Compared as ISO strings rather than `Date` objects: `new Date('2026-01-01')`
+ * parses as UTC midnight, which reintroduces the offset that `todayIso` exists
+ * to avoid. Lexicographic comparison of two `YYYY-MM-DD` strings is exact.
+ *
+ * Both bounds are inclusive, so a tariff whose window opens or closes today is
+ * active.
+ */
+export function validityState(tariff: Tariff, today: string): ValidityState {
+    if (tariff.valid_from > today) return 'scheduled'
+    if (tariff.valid_to && tariff.valid_to < today) return 'expired'
+    return 'active'
+}
+
+export function isTariffCurrentlyValid(tariff: Tariff, today: string): boolean {
+    return validityState(tariff, today) === 'active'
+}

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -886,6 +886,12 @@ export const de = {
             },
             approxPrice: '≈ CHF {{price}}/kWh',
             approxPriceTooltip: '{{percentage}}% des aktiven Netztarifs (CHF {{basePrice}}/kWh) = CHF {{effectivePrice}}/kWh',
+            validity: {
+                since: 'Seit {{date}}',
+                until: 'Bis {{date}}',
+                starts: 'Ab {{date}}',
+                ended: 'Beendet {{date}}',
+            },
             periodCol: {
                 tariff: 'Tarif',
                 type: 'Typ',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -857,6 +857,12 @@ export const en = {
             },
             approxPrice: '≈ CHF {{price}}/kWh',
             approxPriceTooltip: '{{percentage}}% of the active grid tariff (CHF {{basePrice}}/kWh) = CHF {{effectivePrice}}/kWh',
+            validity: {
+                since: 'Since {{date}}',
+                until: 'Until {{date}}',
+                starts: 'Starts {{date}}',
+                ended: 'Ended {{date}}',
+            },
             periodCol: {
                 tariff: 'Tariff',
                 type: 'Type',

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -893,6 +893,12 @@ export const fr = {
             },
             approxPrice: '≈ CHF {{price}}/kWh',
             approxPriceTooltip: '{{percentage}} % du tarif réseau actif (CHF {{basePrice}}/kWh) = CHF {{effectivePrice}}/kWh',
+            validity: {
+                since: 'Depuis le {{date}}',
+                until: "Jusqu'au {{date}}",
+                starts: 'Dès le {{date}}',
+                ended: 'Terminé le {{date}}',
+            },
             periodCol: {
                 tariff: 'Tarif',
                 type: 'Type',

--- a/frontend/src/i18n/locales/it.ts
+++ b/frontend/src/i18n/locales/it.ts
@@ -893,6 +893,12 @@ export const it = {
             },
             approxPrice: '≈ CHF {{price}}/kWh',
             approxPriceTooltip: '{{percentage}}% della tariffa di rete attiva (CHF {{basePrice}}/kWh) = CHF {{effectivePrice}}/kWh',
+            validity: {
+                since: 'Dal {{date}}',
+                until: 'Fino al {{date}}',
+                starts: 'A partire dal {{date}}',
+                ended: 'Terminata il {{date}}',
+            },
             periodCol: {
                 tariff: 'Tariffa',
                 type: 'Tipo',

--- a/frontend/src/pages/TariffsPage.tsx
+++ b/frontend/src/pages/TariffsPage.tsx
@@ -10,6 +10,7 @@ import { TariffImportModal } from '../features/tariffs/TariffImportModal'
 import { TariffPeriodFormModal } from '../features/tariffs/TariffPeriodFormModal'
 import { TariffToolbar, type TariffValidityFilter } from '../features/tariffs/TariffToolbar'
 import { useTariffTransfer } from '../features/tariffs/useTariffTransfer'
+import { isTariffCurrentlyValid, todayIso } from '../features/tariffs/validity'
 import {
     fetchTariffPeriods,
     fetchTariffs,
@@ -24,12 +25,6 @@ import type { Tariff, TariffPeriod } from '../types/api'
 
 const tariffCategoryOrder: Tariff['category'][] = ['energy', 'grid_fees', 'levies', 'metering']
 
-function isTariffCurrentlyValid(tariff: Tariff, todayIso: string): boolean {
-    if (tariff.valid_from > todayIso) return false
-    if (tariff.valid_to && tariff.valid_to < todayIso) return false
-    return true
-}
-
 export function TariffsPage() {
     const queryClient = useQueryClient()
     const { pushToast } = useToast()
@@ -40,7 +35,9 @@ export function TariffsPage() {
     const { t } = useTranslation()
     const isManagedScope = user?.role === 'admin' || user?.role === 'zev_owner'
     const [validityFilter, setValidityFilter] = useState<TariffValidityFilter>('valid')
-    const todayIso = useMemo(() => new Date().toISOString().slice(0, 10), [])
+    // Shared with the validity badge on each card, so the filter and the badge
+    // can never disagree about whether a tariff is in force.
+    const today = useMemo(() => todayIso(), [])
 
     const tariffsQuery = useQuery({
         queryKey: queryKeys.tariffs.list(selectedZevId || undefined),
@@ -133,8 +130,8 @@ export function TariffsPage() {
     )
 
     const visibleTariffs = useMemo(
-        () => (validityFilter === 'all' ? tariffs : tariffs.filter((tariff) => isTariffCurrentlyValid(tariff, todayIso))),
-        [tariffs, validityFilter, todayIso],
+        () => (validityFilter === 'all' ? tariffs : tariffs.filter((tariff) => isTariffCurrentlyValid(tariff, today))),
+        [tariffs, validityFilter, today],
     )
 
     const tariffSections = useMemo(


### PR DESCRIPTION
Validity was only visible after expanding a tariff, yet it is one of the things you most want while *scanning* a list — particularly with seasonal tariffs, where several versions of the same tariff differ only by their window.

It is now a badge in the card header, next to the billing mode and energy type, and no longer in the detail view.

## The badge

The wording names the date that actually matters for the tariff's current state, so the state is carried by the text and not by colour alone:

| State | Badge | Colour |
|---|---|---|
| In force, open-ended | `Since 01.01.2026` | green |
| In force, with an end date | `Until 31.12.2026` | green |
| Not yet in force | `Starts 01.03.2027` | amber |
| Over | `Ended 31.12.2025` | grey |

The full window is always in the `title` tooltip (`01.01.2026 - Open-ended`), so nothing that was on screen before is lost.

Amber rather than blue for the scheduled state: blue is already the billing-mode badge sitting immediately to its left, and two adjacent blue badges read as one group. Caught this while looking at the rendered page rather than the code.

Since validity was the only thing in the expanded detail block besides notes, that block now renders only when notes exist instead of showing an empty card.

## One shared source of truth

`TariffsPage` already had an `isTariffCurrentlyValid` helper behind its "Valid only / All tariffs" filter, so a badge with its own copy of that logic would have been two things free to drift. Both now come from `features/tariffs/validity.ts`.

That surfaced a bug in the existing filter worth fixing on the way:

```js
// before — UTC
const todayIso = new Date().toISOString().slice(0, 10)
```

`toISOString()` returns the **UTC** date. In Swiss timezones (UTC+1/+2) that is *yesterday* for the first hour or two after midnight, so a tariff starting today was filtered out as not-yet-valid during exactly those hours. The shared helper resolves "today" in the viewer's own timezone, and comparisons stay lexicographic on `YYYY-MM-DD` strings rather than going through `Date` — `new Date('2026-01-01')` parses as UTC midnight and would reintroduce the same offset.

Both bounds are inclusive, so a window that opens or closes today reads as active.

## Verification

Driven in a browser against the dev stack. Only currently-active, open-ended tariffs exist in the dev data, so rather than write test tariffs into your database I intercepted the tariff API response in Playwright and rewrote the validity windows — the real component and CSS, exercised across every state, with nothing persisted.

| Case | Result |
|---|---|
| Active, open-ended | `Since 01.01.2026` · `badge-success` · title `01.01.2026 - Open-ended` |
| Active, with end date | `Until 31.12.2026` · `badge-success` |
| Future window | `Starts 01.03.2027` · `badge-warning` |
| Past window | `Ended 31.12.2025` · `badge-neutral` |
| **Starts today** | `badge-success` — active, not scheduled |
| **Ends today** | `badge-success` — active, not expired |
| Expanded detail labels | `["Notes"]` — validity gone |
| 420px viewport | badges wrap below the name; no element past the viewport edge |

The two boundary cases are the ones the timezone handling exists for, so they are the ones I checked most closely.

`tsc` clean, eslint clean (one pre-existing unrelated warning), `npm run build` clean. Translations in all four locales — Italian needed distinct wording for `since` and `starts`, which both wanted to be "Dal".

## Note

The scheduled and expired badges are only reachable with the validity filter set to **All tariffs**; the default "Valid only" hides those tariffs entirely. So the amber and grey states matter exactly when someone goes looking for a tariff that is not currently in force — which is the case where guessing from a date range was hardest.
