### PR TITLE
fix(tariffs): key the overlap guard on tariff name, not category tuple

### DIFF
--- a/backend/tariffs/models.py
+++ b/backend/tariffs/models.py
@@ -71,25 +71,27 @@ class Tariff(models.Model):
         if self.billing_mode in {BillingMode.ENERGY, BillingMode.PERCENTAGE_OF_ENERGY} and not self.energy_type:
             errors["energy_type"] = "Energy-based tariffs require an energy type."
 
-        if (
-            self.zev_id
-            and self.energy_type
-            and self.valid_from
-            and self.billing_mode in {BillingMode.ENERGY, BillingMode.PERCENTAGE_OF_ENERGY}
-        ):
+        # A ZEV legitimately carries several simultaneous per-kWh components in
+        # one category — grid fees are Netznutzung *and* SDL, levies are the
+        # Netzzuschlag *and* the cantonal charge — and the engine is built to
+        # accumulate them into separate invoice lines. So overlapping windows
+        # are only rejected for tariffs sharing a *name*, which is the case that
+        # is almost certainly a mistake: a new seasonal version created without
+        # closing the previous one, which would double-bill every participant.
+        if self.zev_id and self.name and self.valid_from:
             candidate_end = self.valid_to or date.max
             overlaps = Tariff.objects.exclude(pk=self.pk).filter(
                 zev_id=self.zev_id,
-                category=self.category,
-                billing_mode=self.billing_mode,
-                energy_type=self.energy_type,
+                name=self.name,
                 valid_from__lte=candidate_end,
             ).filter(
                 models.Q(valid_to__isnull=True) | models.Q(valid_to__gte=self.valid_from)
             )
             if overlaps.exists():
                 errors["valid_from"] = (
-                    "Overlapping tariff windows are not allowed for the same ZEV, category, billing mode, and energy type."
+                    f'Another tariff named "{self.name}" in this ZEV already covers part of this '
+                    "validity period. Close the previous one with a valid_to date, or give this "
+                    "one a different name if both should apply at the same time."
                 )
 
         if errors:

--- a/backend/tariffs/test_tariffs.py
+++ b/backend/tariffs/test_tariffs.py
@@ -187,7 +187,93 @@ class TariffActionTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid period data", response.data["error"])
+        self.assertIn("period_type", str(response.data["errors"]))
+        self.assertEqual(response.data["errors"][0]["position"], 1)
+        self.assertEqual(response.data["errors"][0]["name"], "Invalid period tariff")
+        self.assertIn("1 of 1 tariffs could not be imported", response.data["detail"])
+
+    def test_import_accepts_several_simultaneous_components_in_one_category(self):
+        """The real-world shape of a Swiss tariff sheet: grid fees and levies each
+        consist of several per-kWh components that all apply at once."""
+        owner = self.make_owner("tariff_components_import_owner")
+        zev = Zev.objects.create(name="Components import ZEV", owner=owner, zev_type="vzev")
+        client = self.make_client(owner)
+
+        def component(name, category, price):
+            return {
+                "name": name,
+                "category": category,
+                "billing_mode": BillingMode.ENERGY,
+                "energy_type": EnergyType.GRID,
+                "valid_from": "2026-01-01",
+                "periods": [{"period_type": "flat", "price_chf_per_kwh": price}],
+            }
+
+        response = client.post(
+            "/api/v1/tariffs/tariffs/import/",
+            {
+                "zev_id": str(zev.id),
+                "tariffs": [
+                    component("Netznutzung Arbeit", TariffCategory.GRID_FEES, "0.09000"),
+                    component("Systemdienstleistung SDL", TariffCategory.GRID_FEES, "0.00750"),
+                    component("Netzzuschlag", TariffCategory.LEVIES, "0.02300"),
+                    component("Kantonale Abgabe", TariffCategory.LEVIES, "0.00500"),
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data["created"], 4)
+        self.assertEqual(Tariff.objects.filter(zev=zev).count(), 4)
+
+    def test_import_reports_every_rejected_tariff_and_saves_nothing(self):
+        """A preset with several problems is fully diagnosed in one response, so
+        it takes one round trip to fix rather than one per problem."""
+        owner = self.make_owner("tariff_multi_error_owner")
+        zev = Zev.objects.create(name="Multi error ZEV", owner=owner, zev_type="vzev")
+        client = self.make_client(owner)
+
+        response = client.post(
+            "/api/v1/tariffs/tariffs/import/",
+            {
+                "zev_id": str(zev.id),
+                "tariffs": [
+                    {
+                        "name": "Valid Local Energy",
+                        "category": TariffCategory.ENERGY,
+                        "billing_mode": BillingMode.ENERGY,
+                        "energy_type": EnergyType.LOCAL,
+                        "valid_from": "2026-01-01",
+                    },
+                    {
+                        # Energy mode with no energy_type.
+                        "name": "Missing Energy Type",
+                        "category": TariffCategory.ENERGY,
+                        "billing_mode": BillingMode.ENERGY,
+                        "valid_from": "2026-01-01",
+                    },
+                    {
+                        # Duplicate of the first entry's name and window.
+                        "name": "Valid Local Energy",
+                        "category": TariffCategory.ENERGY,
+                        "billing_mode": BillingMode.ENERGY,
+                        "energy_type": EnergyType.LOCAL,
+                        "valid_from": "2026-06-01",
+                    },
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        # Both bad entries reported, identified by position, not just the first.
+        self.assertEqual([failure["position"] for failure in response.data["errors"]], [2, 3])
+        self.assertIn("energy_type", response.data["errors"][0]["errors"])
+        self.assertIn("valid_from", response.data["errors"][1]["errors"])
+        self.assertIn("2 of 3 tariffs could not be imported", response.data["detail"])
+        # All-or-nothing: the valid first entry is rolled back too.
+        self.assertEqual(Tariff.objects.filter(zev=zev).count(), 0)
 
     def test_periods_are_rejected_for_fixed_fee_tariffs(self):
         owner = self.make_owner("tariff_fixed_fee_owner")

--- a/backend/tariffs/tests.py
+++ b/backend/tariffs/tests.py
@@ -248,7 +248,24 @@ class TariffPermissionTests(TestCase):
 		self.assertEqual(str(roundtripped.percentage), "7.25")
 		self.assertIsNone(roundtripped.fixed_price_chf)
 
-	def test_rejects_overlapping_energy_tariffs_for_same_scope(self):
+	def _post_tariff(self, client, zev, name, *, valid_from, valid_to=None,
+	                 category=TariffCategory.ENERGY, billing_mode=BillingMode.ENERGY,
+	                 energy_type="local", **extra):
+		payload = {
+			"zev": str(zev.id),
+			"name": name,
+			"category": category,
+			"billing_mode": billing_mode,
+			"energy_type": energy_type,
+			"valid_from": valid_from,
+			"valid_to": valid_to,
+			**extra,
+		}
+		return client.post("/api/v1/tariffs/tariffs/", payload, format="json")
+
+	def test_rejects_overlapping_tariffs_with_the_same_name(self):
+		"""A second version of a tariff created without closing the first would
+		apply both at once and double-bill every participant."""
 		client = APIClient()
 		owner = User.objects.create_user(
 			username="tariff_overlap_owner",
@@ -258,37 +275,79 @@ class TariffPermissionTests(TestCase):
 		zev = Zev.objects.create(name="Tariff Overlap ZEV", owner=owner, zev_type="vzev")
 		auth(client, owner)
 
-		first_resp = client.post(
-			"/api/v1/tariffs/tariffs/",
-			{
-				"zev": str(zev.id),
-				"name": "Base Local Energy",
-				"category": TariffCategory.ENERGY,
-				"billing_mode": BillingMode.ENERGY,
-				"energy_type": "local",
-				"valid_from": "2026-01-01",
-				"valid_to": "2026-12-31",
-			},
-			format="json",
-		)
-		self.assertEqual(first_resp.status_code, 201)
+		first = self._post_tariff(client, zev, "Local Energy", valid_from="2026-01-01", valid_to="2026-12-31")
+		self.assertEqual(first.status_code, 201)
 
-		second_resp = client.post(
-			"/api/v1/tariffs/tariffs/",
-			{
-				"zev": str(zev.id),
-				"name": "Overlapping Local Energy",
-				"category": TariffCategory.ENERGY,
-				"billing_mode": BillingMode.ENERGY,
-				"energy_type": "local",
-				"valid_from": "2026-06-01",
-				"valid_to": "2027-05-31",
-			},
-			format="json",
-		)
+		second = self._post_tariff(client, zev, "Local Energy", valid_from="2026-06-01", valid_to="2027-05-31")
 
-		self.assertEqual(second_resp.status_code, 400)
-		self.assertIn("valid_from", second_resp.data)
+		self.assertEqual(second.status_code, 400)
+		self.assertIn("valid_from", second.data)
+		self.assertIn("Local Energy", str(second.data["valid_from"]))
+
+	def test_allows_overlapping_tariffs_with_different_names(self):
+		"""Distinct per-kWh components of one category coexist by design — grid
+		fees are Netznutzung *and* SDL — and the engine accumulates them into
+		separate invoice lines."""
+		client = APIClient()
+		owner = User.objects.create_user(
+			username="tariff_components_owner",
+			password="pass1234",
+			role=UserRole.ZEV_OWNER,
+		)
+		zev = Zev.objects.create(name="Tariff Components ZEV", owner=owner, zev_type="vzev")
+		auth(client, owner)
+
+		first = self._post_tariff(
+			client, zev, "Netznutzung Arbeit", valid_from="2026-01-01",
+			category=TariffCategory.GRID_FEES, energy_type="grid")
+		second = self._post_tariff(
+			client, zev, "Systemdienstleistung SDL", valid_from="2026-01-01",
+			category=TariffCategory.GRID_FEES, energy_type="grid")
+
+		self.assertEqual(first.status_code, 201)
+		self.assertEqual(second.status_code, 201)
+		self.assertEqual(Tariff.objects.filter(zev=zev, category=TariffCategory.GRID_FEES).count(), 2)
+
+	def test_allows_the_same_name_in_consecutive_windows(self):
+		"""Seasonal versioning done properly: the old window is closed first."""
+		client = APIClient()
+		owner = User.objects.create_user(
+			username="tariff_seasonal_owner",
+			password="pass1234",
+			role=UserRole.ZEV_OWNER,
+		)
+		zev = Zev.objects.create(name="Tariff Seasonal ZEV", owner=owner, zev_type="vzev")
+		auth(client, owner)
+
+		first = self._post_tariff(client, zev, "Local Energy", valid_from="2026-01-01", valid_to="2026-03-31")
+		second = self._post_tariff(client, zev, "Local Energy", valid_from="2026-04-01")
+
+		self.assertEqual(first.status_code, 201)
+		self.assertEqual(second.status_code, 201)
+
+	def test_rejects_overlapping_fixed_fees_with_the_same_name(self):
+		"""The guard used to skip fixed fees entirely, so a duplicated monthly
+		fee was charged twice with nothing to catch it."""
+		client = APIClient()
+		owner = User.objects.create_user(
+			username="tariff_fee_overlap_owner",
+			password="pass1234",
+			role=UserRole.ZEV_OWNER,
+		)
+		zev = Zev.objects.create(name="Tariff Fee Overlap ZEV", owner=owner, zev_type="vzev")
+		auth(client, owner)
+
+		first = self._post_tariff(
+			client, zev, "Metering Fee", valid_from="2026-01-01",
+			category=TariffCategory.METERING, billing_mode=BillingMode.MONTHLY_FEE,
+			energy_type=None, fixed_price_chf="5.00")
+		second = self._post_tariff(
+			client, zev, "Metering Fee", valid_from="2026-06-01",
+			category=TariffCategory.METERING, billing_mode=BillingMode.MONTHLY_FEE,
+			energy_type=None, fixed_price_chf="6.00")
+
+		self.assertEqual(first.status_code, 201)
+		self.assertEqual(second.status_code, 400)
 
 	def test_allows_adjacent_non_overlapping_energy_tariffs(self):
 		client = APIClient()

--- a/backend/tariffs/views.py
+++ b/backend/tariffs/views.py
@@ -2,8 +2,10 @@ from functools import partial
 
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from accounts.permissions import IsZevOwnerOrAdmin
 from zev.models import Zev
@@ -17,6 +19,53 @@ from audit.services import record_audit_event
 
 # Every audit event in this module is a tariff event; bind the category once.
 _record_tariff_event = partial(record_audit_event, action_category=AuditActionCategory.TARIFF)
+
+
+def _normalise_validation_errors(exc) -> dict:
+    """Flatten a DRF or Django ValidationError into ``{field: [messages]}``.
+
+    The two exception types expose their contents differently, and nested
+    serializer errors arrive as lists of dicts; callers want one predictable
+    shape they can render.
+    """
+    if isinstance(exc, DjangoValidationError):
+        return {
+            field: [str(message) for message in messages]
+            for field, messages in (
+                exc.message_dict if hasattr(exc, 'message_dict')
+                else {'non_field_errors': exc.messages}
+            ).items()
+        }
+
+    detail = exc.detail
+    if not isinstance(detail, dict):
+        return {'non_field_errors': [str(item) for item in (detail if isinstance(detail, list) else [detail])]}
+    return {
+        field: [str(message) for message in (messages if isinstance(messages, list) else [messages])]
+        for field, messages in detail.items()
+    }
+
+
+def _describe_failure(failure: dict) -> str:
+    fields = '; '.join(
+        f"{field}: {' '.join(messages)}" for field, messages in failure['errors'].items()
+    )
+    label = f'"{failure["name"]}"' if failure['name'] else 'unnamed'
+    return f'#{failure["position"]} {label} — {fields}'
+
+
+class _TariffImportFailed(Exception):
+    """Raised to roll the import back once every entry has been checked."""
+
+    def __init__(self, failures: list[dict], *, attempted: int):
+        self.failures = failures
+        self.attempted = attempted
+        details = ' | '.join(_describe_failure(failure) for failure in failures)
+        self.summary = (
+            f'{len(failures)} of {attempted} tariffs could not be imported, '
+            f'so nothing was saved: {details}'
+        )
+        super().__init__(self.summary)
 
 
 class TariffViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelViewSet):
@@ -179,36 +228,16 @@ class TariffViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelVi
 
         try:
             with transaction.atomic():
-                created_tariffs = []
-                for tariff_data in tariffs_data:
-                    tariff_data = dict(tariff_data)
-                    # Extract periods before creating tariff
-                    periods_data = tariff_data.pop('periods', [])
-                    tariff_data.pop('id', None)
-                    tariff_data.pop('zev', None)
-                    tariff_data.pop('created_at', None)
-                    tariff_data.pop('updated_at', None)
-                    # Set the ZEV ID
-                    tariff_data['zev'] = str(zev.id)
+                created_tariffs, failures = self._import_tariff_batch(zev, tariffs_data)
 
-                    # Create tariff
-                    tariff_serializer = TariffSerializer(data=tariff_data)
-                    if not tariff_serializer.is_valid():
-                        raise Exception(f"Invalid tariff data: {tariff_serializer.errors}")
-                    tariff = tariff_serializer.save()
-
-                    # Create periods
-                    for period_data in periods_data:
-                        period_data = dict(period_data)
-                        period_data.pop('id', None)
-                        period_data.pop('tariff', None)
-                        period_data['tariff'] = str(tariff.id)
-                        period_serializer = TariffPeriodSerializer(data=period_data)
-                        if not period_serializer.is_valid():
-                            raise Exception(f"Invalid period data: {period_serializer.errors}")
-                        period_serializer.save()
-
-                    created_tariffs.append(tariff_serializer.data)
+                if failures:
+                    # Every entry is reported in one response rather than only the
+                    # first, so a preset with several problems takes one round trip
+                    # to fix instead of one per problem. The import stays
+                    # all-or-nothing: a partially applied tariff set would price
+                    # invoices against an incomplete structure, which is worse than
+                    # importing nothing.
+                    raise _TariffImportFailed(failures, attempted=len(tariffs_data))
 
                 _record_tariff_event(
                     request=request,
@@ -226,6 +255,24 @@ class TariffViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelVi
                     status=status.HTTP_201_CREATED
                 )
 
+        except _TariffImportFailed as failure:
+            _record_tariff_event(
+                request=request,
+                action_type="tariff.import",
+                target_type="zev.Zev",
+                target=zev,
+                target_id=str(zev.id),
+                target_display=zev.name,
+                summary=f"Tariff import failed for ZEV {zev.name}: {failure.summary}",
+                status=AuditEventStatus.FAILED,
+                metadata={"attempted": failure.attempted, "rejected": len(failure.failures)},
+            )
+            # ``detail`` carries the human-readable summary; ``errors`` keeps the
+            # per-entry breakdown for API consumers.
+            return Response(
+                {'detail': failure.summary, 'errors': failure.failures},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except Exception as e:
             _record_tariff_event(
                 request=request,
@@ -239,6 +286,51 @@ class TariffViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelVi
                 metadata={"error": str(e)},
             )
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+    def _import_tariff_batch(self, zev, tariffs_data):
+        """Create every tariff in ``tariffs_data``, collecting failures as it goes.
+
+        Each entry runs in its own savepoint so one rejection cannot poison the
+        surrounding transaction, letting the remaining entries still be checked.
+        The caller decides what to do with the failures.
+        """
+        created_tariffs = []
+        failures = []
+
+        for index, raw in enumerate(tariffs_data):
+            payload = dict(raw)
+            periods_data = payload.pop('periods', [])
+            for ignored in ('id', 'zev', 'created_at', 'updated_at'):
+                payload.pop(ignored, None)
+            payload['zev'] = str(zev.id)
+
+            try:
+                with transaction.atomic():  # savepoint
+                    tariff_serializer = TariffSerializer(data=payload)
+                    tariff_serializer.is_valid(raise_exception=True)
+                    # The overlap guard lives in the model's full_clean(), which
+                    # the serializer only reaches on save() — so this can raise
+                    # even though is_valid() passed.
+                    tariff = tariff_serializer.save()
+
+                    for period_data in periods_data:
+                        period_payload = dict(period_data)
+                        period_payload.pop('id', None)
+                        period_payload['tariff'] = str(tariff.id)
+                        period_serializer = TariffPeriodSerializer(data=period_payload)
+                        period_serializer.is_valid(raise_exception=True)
+                        period_serializer.save()
+            except (DRFValidationError, DjangoValidationError) as exc:
+                failures.append({
+                    'position': index + 1,
+                    'name': str(raw.get('name') or ''),
+                    'errors': _normalise_validation_errors(exc),
+                })
+                continue
+
+            created_tariffs.append(tariff_serializer.data)
+
+        return created_tariffs, failures
 
 
 class TariffPeriodViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelViewSet):

--- a/docs/specs/2026-03-tariffs-and-billing-engine.md
+++ b/docs/specs/2026-03-tariffs-and-billing-engine.md
@@ -69,9 +69,25 @@ re-implement the engine from scratch.
 
 A tariff is **active on day `d`** iff `valid_from ≤ d` and (`valid_to IS NULL` or `valid_to ≥ d`).
 
-For energy-based tariffs (`billing_mode ∈ {energy, percentage_of_energy}`),
-OpenZEV rejects overlapping validity windows for the same tuple of:
-`(zev, category, billing_mode, energy_type)`.
+OpenZEV rejects overlapping validity windows for two tariffs of the same
+`(zev, name)` — regardless of billing mode.
+
+The rule is deliberately keyed on **name**, not on
+`(category, billing_mode, energy_type)`.  A ZEV normally carries several
+simultaneous per-kWh components inside one category — grid fees are
+*Netznutzung* **and** *Systemdienstleistung*; levies are the *Netzzuschlag*
+**and** a cantonal charge — and §4.4.1 accumulates them into separate invoice
+lines by design (see also the risk table in §12).  Keying the check on the
+category tuple made that ordinary structure unrepresentable.
+
+What the check does catch is the case that is almost always a mistake:
+a new seasonal version of a tariff created without closing the previous one,
+where both windows stay open and every participant is billed twice with nothing
+to signal it.
+
+The check covers fixed-fee modes too.  It previously applied only to
+`energy` and `percentage_of_energy`, so a duplicated monthly fee was charged
+twice unguarded.
 
 ### 3.2 TariffPeriod (price bands within a tariff)
 
@@ -817,6 +833,18 @@ The description renders as: `"Surcharge 50% (50% von CHF 0.32/kWh)"` (German).
 |---|---|
 | `test_owner_can_export_tariffs_as_json` | §6.1: export returns preset array, strips `id`/`zev`, includes nested periods without `tariff` FK |
 | `test_owner_can_import_tariffs_from_json` | §6.2: import creates tariff + periods in target ZEV, returns 201 with created count |
+| `test_import_accepts_several_simultaneous_components_in_one_category` | §3.1: multiple per-kWh components sharing category/mode/energy type import cleanly |
+| `test_import_reports_every_rejected_tariff_and_saves_nothing` | §6.2: every rejected entry reported by position and name in one response; valid entries rolled back with them |
+| `test_import_rejects_invalid_period_payload` | §6.2: nested period errors surface per entry |
+
+### Backend (`tariffs/tests.py`) — validity windows
+
+| Test case | Validates |
+|---|---|
+| `test_rejects_overlapping_tariffs_with_the_same_name` | §3.1: the forgotten-`valid_to` double-billing case is blocked |
+| `test_allows_overlapping_tariffs_with_different_names` | §3.1: distinct simultaneous components are permitted |
+| `test_allows_the_same_name_in_consecutive_windows` | §3.1: seasonal versioning with the old window closed |
+| `test_rejects_overlapping_fixed_fees_with_the_same_name` | §3.1: the check covers fixed-fee modes, not only energy modes |
 
 ### Frontend
 

--- a/docs/user-guide/07-tariff-configuration.md
+++ b/docs/user-guide/07-tariff-configuration.md
@@ -235,11 +235,59 @@ When saving a tariff, OpenZEV checks:
 | Check | Requirement |
 | --- | --- |
 | **Valid From ≤ Valid To** | Validity period must be in order |
-| **No overlapping periods (same type)** | Can't have two "Local Energy" tariffs for the same date |
+| **No overlapping windows for the same name** | Two tariffs *called the same thing* can't both be valid on the same date — see below |
 | **Price format** | Numeric, up to 5 decimals (e.g., `0.12345` CHF/kWh) |
 | **Mandatory fields** | Name, type, validity period, prices |
 
 If validation fails, you'll see a clear error message. Fix and retry.
+
+### Several Tariffs at Once Is Normal
+
+You can have **as many tariffs applying simultaneously as you need**, including
+in the same category, with the same billing mode and the same energy type. This
+is the usual shape of a Swiss tariff sheet:
+
+```
+Grid Fees
+├─ Netznutzung Arbeit         0.09000 CHF/kWh
+└─ Systemdienstleistung SDL   0.00750 CHF/kWh
+
+Levies
+├─ Netzzuschlag               0.02300 CHF/kWh
+└─ Kantonale Abgabe           0.00500 CHF/kWh
+```
+
+All four apply at once, and each becomes its own line on the invoice, so
+participants see what they are paying for rather than one merged figure.
+
+The **only** thing OpenZEV blocks is two tariffs with the **same name** whose
+validity windows overlap — because that is nearly always a forgotten end date:
+
+```
+✗ Local Energy   2026-01-01 → (open)      ← old version, never closed
+  Local Energy   2026-04-01 → (open)      ← new version
+    Both apply. Every participant is billed twice.
+
+✓ Local Energy   2026-01-01 → 2026-03-31  ← closed first
+  Local Energy   2026-04-01 → (open)
+```
+
+So when you introduce a new version of a tariff, set **Valid To** on the old one
+first. If two tariffs really are meant to apply together, give them different
+names — which you would want anyway, since the name is what appears on the
+invoice line.
+
+## Importing Several Tariffs at Once
+
+**Import JSON** applies all or nothing. If any entry is rejected, nothing is
+saved and the error names **every** problem entry by its position in the file and
+its name, so you can fix them all in one pass:
+
+```
+2 of 7 tariffs could not be imported, so nothing was saved:
+  #3 "Kantonale Abgabe" — valid_from: Another tariff named "Kantonale Abgabe" …
+  #5 "Local Energy" — energy_type: Energy tariffs require an energy type.
+```
 
 ## Editing and Deactivating Tariffs
 


### PR DESCRIPTION
## The bug

You reported: importing existing tariffs failed with

> `Overlapping tariff windows are not allowed for the same ZEV, category, billing mode, and energy type`

I built the exact shape you're likely importing — two grid-fee components (Netznutzung + SDL) — and ran it against the engine directly, bypassing the guard:

```
--- invoice lines ---
  energy     Grid Energy                100.0000 x 0.20000 =  20.00
  grid_fees  Netznutzung Arbeit         100.0000 x 0.09000 =   9.00
  grid_fees  Systemdienstleistung SDL   100.0000 x 0.00750 =   0.75
  subtotal: 29.75
```

The engine handles it correctly — three separate, individually-labelled lines. That's not incidental tolerance; the spec's own risk table says overlapping windows "accumulate (no conflict)". The model's constraint contradicted the engine it's supposed to protect.

It was also inconsistent with itself — I confirmed two overlapping `MONTHLY_FEE` tariffs were allowed while two overlapping per-kWh levies were blocked, because the old guard only covered `energy`/`percentage_of_energy`.

## The fix

**Key the overlap guard on tariff name instead of `(category, billing_mode, energy_type)`.**

This still catches the real hazard the guard existed for: a new seasonal version of a tariff created without closing the previous one's `valid_to`, silently double-billing every participant. It no longer blocks the ordinary case of several *distinct* per-kWh components — Netznutzung + SDL, Netzzuschlag + cantonal charge — coexisting in one category, which is the normal shape of a Swiss tariff sheet.

Also closed a gap: the check now covers fixed-fee modes too, which it skipped entirely before.

```python
# Keyed on (zev, name) — catches "same tariff, forgotten end date",
# not "two different tariffs in the same category".
overlaps = Tariff.objects.exclude(pk=self.pk).filter(
    zev_id=self.zev_id, name=self.name, valid_from__lte=candidate_end,
).filter(models.Q(valid_to__isnull=True) | models.Q(valid_to__gte=self.valid_from))
```

## Import error handling

While in there: `import_tariffs` aborted on the **first** invalid entry with a raw `Invalid tariff data: {...}` dump from a bare `Exception`, discarding the whole batch without saying what else was wrong.

Now every rejected entry is collected — each runs in its own savepoint so one failure can't poison the transaction — and reported together, by position and name:

```
2 of 7 tariffs could not be imported, so nothing was saved:
  #3 "Kantonale Abgabe" — valid_from: Another tariff named "Kantonale Abgabe" …
  #5 "Local Energy" — energy_type: Energy tariffs require an energy type.
```

The import is still all-or-nothing on success — a partially applied tariff set would price invoices against an incomplete structure, which is worse than importing nothing.

## Tests

8 new/rewritten cases:
- Same-name overlap is rejected (energy **and** fixed-fee modes)
- Different-name overlap in one category is accepted — this is your scenario, run end-to-end through `/tariffs/import/`
- Same name in consecutive, properly-closed windows is accepted
- Multi-error import reports every failure by position/name and rolls everything back
- Existing single-error import test updated to the new response shape

`664 passed` (was 656), ruff clean, no pending migrations.

## Docs

Spec §3.1 rewritten to explain *why* the check is keyed on name, with a cross-reference to §4.4.1 where the engine actually accumulates same-category tariffs. User guide gets a new "Several Tariffs at Once Is Normal" section with the Netznutzung/SDL example and a right/wrong diagram for the seasonal-versioning case, plus a note on the new import error format.
