### PR TITLE
feat(tariffs): version tariffs by name with gap detection

### DIFF
--- a/backend/tariffs/models.py
+++ b/backend/tariffs/models.py
@@ -4,6 +4,8 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from zev.models import Zev
 
+from .series import SERIES_FIELDS
+
 
 class EnergyType(models.TextChoices):
     LOCAL = "local", "Local (Solar/ZEV)"
@@ -93,6 +95,25 @@ class Tariff(models.Model):
                     "validity period. Close the previous one with a valid_to date, or give this "
                     "one a different name if both should apply at the same time."
                 )
+
+            # Tariffs sharing a name are versions of one another, so they must
+            # agree on what the tariff *is*. Letting these drift would make the
+            # series incoherent: comparing versions would compare a local-energy
+            # rate against a grid fee, and the engine would bucket the same
+            # "tariff" differently from one year to the next.
+            sibling = Tariff.objects.exclude(pk=self.pk).filter(
+                zev_id=self.zev_id, name=self.name
+            ).first()
+            if sibling is not None:
+                for field in SERIES_FIELDS:
+                    mine, theirs = getattr(self, field), getattr(sibling, field)
+                    if mine != theirs:
+                        errors[field] = (
+                            f'Other versions of "{self.name}" in this ZEV use '
+                            f"{field}={theirs!r}. Every version of a tariff must agree on its "
+                            "category, billing mode, and energy type — use a different name to "
+                            "create a separate tariff instead."
+                        )
 
         if errors:
             raise ValidationError(errors)

--- a/backend/tariffs/series.py
+++ b/backend/tariffs/series.py
@@ -1,0 +1,123 @@
+"""Tariff versioning: grouping, gap detection, and validity-window arithmetic.
+
+A *series* is every tariff in a ZEV sharing a name. That grouping is not a
+convention layered on top of the data — it is the invariant the model already
+enforces: two tariffs with the same name in one ZEV may not have overlapping
+validity windows (see ``Tariff.clean``). So the versions of a series form a
+non-overlapping timeline by construction, and the billing engine already picks
+the right one because it resolves tariffs per day.
+
+The pure functions here are kept free of the ORM so the window arithmetic — the
+part that is easy to get wrong by a day — can be tested directly.
+"""
+
+from datetime import date, timedelta
+from typing import Iterable, NamedTuple
+
+# Fields that identify what a tariff *is*, as opposed to when it applies or what
+# it costs. Every version of one series must agree on all of them; otherwise
+# "the same tariff over time" is not a meaningful claim and comparing versions
+# would mean comparing a local-energy rate against a grid fee.
+SERIES_FIELDS = ("category", "billing_mode", "energy_type")
+
+#: Series are keyed on name alone. Category is deliberately excluded: two
+#: tariffs sharing a name would be indistinguishable on an invoice line anyway,
+#: and the overlap guard already treats them as the same thing.
+SERIES_KEY_FIELDS = ("zev_id", "name")
+
+
+class Gap(NamedTuple):
+    """An uncovered stretch between two versions of a series.
+
+    Gaps are a billing hazard rather than a modelling curiosity: the engine
+    prices energy only against tariffs active on the day, so a day inside a gap
+    yields consumed kWh with no line item and no charge at all.
+    """
+
+    start: date
+    end: date
+
+
+class VersionWindow(NamedTuple):
+    """Where a new version fits into an existing timeline."""
+
+    #: Version whose window must be truncated to make room, if any.
+    predecessor_id: object | None
+    #: New end date for that predecessor (``None`` when nothing to truncate).
+    predecessor_valid_to: date | None
+    #: End date the new version must take so it stops before the next one.
+    valid_to: date | None
+
+
+def series_key(tariff) -> tuple:
+    return tuple(getattr(tariff, field) for field in SERIES_KEY_FIELDS)
+
+
+def sort_versions(versions: Iterable) -> list:
+    """Oldest first. ``valid_from`` is unique within a series, so this is total."""
+    return sorted(versions, key=lambda version: version.valid_from)
+
+
+def active_version(versions: Iterable, today: date):
+    """The version in force on ``today``, or ``None`` if the series has a gap there."""
+    for version in versions:
+        if version.valid_from <= today and (version.valid_to is None or version.valid_to >= today):
+            return version
+    return None
+
+
+def find_gaps(versions: Iterable) -> list[Gap]:
+    """Uncovered stretches between consecutive versions, oldest first.
+
+    Only interior gaps are reported. The stretch before the first version and
+    after an end-dated last version are not gaps — they are simply periods the
+    series does not cover, which is normal for a tariff that started late or
+    has been retired.
+    """
+    ordered = sort_versions(versions)
+    gaps = []
+    for earlier, later in zip(ordered, ordered[1:]):
+        if earlier.valid_to is None:
+            # Open-ended followed by another version would be an overlap, which
+            # the model rejects. Nothing to report.
+            continue
+        expected_next = earlier.valid_to + timedelta(days=1)
+        if later.valid_from > expected_next:
+            gaps.append(Gap(expected_next, later.valid_from - timedelta(days=1)))
+    return gaps
+
+
+def plan_new_version(versions: Iterable, valid_from: date) -> VersionWindow:
+    """Work out how a version starting on ``valid_from`` slots into the timeline.
+
+    The predecessor is truncated to the day before, and the new version is
+    capped at the day before whichever version follows it — so inserting into
+    the middle of a chain bounds *both* sides. Without the second half the new
+    version would swallow its successor's window and be rejected by the overlap
+    guard with a message that explains nothing.
+
+    A predecessor that already ends before ``valid_from`` is left alone: the
+    resulting gap may well be deliberate, and silently extending a closed
+    window would change what that period bills.
+    """
+    ordered = sort_versions(versions)
+
+    predecessor = None
+    successor = None
+    for version in ordered:
+        if version.valid_from < valid_from:
+            predecessor = version
+        elif version.valid_from > valid_from and successor is None:
+            successor = version
+
+    truncate_to = None
+    if predecessor is not None:
+        day_before = valid_from - timedelta(days=1)
+        if predecessor.valid_to is None or predecessor.valid_to > day_before:
+            truncate_to = day_before
+
+    return VersionWindow(
+        predecessor_id=predecessor.pk if predecessor is not None else None,
+        predecessor_valid_to=truncate_to,
+        valid_to=(successor.valid_from - timedelta(days=1)) if successor is not None else None,
+    )

--- a/backend/tariffs/test_series.py
+++ b/backend/tariffs/test_series.py
@@ -1,0 +1,232 @@
+"""Unit tests for tariff-series arithmetic.
+
+No database: ``series.py`` is deliberately ORM-free so the part that is easy to
+get wrong by a single day can be stated as arithmetic. The API behaviour built
+on top is covered in ``test_versioning.py``.
+"""
+
+from datetime import date
+
+import pytest
+
+from .series import Gap, active_version, find_gaps, plan_new_version, sort_versions
+
+
+class FakeVersion:
+    """Enough of a Tariff for the window arithmetic."""
+
+    def __init__(self, pk, valid_from, valid_to=None):
+        self.pk = pk
+        self.valid_from = valid_from
+        self.valid_to = valid_to
+
+    def __repr__(self):
+        return f"<{self.pk} {self.valid_from}..{self.valid_to}>"
+
+
+def version(pk, valid_from, valid_to=None):
+    return FakeVersion(pk, date.fromisoformat(valid_from),
+                       date.fromisoformat(valid_to) if valid_to else None)
+
+
+# ---------------------------------------------------------------------------
+# sort_versions / active_version
+# ---------------------------------------------------------------------------
+
+def test_versions_sort_oldest_first_regardless_of_input_order():
+    late = version("late", "2027-01-01")
+    early = version("early", "2025-01-01", "2025-12-31")
+    middle = version("middle", "2026-01-01", "2026-12-31")
+
+    assert sort_versions([late, early, middle]) == [early, middle, late]
+
+
+def test_the_active_version_is_the_one_covering_today():
+    versions = [
+        version("v1", "2025-01-01", "2025-12-31"),
+        version("v2", "2026-01-01", "2026-12-31"),
+        version("v3", "2027-01-01"),
+    ]
+
+    assert active_version(versions, date(2026, 6, 15)).pk == "v2"
+
+
+@pytest.mark.parametrize("day", ["2026-01-01", "2026-12-31"])
+def test_both_bounds_of_a_window_are_inclusive(day):
+    versions = [version("v", "2026-01-01", "2026-12-31")]
+
+    assert active_version(versions, date.fromisoformat(day)).pk == "v"
+
+
+def test_an_open_ended_version_stays_active_indefinitely():
+    versions = [version("v", "2026-01-01")]
+
+    assert active_version(versions, date(2099, 1, 1)).pk == "v"
+
+
+def test_a_day_inside_a_gap_has_no_active_version():
+    """Which is exactly the state that bills consumed energy at nothing."""
+    versions = [
+        version("v1", "2026-01-01", "2026-06-30"),
+        version("v2", "2026-08-01"),
+    ]
+
+    assert active_version(versions, date(2026, 7, 15)) is None
+
+
+def test_a_day_before_the_series_begins_has_no_active_version():
+    assert active_version([version("v", "2026-01-01")], date(2025, 12, 31)) is None
+
+
+# ---------------------------------------------------------------------------
+# find_gaps
+# ---------------------------------------------------------------------------
+
+def test_a_contiguous_timeline_has_no_gaps():
+    versions = [
+        version("v1", "2025-01-01", "2025-12-31"),
+        version("v2", "2026-01-01", "2026-12-31"),
+        version("v3", "2027-01-01"),
+    ]
+
+    assert find_gaps(versions) == []
+
+
+def test_a_missing_month_is_reported_with_inclusive_bounds():
+    versions = [
+        version("v1", "2026-01-01", "2026-06-30"),
+        version("v2", "2026-08-01"),
+    ]
+
+    assert find_gaps(versions) == [Gap(date(2026, 7, 1), date(2026, 7, 31))]
+
+
+def test_a_single_missing_day_is_still_a_gap():
+    """The off-by-one that a manual end date invites."""
+    versions = [
+        version("v1", "2026-01-01", "2026-12-30"),
+        version("v2", "2027-01-01"),
+    ]
+
+    assert find_gaps(versions) == [Gap(date(2026, 12, 31), date(2026, 12, 31))]
+
+
+def test_every_interior_gap_is_reported():
+    versions = [
+        version("v1", "2026-01-01", "2026-01-31"),
+        version("v2", "2026-03-01", "2026-03-31"),
+        version("v3", "2026-05-01"),
+    ]
+
+    assert find_gaps(versions) == [
+        Gap(date(2026, 2, 1), date(2026, 2, 28)),
+        Gap(date(2026, 4, 1), date(2026, 4, 30)),
+    ]
+
+
+def test_the_stretch_before_the_first_version_is_not_a_gap():
+    assert find_gaps([version("v", "2026-06-01")]) == []
+
+
+def test_a_retired_series_does_not_report_a_trailing_gap():
+    """A tariff that has ended simply no longer applies; that is not a hole."""
+    assert find_gaps([version("v", "2026-01-01", "2026-12-31")]) == []
+
+
+def test_gaps_are_found_regardless_of_input_order():
+    versions = [
+        version("v2", "2026-08-01"),
+        version("v1", "2026-01-01", "2026-06-30"),
+    ]
+
+    assert find_gaps(versions) == [Gap(date(2026, 7, 1), date(2026, 7, 31))]
+
+
+# ---------------------------------------------------------------------------
+# plan_new_version
+# ---------------------------------------------------------------------------
+
+def test_appending_closes_the_open_ended_predecessor_the_day_before():
+    versions = [version("v1", "2026-01-01")]
+
+    window = plan_new_version(versions, date(2027, 1, 1))
+
+    assert window.predecessor_id == "v1"
+    assert window.predecessor_valid_to == date(2026, 12, 31)
+    assert window.valid_to is None
+
+
+def test_appending_truncates_a_predecessor_that_ends_too_late():
+    versions = [version("v1", "2026-01-01", "2027-12-31")]
+
+    window = plan_new_version(versions, date(2027, 1, 1))
+
+    assert window.predecessor_valid_to == date(2026, 12, 31)
+
+
+def test_inserting_mid_chain_bounds_both_sides():
+    """Without the upper bound the new version would swallow its successor's
+    window and be rejected by the overlap guard for reasons the caller cannot
+    see."""
+    versions = [
+        version("v1", "2026-01-01", "2026-12-31"),
+        version("v3", "2028-01-01"),
+    ]
+
+    window = plan_new_version(versions, date(2027, 1, 1))
+
+    assert window.predecessor_id == "v1"
+    assert window.predecessor_valid_to is None  # already ends before the new start
+    assert window.valid_to == date(2027, 12, 31)
+
+
+def test_inserting_mid_chain_truncates_an_overlapping_predecessor():
+    versions = [
+        version("v1", "2026-01-01", "2027-06-30"),
+        version("v3", "2028-01-01"),
+    ]
+
+    window = plan_new_version(versions, date(2027, 1, 1))
+
+    assert window.predecessor_valid_to == date(2026, 12, 31)
+    assert window.valid_to == date(2027, 12, 31)
+
+
+def test_a_predecessor_that_already_ends_earlier_is_left_alone():
+    """Extending a closed window would change what that period bills, and the
+    resulting gap may well be deliberate."""
+    versions = [version("v1", "2026-01-01", "2026-06-30")]
+
+    window = plan_new_version(versions, date(2027, 1, 1))
+
+    assert window.predecessor_id == "v1"
+    assert window.predecessor_valid_to is None
+
+
+def test_prepending_before_every_existing_version_has_no_predecessor():
+    versions = [version("v1", "2026-01-01")]
+
+    window = plan_new_version(versions, date(2025, 1, 1))
+
+    assert window.predecessor_id is None
+    assert window.predecessor_valid_to is None
+    assert window.valid_to == date(2025, 12, 31)
+
+
+def test_the_first_version_of_a_series_is_unbounded():
+    window = plan_new_version([], date(2026, 1, 1))
+
+    assert window.predecessor_id is None
+    assert window.valid_to is None
+
+
+def test_only_the_immediately_preceding_version_is_truncated():
+    versions = [
+        version("v1", "2025-01-01", "2025-12-31"),
+        version("v2", "2026-01-01"),
+    ]
+
+    window = plan_new_version(versions, date(2027, 1, 1))
+
+    assert window.predecessor_id == "v2"
+    assert window.predecessor_valid_to == date(2026, 12, 31)

--- a/backend/tariffs/test_versioning.py
+++ b/backend/tariffs/test_versioning.py
@@ -1,0 +1,422 @@
+"""API tests for tariff versioning.
+
+Versions of a tariff are the tariffs in a ZEV sharing its name — an invariant
+the model already enforces by rejecting overlapping windows for one name. These
+endpoints supply what was missing: grouping them for display, and moving the
+timeline without hand-computing end dates, which is where the off-by-one that
+silently unbills a month came from.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from tariffs.models import BillingMode, EnergyType, PeriodType, Tariff, TariffCategory
+from testing import factories
+from testing.helpers import authenticate as auth
+from rest_framework.test import APIClient
+
+pytestmark = pytest.mark.django_db
+
+SERIES_URL = "/api/v1/tariffs/tariffs/series/"
+
+
+def url(tariff, verb):
+    return f"/api/v1/tariffs/tariffs/{tariff.pk}/{verb}/"
+
+
+@pytest.fixture
+def owner_client(db):
+    owner = factories.OwnerFactory()
+    zev = factories.ZevFactory(owner=owner)
+    client = APIClient()
+    auth(client, owner)
+    return client, zev
+
+
+def energy_version(zev, *, name="Local Energy", valid_from, valid_to=None, price="0.10000",
+                   category=TariffCategory.ENERGY, energy_type=EnergyType.LOCAL):
+    """One version of a flat-rate energy tariff."""
+    tariff = factories.TariffFactory(
+        zev=zev, name=name, category=category, billing_mode=BillingMode.ENERGY,
+        energy_type=energy_type,
+        valid_from=date.fromisoformat(valid_from),
+        valid_to=date.fromisoformat(valid_to) if valid_to else None,
+    )
+    factories.TariffPeriodFactory(
+        tariff=tariff, period_type=PeriodType.FLAT, price_chf_per_kwh=Decimal(price)
+    )
+    return tariff
+
+
+# ---------------------------------------------------------------------------
+# GET series
+# ---------------------------------------------------------------------------
+
+def test_versions_of_one_name_collapse_into_a_single_series(owner_client):
+    client, zev = owner_client
+    energy_version(zev, valid_from="2025-01-01", valid_to="2025-12-31", price="0.10000")
+    energy_version(zev, valid_from="2026-01-01", price="0.11000")
+
+    response = client.get(SERIES_URL)
+
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    series = response.data[0]
+    assert series["name"] == "Local Energy"
+    assert series["version_count"] == 2
+    assert series["category"] == TariffCategory.ENERGY
+    assert series["energy_type"] == EnergyType.LOCAL
+
+
+def test_versions_come_back_newest_first(owner_client):
+    client, zev = owner_client
+    energy_version(zev, valid_from="2025-01-01", valid_to="2025-12-31")
+    energy_version(zev, valid_from="2026-01-01", valid_to="2026-12-31")
+    energy_version(zev, valid_from="2027-01-01")
+
+    series = client.get(SERIES_URL).data[0]
+
+    assert [v["valid_from"] for v in series["versions"]] == ["2027-01-01", "2026-01-01", "2025-01-01"]
+
+
+def test_the_active_version_is_identified(owner_client):
+    client, zev = owner_client
+    energy_version(zev, valid_from="2020-01-01", valid_to="2020-12-31")
+    current = energy_version(zev, valid_from="2021-01-01")
+
+    series = client.get(SERIES_URL).data[0]
+
+    assert series["active_version_id"] == str(current.pk)
+
+
+def test_a_fully_retired_series_reports_no_active_version(owner_client):
+    client, zev = owner_client
+    energy_version(zev, valid_from="2020-01-01", valid_to="2020-12-31")
+
+    series = client.get(SERIES_URL).data[0]
+
+    assert series["active_version_id"] is None
+
+
+def test_distinct_names_stay_separate_series(owner_client):
+    client, zev = owner_client
+    energy_version(zev, name="Netznutzung", valid_from="2026-01-01",
+                   category=TariffCategory.GRID_FEES, energy_type=EnergyType.GRID)
+    energy_version(zev, name="Systemdienstleistung", valid_from="2026-01-01",
+                   category=TariffCategory.GRID_FEES, energy_type=EnergyType.GRID)
+
+    response = client.get(SERIES_URL)
+
+    assert {series["name"] for series in response.data} == {"Netznutzung", "Systemdienstleistung"}
+
+
+def test_a_gap_in_the_timeline_is_reported(owner_client):
+    """The whole reason gaps matter: a day with no version bills its energy at
+    nothing, and today that is invisible."""
+    client, zev = owner_client
+    energy_version(zev, valid_from="2026-01-01", valid_to="2026-06-30")
+    energy_version(zev, valid_from="2026-08-01")
+
+    series = client.get(SERIES_URL).data[0]
+
+    assert series["gaps"] == [{"start": "2026-07-01", "end": "2026-07-31"}]
+
+
+def test_a_contiguous_series_reports_no_gaps(owner_client):
+    client, zev = owner_client
+    energy_version(zev, valid_from="2026-01-01", valid_to="2026-12-31")
+    energy_version(zev, valid_from="2027-01-01")
+
+    assert client.get(SERIES_URL).data[0]["gaps"] == []
+
+
+def test_series_are_scoped_to_the_callers_zevs(owner_client):
+    client, zev = owner_client
+    energy_version(zev, valid_from="2026-01-01")
+    other = factories.ZevFactory()
+    energy_version(other, name="Someone Elses Tariff", valid_from="2026-01-01")
+
+    response = client.get(SERIES_URL)
+
+    assert [series["name"] for series in response.data] == ["Local Energy"]
+
+
+def test_series_can_be_filtered_to_one_zev(owner_client):
+    client, zev = owner_client
+    owner = zev.owner
+    second = factories.ZevFactory(owner=owner)
+    energy_version(zev, valid_from="2026-01-01")
+    energy_version(second, name="Second ZEV Tariff", valid_from="2026-01-01")
+
+    response = client.get(SERIES_URL, {"zev_id": str(second.pk)})
+
+    assert [series["name"] for series in response.data] == ["Second ZEV Tariff"]
+
+
+# ---------------------------------------------------------------------------
+# new-version
+# ---------------------------------------------------------------------------
+
+def test_a_new_version_closes_the_previous_one_the_day_before(owner_client):
+    client, zev = owner_client
+    original = energy_version(zev, valid_from="2026-01-01", price="0.10000")
+
+    response = client.post(url(original, "new-version"), {"valid_from": "2027-01-01"}, format="json")
+
+    assert response.status_code == 201, response.data
+    original.refresh_from_db()
+    assert original.valid_to == date(2026, 12, 31)
+    assert response.data["valid_from"] == "2027-01-01"
+    assert response.data["valid_to"] is None
+
+
+def test_a_new_version_leaves_no_gap(owner_client):
+    """Auto-closing removes the cause of the silently-unbilled month."""
+    client, zev = owner_client
+    original = energy_version(zev, valid_from="2026-01-01")
+
+    client.post(url(original, "new-version"), {"valid_from": "2027-01-01"}, format="json")
+
+    assert client.get(SERIES_URL).data[0]["gaps"] == []
+
+
+def test_a_new_version_copies_the_price_bands(owner_client):
+    """Prices live on TariffPeriod, so a copy without them would be free energy."""
+    client, zev = owner_client
+    original = factories.TariffFactory(
+        zev=zev, name="Grid Energy", category=TariffCategory.ENERGY,
+        billing_mode=BillingMode.ENERGY, energy_type=EnergyType.GRID,
+        valid_from=date(2026, 1, 1),
+    )
+    factories.TariffPeriodFactory(tariff=original, period_type=PeriodType.HIGH,
+                                  price_chf_per_kwh=Decimal("0.28000"),
+                                  time_from="06:00", time_to="22:00")
+    factories.TariffPeriodFactory(tariff=original, period_type=PeriodType.LOW,
+                                  price_chf_per_kwh=Decimal("0.18000"),
+                                  time_from="22:00", time_to="06:00")
+
+    response = client.post(url(original, "new-version"), {"valid_from": "2027-01-01"}, format="json")
+
+    created = Tariff.objects.get(pk=response.data["id"])
+    copied = {period.period_type: period.price_chf_per_kwh for period in created.periods.all()}
+    assert copied == {PeriodType.HIGH: Decimal("0.28000"), PeriodType.LOW: Decimal("0.18000")}
+    assert created.periods.get(period_type=PeriodType.HIGH).time_from.hour == 6
+
+
+def test_a_new_version_can_set_new_prices_in_one_call(owner_client):
+    """A version almost always exists because the price changed, so requiring a
+    second request to edit it would make the common case two steps."""
+    client, zev = owner_client
+    original = energy_version(zev, valid_from="2026-01-01", price="0.10000")
+
+    response = client.post(
+        url(original, "new-version"),
+        {
+            "valid_from": "2027-01-01",
+            "periods": [{"period_type": PeriodType.FLAT, "price_chf_per_kwh": "0.12500"}],
+        },
+        format="json",
+    )
+
+    created = Tariff.objects.get(pk=response.data["id"])
+    assert [p.price_chf_per_kwh for p in created.periods.all()] == [Decimal("0.12500")]
+    # The source keeps its own price.
+    assert [p.price_chf_per_kwh for p in original.periods.all()] == [Decimal("0.10000")]
+
+
+def test_a_new_version_of_a_fixed_fee_can_override_the_amount(owner_client):
+    client, zev = owner_client
+    original = factories.TariffFactory(
+        zev=zev, name="Metering Fee", category=TariffCategory.METERING,
+        billing_mode=BillingMode.MONTHLY_FEE, energy_type=None,
+        fixed_price_chf=Decimal("5.00"), valid_from=date(2026, 1, 1),
+    )
+
+    response = client.post(
+        url(original, "new-version"),
+        {"valid_from": "2027-01-01", "fixed_price_chf": "6.50"},
+        format="json",
+    )
+
+    assert response.status_code == 201, response.data
+    assert Tariff.objects.get(pk=response.data["id"]).fixed_price_chf == Decimal("6.50")
+
+
+def test_inserting_a_version_mid_chain_bounds_it_against_the_successor(owner_client):
+    client, zev = owner_client
+    first = energy_version(zev, valid_from="2026-01-01", valid_to="2026-12-31")
+    energy_version(zev, valid_from="2028-01-01")
+
+    response = client.post(url(first, "new-version"), {"valid_from": "2027-01-01"}, format="json")
+
+    assert response.status_code == 201, response.data
+    assert response.data["valid_to"] == "2027-12-31"
+    assert client.get(SERIES_URL).data[0]["gaps"] == []
+
+
+def test_a_second_version_cannot_start_on_an_existing_start_date(owner_client):
+    client, zev = owner_client
+    original = energy_version(zev, valid_from="2026-01-01")
+
+    response = client.post(url(original, "new-version"), {"valid_from": "2026-01-01"}, format="json")
+
+    assert response.status_code == 400
+    assert "already starts" in str(response.data["valid_from"])
+
+
+def test_new_version_requires_a_date(owner_client):
+    client, zev = owner_client
+    original = energy_version(zev, valid_from="2026-01-01")
+
+    response = client.post(url(original, "new-version"), {}, format="json")
+
+    assert response.status_code == 400
+    assert "valid_from" in response.data
+
+
+def test_new_version_rejects_a_malformed_date(owner_client):
+    client, zev = owner_client
+    original = energy_version(zev, valid_from="2026-01-01")
+
+    response = client.post(url(original, "new-version"), {"valid_from": "01.01.2027"}, format="json")
+
+    assert response.status_code == 400
+    assert "valid_from" in response.data
+
+
+def test_new_version_is_refused_on_another_owners_tariff(owner_client):
+    client, _ = owner_client
+    foreign = energy_version(factories.ZevFactory(), valid_from="2026-01-01")
+
+    response = client.post(url(foreign, "new-version"), {"valid_from": "2027-01-01"}, format="json")
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# duplicate
+# ---------------------------------------------------------------------------
+
+def test_duplicate_creates_a_separate_series_without_touching_the_source(owner_client):
+    client, zev = owner_client
+    original = energy_version(zev, valid_from="2026-01-01", price="0.10000")
+
+    response = client.post(url(original, "duplicate"), {"name": "Local Energy Reduced"}, format="json")
+
+    assert response.status_code == 201, response.data
+    original.refresh_from_db()
+    assert original.valid_to is None  # timeline untouched
+    copy = Tariff.objects.get(pk=response.data["id"])
+    assert copy.name == "Local Energy Reduced"
+    assert [p.price_chf_per_kwh for p in copy.periods.all()] == [Decimal("0.10000")]
+
+
+def test_duplicate_requires_a_name(owner_client):
+    client, zev = owner_client
+    original = energy_version(zev, valid_from="2026-01-01")
+
+    response = client.post(url(original, "duplicate"), {"name": "   "}, format="json")
+
+    assert response.status_code == 400
+    assert "name" in response.data
+
+
+def test_duplicate_refuses_the_source_name(owner_client):
+    """That request means "another version", which has its own endpoint and very
+    different timeline semantics."""
+    client, zev = owner_client
+    original = energy_version(zev, valid_from="2026-01-01")
+
+    response = client.post(url(original, "duplicate"), {"name": "Local Energy"}, format="json")
+
+    assert response.status_code == 400
+    assert "new-version" in str(response.data["name"])
+
+
+# ---------------------------------------------------------------------------
+# rename-series
+# ---------------------------------------------------------------------------
+
+def test_renaming_a_series_renames_every_version(owner_client):
+    """The name is what groups versions, so renaming one would fork the chain."""
+    client, zev = owner_client
+    first = energy_version(zev, valid_from="2025-01-01", valid_to="2025-12-31")
+    second = energy_version(zev, valid_from="2026-01-01")
+
+    response = client.post(url(second, "rename-series"), {"name": "ZEV Solar"}, format="json")
+
+    assert response.status_code == 200, response.data
+    first.refresh_from_db()
+    second.refresh_from_db()
+    assert (first.name, second.name) == ("ZEV Solar", "ZEV Solar")
+    assert client.get(SERIES_URL).data[0]["version_count"] == 2
+
+
+def test_renaming_onto_an_existing_name_is_refused(owner_client):
+    client, zev = owner_client
+    energy_version(zev, name="Grid Energy", valid_from="2026-01-01", energy_type=EnergyType.GRID)
+    local = energy_version(zev, name="Local Energy", valid_from="2026-01-01")
+
+    response = client.post(url(local, "rename-series"), {"name": "Grid Energy"}, format="json")
+
+    assert response.status_code == 400
+    assert "already exists" in str(response.data["name"])
+
+
+def test_renaming_to_the_same_name_is_a_no_op(owner_client):
+    client, zev = owner_client
+    original = energy_version(zev, valid_from="2026-01-01")
+
+    response = client.post(url(original, "rename-series"), {"name": "Local Energy"}, format="json")
+
+    assert response.status_code == 200
+    assert Tariff.objects.filter(zev=zev, name="Local Energy").count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Series coherence
+# ---------------------------------------------------------------------------
+
+def test_a_version_cannot_change_what_the_tariff_is(owner_client):
+    """Versions sharing a name must agree on category/mode/energy type, or
+    comparing them would compare a local rate against a grid fee."""
+    client, zev = owner_client
+    energy_version(zev, valid_from="2026-01-01", valid_to="2026-12-31")
+
+    response = client.post(
+        "/api/v1/tariffs/tariffs/",
+        {
+            "zev": str(zev.pk),
+            "name": "Local Energy",
+            "category": TariffCategory.GRID_FEES,
+            "billing_mode": BillingMode.ENERGY,
+            "energy_type": EnergyType.GRID,
+            "valid_from": "2027-01-01",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert "category" in response.data or "energy_type" in response.data
+
+
+def test_a_matching_new_version_is_accepted(owner_client):
+    client, zev = owner_client
+    energy_version(zev, valid_from="2026-01-01", valid_to="2026-12-31")
+
+    response = client.post(
+        "/api/v1/tariffs/tariffs/",
+        {
+            "zev": str(zev.pk),
+            "name": "Local Energy",
+            "category": TariffCategory.ENERGY,
+            "billing_mode": BillingMode.ENERGY,
+            "energy_type": EnergyType.LOCAL,
+            "valid_from": "2027-01-01",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201, response.data

--- a/backend/tariffs/views.py
+++ b/backend/tariffs/views.py
@@ -7,11 +7,14 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
+from django.utils import timezone
+from django.utils.dateparse import parse_date
 from accounts.permissions import IsZevOwnerOrAdmin
 from zev.models import Zev
 from .models import Tariff, TariffPeriod
 from zev.scoping import ZevScopedQuerySetMixin
 from .serializers import TariffSerializer, TariffPeriodSerializer
+from .series import active_version, find_gaps, plan_new_version, series_key, sort_versions
 from audit.models import AuditActionCategory, AuditEventStatus
 from audit.mixins import AuditedUpdateMixin
 from audit.services import record_audit_event
@@ -52,6 +55,54 @@ def _describe_failure(failure: dict) -> str:
     )
     label = f'"{failure["name"]}"' if failure['name'] else 'unnamed'
     return f'#{failure["position"]} {label} — {fields}'
+
+
+def _parse_required_date(raw, field: str):
+    """Parse an ISO date, raising a DRF error the client can act on."""
+    parsed = parse_date(str(raw)) if raw else None
+    if parsed is None:
+        raise DRFValidationError({field: [f'{field} is required as an ISO date (YYYY-MM-DD).']})
+    return parsed
+
+
+def _apply_price_overrides(tariff, data: dict) -> None:
+    """Carry an explicit ``fixed_price_chf`` / ``percentage`` onto a copied tariff.
+
+    Absent keys leave the copied value in place; a new version that only shifts
+    its validity window should not have to restate its price.
+    """
+    for field in ('fixed_price_chf', 'percentage'):
+        if field in data:
+            setattr(tariff, field, data[field])
+
+
+def _copy_or_replace_periods(source, target, periods_data) -> None:
+    """Give ``target`` the price bands of ``source``, or the supplied ones.
+
+    Prices live on ``TariffPeriod``, not on the tariff, so a copy that skipped
+    the bands would produce a version priced at nothing.
+    """
+    if periods_data is None:
+        TariffPeriod.objects.bulk_create([
+            TariffPeriod(
+                tariff=target,
+                period_type=period.period_type,
+                price_chf_per_kwh=period.price_chf_per_kwh,
+                time_from=period.time_from,
+                time_to=period.time_to,
+                weekdays=period.weekdays,
+            )
+            for period in source.periods.all()
+        ])
+        return
+
+    for period_data in periods_data:
+        payload = dict(period_data)
+        payload.pop('id', None)
+        payload['tariff'] = str(target.pk)
+        serializer = TariffPeriodSerializer(data=payload)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
 
 
 class _TariffImportFailed(Exception):
@@ -141,6 +192,233 @@ class TariffViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelVi
                 for period in tariff.periods.all()
             ],
         }
+
+    # ── Versioning ───────────────────────────────────────────────────────────
+    #
+    # Tariffs sharing a name within a ZEV are versions of one another; the model
+    # already guarantees their windows do not overlap, and the engine already
+    # resolves the right one per day. These endpoints add the missing
+    # affordances: grouping them for display, and editing the timeline without
+    # hand-computing end dates.
+
+    @action(detail=False, methods=['get'], url_path='series')
+    def list_series(self, request):
+        """Tariffs grouped into series, newest version first, with gaps flagged."""
+        today = timezone.localdate()
+        tariffs = self.get_queryset().prefetch_related('periods')
+
+        zev_id = request.query_params.get('zev_id')
+        if zev_id:
+            tariffs = tariffs.filter(zev_id=zev_id)
+
+        grouped: dict[tuple, list] = {}
+        for tariff in tariffs:
+            grouped.setdefault(series_key(tariff), []).append(tariff)
+
+        payload = []
+        for versions in grouped.values():
+            ordered = sort_versions(versions)
+            newest = ordered[-1]
+            active = active_version(ordered, today)
+            payload.append({
+                'zev': str(newest.zev_id),
+                'name': newest.name,
+                # Identity fields are invariant across a series (enforced in
+                # Tariff.clean), so reading them off any version is safe.
+                'category': newest.category,
+                'billing_mode': newest.billing_mode,
+                'energy_type': newest.energy_type,
+                'version_count': len(ordered),
+                'active_version_id': str(active.pk) if active else None,
+                'gaps': [
+                    {'start': gap.start.isoformat(), 'end': gap.end.isoformat()}
+                    for gap in find_gaps(ordered)
+                ],
+                'versions': TariffSerializer(
+                    list(reversed(ordered)), many=True, context={'request': request},
+                ).data,
+            })
+
+        payload.sort(key=lambda series: (series['category'], series['name'].lower()))
+        return Response(payload)
+
+    @action(detail=True, methods=['post'], url_path='new-version')
+    def new_version(self, request, pk=None):
+        """Start a new version of this tariff, closing the previous one.
+
+        Copies the source version's configuration and price bands, then lets the
+        payload override the prices — which is the whole point, since a new
+        version almost always exists because the price changed.
+        """
+        source = self.get_object()
+        valid_from = _parse_required_date(request.data.get('valid_from'), 'valid_from')
+
+        siblings = list(
+            Tariff.objects.filter(zev_id=source.zev_id, name=source.name).prefetch_related('periods')
+        )
+        if any(version.valid_from == valid_from for version in siblings):
+            return Response(
+                {'valid_from': [
+                    f'A version of "{source.name}" already starts on {valid_from.isoformat()}.'
+                ]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        window = plan_new_version(siblings, valid_from)
+
+        with transaction.atomic():
+            # Truncate first: saving the new version while the predecessor still
+            # covers this date would trip the overlap guard.
+            if window.predecessor_valid_to is not None:
+                predecessor = next(v for v in siblings if v.pk == window.predecessor_id)
+                predecessor.valid_to = window.predecessor_valid_to
+                predecessor.save()
+
+            new_version = Tariff(
+                zev_id=source.zev_id,
+                name=source.name,
+                category=source.category,
+                billing_mode=source.billing_mode,
+                energy_type=source.energy_type,
+                fixed_price_chf=source.fixed_price_chf,
+                percentage=source.percentage,
+                notes=source.notes,
+                valid_from=valid_from,
+                valid_to=window.valid_to,
+            )
+            _apply_price_overrides(new_version, request.data)
+            new_version.save()
+            _copy_or_replace_periods(source, new_version, request.data.get('periods'))
+
+        _record_tariff_event(
+            request=request,
+            action_type="tariff.new_version",
+            target_type="tariffs.Tariff",
+            target=new_version,
+            target_id=str(new_version.pk),
+            target_display=new_version.name,
+            summary=f"Created a new version of {new_version.name} from {valid_from.isoformat()}.",
+            metadata={
+                "zev_id": str(new_version.zev_id),
+                "source_version_id": str(source.pk),
+                "closed_previous_on": (
+                    window.predecessor_valid_to.isoformat()
+                    if window.predecessor_valid_to else None
+                ),
+                "valid_to": window.valid_to.isoformat() if window.valid_to else None,
+            },
+        )
+        return Response(
+            TariffSerializer(new_version, context={'request': request}).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @action(detail=True, methods=['post'], url_path='duplicate')
+    def duplicate(self, request, pk=None):
+        """Copy this tariff under a new name, starting a separate series.
+
+        Unlike ``new-version`` this does not touch the source's timeline: the
+        copy is a different tariff that happens to start from the same numbers.
+        """
+        source = self.get_object()
+        name = str(request.data.get('name') or '').strip()
+        if not name:
+            return Response({'name': ['A name is required.']}, status=status.HTTP_400_BAD_REQUEST)
+        if name == source.name:
+            return Response(
+                {'name': ['Use new-version to add another version under the same name.']},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        valid_from_raw = request.data.get('valid_from')
+        valid_from = (
+            _parse_required_date(valid_from_raw, 'valid_from') if valid_from_raw
+            else source.valid_from
+        )
+
+        with transaction.atomic():
+            copy = Tariff(
+                zev_id=source.zev_id,
+                name=name,
+                category=source.category,
+                billing_mode=source.billing_mode,
+                energy_type=source.energy_type,
+                fixed_price_chf=source.fixed_price_chf,
+                percentage=source.percentage,
+                notes=source.notes,
+                valid_from=valid_from,
+                valid_to=source.valid_to,
+            )
+            _apply_price_overrides(copy, request.data)
+            copy.save()
+            _copy_or_replace_periods(source, copy, request.data.get('periods'))
+
+        _record_tariff_event(
+            request=request,
+            action_type="tariff.duplicate",
+            target_type="tariffs.Tariff",
+            target=copy,
+            target_id=str(copy.pk),
+            target_display=copy.name,
+            summary=f"Duplicated tariff {source.name} as {copy.name}.",
+            metadata={"zev_id": str(copy.zev_id), "source_id": str(source.pk)},
+        )
+        return Response(
+            TariffSerializer(copy, context={'request': request}).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @action(detail=True, methods=['post'], url_path='rename-series')
+    def rename_series(self, request, pk=None):
+        """Rename every version of this tariff at once.
+
+        The name is what groups versions, so renaming a single version would
+        silently fork the series and leave a hole in the original timeline.
+        Renaming is therefore only offered for the series as a whole.
+        """
+        source = self.get_object()
+        name = str(request.data.get('name') or '').strip()
+        if not name:
+            return Response({'name': ['A name is required.']}, status=status.HTTP_400_BAD_REQUEST)
+
+        old_name = source.name
+        if name == old_name:
+            return Response(
+                TariffSerializer(source, context={'request': request}).data,
+                status=status.HTTP_200_OK,
+            )
+
+        versions = list(Tariff.objects.filter(zev_id=source.zev_id, name=old_name))
+        clash = Tariff.objects.filter(zev_id=source.zev_id, name=name).exclude(
+            pk__in=[version.pk for version in versions]
+        )
+        if clash.exists():
+            return Response(
+                {'name': [f'A tariff named "{name}" already exists in this ZEV.']},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        with transaction.atomic():
+            # bulk_update bypasses full_clean() deliberately: renaming the whole
+            # series preserves every invariant, but validating each row against
+            # its not-yet-renamed siblings would report a false name clash.
+            for version in versions:
+                version.name = name
+            Tariff.objects.bulk_update(versions, ['name'])
+
+        _record_tariff_event(
+            request=request,
+            action_type="tariff.rename_series",
+            target_type="tariffs.Tariff",
+            target=source,
+            target_id=str(source.pk),
+            target_display=name,
+            summary=f'Renamed tariff series "{old_name}" to "{name}".',
+            changes={"name": {"before": old_name, "after": name}},
+            metadata={"zev_id": str(source.zev_id), "versions_renamed": len(versions)},
+        )
+        source.refresh_from_db()
+        return Response(TariffSerializer(source, context={'request': request}).data)
 
     @action(detail=False, methods=['get'], url_path='export')
     def export_tariffs(self, request):

--- a/docs/specs/2026-03-tariffs-and-billing-engine.md
+++ b/docs/specs/2026-03-tariffs-and-billing-engine.md
@@ -69,6 +69,62 @@ re-implement the engine from scratch.
 
 A tariff is **active on day `d`** iff `valid_from ≤ d` and (`valid_to IS NULL` or `valid_to ≥ d`).
 
+### 3.1.1 Tariff series (versioning)
+
+Every tariff in a ZEV sharing a `name` is a **version** of one **series**.  This
+is not a convention layered on the data — it follows from the overlap rule
+below: versions of a series form a non-overlapping timeline by construction, and
+§4.4.1 already selects the right one because tariff resolution is evaluated
+**per day**, not once per invoice.
+
+There is no separate series table.  The series is derived from `(zev, name)`;
+helpers live in `tariffs/series.py`.
+
+Every version of one series must agree on `category`, `billing_mode`, and
+`energy_type` (`SERIES_FIELDS`), enforced in `Tariff.clean()`.  Without that,
+"the same tariff over time" would be meaningless and comparing versions could
+compare a local-energy rate against a grid fee.
+
+**Prices are not on the tariff.**  For `energy` mode they live on
+`TariffPeriod`; for fixed-fee modes on `fixed_price_chf`; a
+`percentage_of_energy` tariff has no own price at all.  Any operation that
+copies a version must therefore copy its price bands too, or the copy prices
+nothing.
+
+#### Gaps are a billing hazard
+
+A day covered by **no** version of a series is not an error anywhere today, and
+its consequences are silent: §4.4.1 prices energy only against tariffs active on
+that day, so the allocated kWh still appear on the invoice while no line item is
+produced.
+
+Measured on a 3-month invoice with a one-month gap and 500 kWh consumed inside
+it:
+
+```
+grid kWh on the invoice: 500.0000
+line items:              0
+subtotal CHF:            0.00
+```
+
+`find_gaps()` reports interior gaps so callers can surface them.  Only interior
+gaps count: the stretch before a series begins, and the stretch after an
+end-dated last version, are simply periods the series does not cover.
+
+#### Version window arithmetic
+
+`plan_new_version(versions, valid_from)` decides how a new version slots in:
+
+- The **predecessor** (greatest `valid_from` below the new one) is truncated to
+  `valid_from − 1 day`, but **only** if it would otherwise overlap.  A
+  predecessor that already ends earlier is left alone — extending a closed
+  window would change what that period bills, and the gap may be deliberate.
+- The new version is capped at `successor.valid_from − 1 day` when a later
+  version exists, so a mid-chain insert is bounded on **both** sides.  Without
+  the upper bound the new version would swallow its successor's window and be
+  rejected by the overlap guard for reasons the caller cannot see.
+- Two versions of one series may not share a `valid_from`.
+
 OpenZEV rejects overlapping validity windows for two tariffs of the same
 `(zev, name)` — regardless of billing mode.
 
@@ -469,6 +525,56 @@ ELSE:
 Stripped fields: `id`, `zev`, `created_at`, `updated_at` are excluded so the
 preset is portable across ZEVs.
 
+### 6.1a Tariff series and version endpoints
+
+All four are `IsAuthenticated`, `IsZevOwnerOrAdmin`, and ZEV-scoped through
+`ZevScopedQuerySetMixin` — a caller cannot reach another owner's tariff (404).
+
+| Method | URL | Purpose |
+|---|---|---|
+| `GET` | `/tariffs/tariffs/series/` | Tariffs grouped into series. Optional `?zev_id=`. |
+| `POST` | `/tariffs/tariffs/{id}/new-version/` | Add a version to this series, closing the previous one. |
+| `POST` | `/tariffs/tariffs/{id}/duplicate/` | Copy under a new name as a separate series. |
+| `POST` | `/tariffs/tariffs/{id}/rename-series/` | Rename every version at once. |
+
+**`GET series/`** returns one object per series, sorted by `(category, name)`:
+
+| Field | Notes |
+|---|---|
+| `name`, `category`, `billing_mode`, `energy_type` | Invariant across the series (§3.1.1) |
+| `version_count` | |
+| `active_version_id` | `null` when today falls in a gap, or the series has been retired |
+| `gaps` | `[{start, end}]`, inclusive, interior only |
+| `versions` | Full `TariffSerializer` payloads, **newest first** |
+
+**`POST new-version/`** — body `{valid_from, fixed_price_chf?, percentage?, periods?}`.
+Copies the source version's configuration, applies the overrides, and copies the
+source's price bands unless `periods` is supplied.  Prices are overridable in the
+same request because a new version almost always exists *because* the price
+changed; requiring a second call would make the common case two steps.
+Truncation of the predecessor happens **before** the insert, since saving while
+the predecessor still covers the date would trip the overlap guard.
+`400` if a version already starts on that date.
+
+**`POST duplicate/`** — body `{name, valid_from?, fixed_price_chf?, percentage?, periods?}`.
+Does not touch the source's timeline.  `400` if `name` is blank or equal to the
+source's — the latter request means "another version", which has different
+timeline semantics and its own endpoint.
+
+**`POST rename-series/`** — body `{name}`.  Renames every version via
+`bulk_update`, deliberately bypassing `full_clean()`: renaming the whole series
+preserves every invariant, but validating each row against its not-yet-renamed
+siblings would report a false name clash.  `400` if another series in the ZEV
+already holds that name.
+
+Renaming is only offered series-wide.  Because the name *is* the series
+identity, renaming one version would fork the chain and leave a hole in the
+original timeline, so `name` is not editable per version.
+
+**Audit events:** `tariff.new_version`, `tariff.duplicate`,
+`tariff.rename_series` (all `AuditActionCategory.TARIFF`).  The rename records a
+`name` before/after diff.
+
 ### 6.2 Tariff preset import
 
 **Endpoint:** `POST /api/v1/tariffs/tariffs/import/`
@@ -836,6 +942,27 @@ The description renders as: `"Surcharge 50% (50% von CHF 0.32/kWh)"` (German).
 | `test_import_accepts_several_simultaneous_components_in_one_category` | §3.1: multiple per-kWh components sharing category/mode/energy type import cleanly |
 | `test_import_reports_every_rejected_tariff_and_saves_nothing` | §6.2: every rejected entry reported by position and name in one response; valid entries rolled back with them |
 | `test_import_rejects_invalid_period_payload` | §6.2: nested period errors surface per entry |
+
+### Backend (`tariffs/test_series.py`) — version arithmetic (no DB)
+
+| Test case | Validates |
+|---|---|
+| `active_version` across both inclusive bounds, open-ended, and inside a gap | §3.1.1 day resolution |
+| `find_gaps`: contiguous, one missing month, **one missing day**, several interior gaps, leading/trailing stretches ignored, input order irrelevant | §3.1.1 gap detection |
+| `plan_new_version`: append onto open-ended, truncate an over-long predecessor, mid-chain insert bounding both sides, predecessor already ending earlier left alone, prepend, first version of a series, only the immediate predecessor touched | §3.1.1 window arithmetic |
+
+### Backend (`tariffs/test_versioning.py`) — series API
+
+| Test case | Validates |
+|---|---|
+| Versions collapse into one series, newest first, active version identified, retired series has none | §6.1a `GET series/` |
+| Gaps reported / absent; series scoped to the caller's ZEVs; `?zev_id=` filter | §6.1a |
+| New version closes the predecessor the day before and leaves no gap | §3.1.1 |
+| New version copies HT/NT bands including times; can set new prices in one call; fixed-fee amount overridable | §6.1a |
+| Mid-chain insert is capped against its successor | §3.1.1 |
+| Duplicate starts a separate series without touching the source; refuses a blank or identical name | §6.1a |
+| Rename renames every version; refuses a name already in use; identical name is a no-op | §6.1a |
+| A version cannot change the series' category/billing mode/energy type | §3.1.1 |
 
 ### Backend (`tariffs/tests.py`) — validity windows
 

--- a/docs/user-guide/07-tariff-configuration.md
+++ b/docs/user-guide/07-tariff-configuration.md
@@ -206,27 +206,65 @@ Most ZEVs use multiple tariffs simultaneously:
 
 During billing, OpenZEV automatically selects the right tariff for each timestamp and energy type.
 
-## Seasonal and Quarterly Tariffs
+## Tariff Versions
 
-Create version-specific tariffs for seasonal changes:
+Prices change — usually every year. Rather than creating a new tariff each time,
+add a **version** to the existing one.
 
-**Example: Summer vs. Winter**
+All versions of a tariff share its **name**. That is what makes them versions:
+the name identifies the tariff, and the validity windows say which version
+applied when.
 
 ```
-Tariff: Local Energy HT "Spring/Summer 2026-04-01"
-  Valid From: 2026-04-01
-  Valid To: 2026-09-30
-  HT Price: CHF 0.10/kWh
-  NT Price: CHF 0.05/kWh
-
-Tariff: Local Energy HT "Fall/Winter 2026-10-01"
-  Valid From: 2026-10-01
-  Valid To: 2027-03-31
-  HT Price: CHF 0.12/kWh (higher winter demand)
-  NT Price: CHF 0.06/kWh
+Local Energy                                    ← one tariff, three versions
+├─ 2025-01-01 → 2025-12-31   0.10 CHF/kWh
+├─ 2026-01-01 → 2026-12-31   0.11 CHF/kWh
+└─ 2027-01-01 → (open)       0.12 CHF/kWh       ← active
 ```
 
-OpenZEV automatically applies the correct tariff based on each invoice period's end date.
+### Adding a New Version
+
+1. Find the tariff and click **New version**
+2. Enter the date the new prices take effect
+3. Adjust the prices (pre-filled from the current version)
+4. Click **Create**
+
+OpenZEV **closes the previous version automatically** on the day before, so the
+timeline stays continuous. You never set an end date by hand.
+
+> **Why this matters:** if a day falls between two versions, OpenZEV has no price
+> for it. The energy still appears on the invoice but is **charged at nothing** —
+> a whole month can be given away without any warning. Letting OpenZEV compute
+> the end date removes the off-by-one that causes this. Any series that already
+> has a gap is flagged on the tariff card.
+
+You can also insert a version *between* two existing ones; OpenZEV bounds it on
+both sides.
+
+### Comparing Versions
+
+Expand a tariff to see its full history, with each version's window and prices.
+This is also where price changes over time are charted, so you can see how a
+rate has moved across years.
+
+### Renaming
+
+Renaming is done for the **whole tariff**, not per version — the name is what
+holds the versions together, so renaming just one would split it into two
+unrelated tariffs.
+
+### Duplicating
+
+Use **Duplicate** to create a *different* tariff starting from an existing one's
+numbers. It asks for a new name and leaves the original untouched. (Use **New
+version** instead when the prices of the *same* tariff have changed.)
+
+### Which Version Gets Billed
+
+OpenZEV picks the version that was valid **on each individual reading's
+timestamp** — not the one valid at the end of the invoice period. So an invoice
+covering a price change is priced correctly on both sides of it: a January–March
+invoice uses the old price for January and the new one from February.
 
 ## Tariff Validation
 
@@ -301,6 +339,12 @@ Edit **future** tariffs freely:
 4. Click **Save**
 
 Changes apply to **new invoices only**. Past invoices keep original tariffs.
+
+> **Prices changed from a certain date?** Use **New version** instead of editing.
+> Editing rewrites what the *current* version has always charged; a new version
+> records the change, keeps the old prices on the record, and lets invoices
+> spanning the switch bill each part correctly. See
+> [Tariff Versions](#tariff-versions).
 
 ### Deactivating a Tariff
 


### PR DESCRIPTION
First of three PRs for tariff versioning. This is the backend; the UI (collapsing versions into one card, the new-version dialog, gap warnings) and the price-history chart follow separately.

## The premise: versioning already exists, implicitly

Tariffs sharing a name in a ZEV already may not have overlapping windows (#368), so versions of a tariff already form a non-overlapping timeline. And the engine already resolves tariffs **per day** — `resolver.energy(energy_type, ts.date())` — so it already bills the right version, and does so better than "the currently active one" would: an invoice spanning a price change is priced correctly on both sides.

So this needs **no migration and no engine change**. What was missing was the affordances: nothing to add a version, nothing to duplicate, nothing to group them for display.

Your dev data makes the case: 19 tariff series, all single-version, including a real Swiss levy sheet with 7 separate levy components. Come January, every one of those needs a new version by hand.

## Gap detection — the correctness payoff

A day covered by no version bills its energy at **nothing**, silently. Measured on a 3-month invoice with a one-month gap and 500 kWh consumed inside it:

```
grid kWh on the invoice: 500.0000
line items:              0
subtotal CHF:            0.00
```

The invoice shows the kWh and looks plausible. Since the old workflow was *manually* end-date one tariff then *manually* create its successor, this is precisely the mistake it invites. Auto-closing removes the cause; `find_gaps()` surfaces gaps that already exist, reported per series so the UI can flag them.

Only interior gaps count — the stretch before a series begins, or after a retired one ends, is not a hole.

## Endpoints

| Method | URL | Purpose |
|---|---|---|
| `GET` | `/tariffs/tariffs/series/` | Series with active version + gaps; optional `?zev_id=` |
| `POST` | `/tariffs/tariffs/{id}/new-version/` | Add a version, closing the previous |
| `POST` | `/tariffs/tariffs/{id}/duplicate/` | Copy under a new name as a separate tariff |
| `POST` | `/tariffs/tariffs/{id}/rename-series/` | Rename every version at once |

All ZEV-scoped through the existing mixin (404 on another owner's tariff), all audited (`tariff.new_version`, `tariff.duplicate`, `tariff.rename_series`).

**Three design points worth reviewing:**

**Prices live on `TariffPeriod`, not on the tariff.** A version copy that skipped the bands would price nothing, so `new-version` and `duplicate` deep-copy them (including HT/NT times and weekdays). Both also accept price overrides in the *same* request — a new version almost always exists *because* the price changed, so requiring a second call would make the common case two steps.

**Mid-chain inserts are bounded on both sides.** The predecessor is truncated to the day before, *and* the new version is capped at the successor's start − 1. Without the upper bound the new version would swallow its successor's window and be rejected by the overlap guard for reasons the caller can't see. A predecessor that already ends earlier is left alone — extending a closed window would change what that period billed, and the gap may be deliberate.

**Renaming is series-wide only.** The name *is* the series identity, so renaming one version would fork the chain and leave a hole in the original timeline. `rename-series` uses `bulk_update`, deliberately bypassing `full_clean()`: renaming the whole series preserves every invariant, but validating each row against its not-yet-renamed siblings reports a false name clash.

## Series coherence

Versions of one series must now agree on `category`, `billing_mode` and `energy_type`, enforced in `Tariff.clean()`. Otherwise "the same tariff over time" is not a meaningful claim and the comparison chart in PR 3 could plot a local-energy rate against a grid fee.

This is also the reason no `TariffSeries` table was added — that integrity argument is the only one it had, and `clean()` covers it. A table would cost a migration plus updating 51 call sites that read `tariff.name/category/billing_mode/energy_type` (36 in `engine.py`) for zero gain in billing correctness. Worth revisiting only if series need their own attributes.

## Tests

**49 new tests, 713 total.**

`test_series.py` (22, no DB) — the window arithmetic is where a one-day error lives, so it's tested as arithmetic: inclusive bounds, open-ended versions, a day inside a gap, a **one-day** gap, several interior gaps, leading/trailing stretches correctly ignored, order-independence, and every `plan_new_version` case including prepend and "only the immediate predecessor is touched".

`test_versioning.py` (27) — the API: grouping, newest-first ordering, active version, retired series, gaps, ZEV scoping, `?zev_id=`; auto-close leaves no gap; HT/NT bands copied with their times; prices settable in one call; fixed-fee amount overridable; mid-chain capping; duplicate not touching the source; rename covering all versions and refusing a name in use; drift rejected.

Also verified over real HTTP against the dev stack — `GET series/` returned all 19 of your series correctly grouped, and the three write routes are wired and validating. I did **not** write to your dev database.

## Docs

New spec §3.1.1 (series, gaps, window arithmetic) and §6.1a (endpoints), plus test-plan entries.

Two corrections to the user guide's seasonal-tariff advice, both wrong before:
- It advised giving each season a **different name** — which makes them separate tariffs, not versions of one.
- It claimed OpenZEV "applies the correct tariff based on each invoice period's end date". Tariffs are resolved **per reading timestamp**; only VAT uses `period_end`.
