### PR TITLE
feat(tariffs): chart the price history of a versioned tariff

### DIFF
--- a/frontend/src/features/tariffs/TariffCategorySections.tsx
+++ b/frontend/src/features/tariffs/TariffCategorySections.tsx
@@ -21,6 +21,7 @@ import type {
     TariffVersion,
 } from '../../types/api'
 import { todayIso, validityState, type ValidityState } from './validity'
+import { TariffPriceHistoryChart } from './TariffPriceHistoryChart'
 
 type TariffSeriesSection = {
     category: Tariff['category']
@@ -37,6 +38,8 @@ const VALIDITY_BADGE_CLASS: Record<ValidityState, string> = {
 
 type TariffCategorySectionsProps = {
     tariffSections: TariffSeriesSection[]
+    /** Every series in scope — percentage tariffs derive their price from the grid ones. */
+    allSeries: TariffSeries[]
     percentageBasePricing: Map<string, number>
     settings: AppSettings
     deleteTariffDisabled: boolean
@@ -53,6 +56,7 @@ type TariffCategorySectionsProps = {
 
 export function TariffCategorySections({
     tariffSections,
+    allSeries,
     percentageBasePricing,
     settings,
     deleteTariffDisabled,
@@ -346,6 +350,14 @@ export function TariffCategorySections({
                                                     })}
                                                 </div>
                                             </div>
+
+                                            {series.version_count > 1 && (
+                                                <TariffPriceHistoryChart
+                                                    series={series}
+                                                    allSeries={allSeries}
+                                                    settings={settings}
+                                                />
+                                            )}
 
                                             {notes && (
                                                 <div className="tariff-card-details">

--- a/frontend/src/features/tariffs/TariffPriceHistoryChart.tsx
+++ b/frontend/src/features/tariffs/TariffPriceHistoryChart.tsx
@@ -118,7 +118,9 @@ export function TariffPriceHistoryChart({ series, allSeries, settings }: Props) 
                         ]}
                         contentStyle={{ fontSize: '0.82rem', borderRadius: 6 }}
                     />
-                    {history.bands.length > 1 && <Legend fontSize={11} />}
+                    {history.bands.length > 1 && (
+                        <Legend wrapperStyle={{ fontSize: '0.72rem' }} />
+                    )}
                     {history.bands.map((band) => (
                         <Line
                             key={band}

--- a/frontend/src/features/tariffs/TariffPriceHistoryChart.tsx
+++ b/frontend/src/features/tariffs/TariffPriceHistoryChart.tsx
@@ -1,0 +1,143 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+    CartesianGrid,
+    Legend,
+    Line,
+    LineChart,
+    ReferenceArea,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from 'recharts'
+import { formatShortDate } from '../../lib/appSettings'
+import type { AppSettings, TariffSeries } from '../../types/api'
+import { buildPriceHistory, type BandKey, type PriceUnit } from './priceHistory'
+import { todayIso } from './validity'
+
+// Blue and orange are the colourblind-safe pair and carry the two bands that
+// actually co-occur (HT and NT). Flat never shares a version with HT/NT in
+// practice, so its blue can be reused without an ambiguous adjacency.
+const BAND_COLOR: Record<BandKey, string> = {
+    flat: '#2563eb',
+    high: '#ea580c',
+    low: '#0891b2',
+    amount: '#2563eb',
+    effective: '#2563eb',
+}
+const AXIS_COLOR = '#9ca3af'
+const GAP_FILL = '#ef4444'
+
+type Props = {
+    series: TariffSeries
+    allSeries: TariffSeries[]
+    settings: AppSettings
+}
+
+function decimalsFor(unit: PriceUnit): number {
+    return unit === 'chf' ? 2 : 5
+}
+
+export function TariffPriceHistoryChart({ series, allSeries, settings }: Props) {
+    const { t } = useTranslation()
+    const today = todayIso()
+
+    const history = useMemo(
+        () => buildPriceHistory(series, allSeries, today),
+        [series, allSeries, today],
+    )
+
+    // Recharts wants each band as a top-level key, while the builder keeps them
+    // nested so the shape stays easy to assert in tests.
+    const data = useMemo(
+        () => history.points.map((point) => ({ t: point.t, note: point.note, ...point.values })),
+        [history.points],
+    )
+
+    if (data.length < 2) return null
+
+    const decimals = decimalsFor(history.unit)
+    const unitLabel = history.unit === 'chf_per_kwh'
+        ? t('pages.tariffs.chfPerKwh')
+        : history.unit === 'chf'
+            ? 'CHF'
+            : '%'
+
+    return (
+        <div className="tariff-price-history">
+            <div className="tariff-price-history-header">
+                <h4>{t('pages.tariffs.priceHistory.title')}</h4>
+                <span className="muted">{unitLabel}</span>
+            </div>
+
+            {history.derived && (
+                <p className="muted tariff-price-history-note">
+                    {t('pages.tariffs.priceHistory.derivedNote')}
+                </p>
+            )}
+
+            <ResponsiveContainer width="100%" height={220}>
+                <LineChart data={data} margin={{ top: 8, right: 16, left: 4, bottom: 4 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    {/* Shade uncovered stretches: nothing was billed there, and the
+                        broken line alone does not say why. */}
+                    {history.gaps.map((gap) => (
+                        <ReferenceArea
+                            key={gap.from}
+                            x1={gap.from}
+                            x2={gap.to}
+                            fill={GAP_FILL}
+                            fillOpacity={0.1}
+                            stroke="none"
+                        />
+                    ))}
+                    <XAxis
+                        dataKey="t"
+                        type="number"
+                        scale="time"
+                        domain={['dataMin', 'dataMax']}
+                        tickFormatter={(value: number) => formatShortDate(new Date(value).toISOString().slice(0, 10), settings)}
+                        stroke={AXIS_COLOR}
+                        fontSize={11}
+                        minTickGap={40}
+                    />
+                    <YAxis
+                        stroke={AXIS_COLOR}
+                        fontSize={11}
+                        tickFormatter={(value: number) => value.toFixed(decimals === 5 ? 3 : 2)}
+                        width={56}
+                    />
+                    <Tooltip
+                        labelFormatter={(value) => formatShortDate(new Date(Number(value)).toISOString().slice(0, 10), settings)}
+                        formatter={(value, name) => [
+                            value === null || value === undefined
+                                ? t('pages.tariffs.priceHistory.noPrice')
+                                : `${Number(value).toFixed(decimals)} ${unitLabel}`,
+                            t(`pages.tariffs.priceHistory.bands.${name}` as Parameters<typeof t>[0], { defaultValue: String(name) }),
+                        ]}
+                        contentStyle={{ fontSize: '0.82rem', borderRadius: 6 }}
+                    />
+                    {history.bands.length > 1 && <Legend fontSize={11} />}
+                    {history.bands.map((band) => (
+                        <Line
+                            key={band}
+                            // Stepped, not interpolated: a price holds for its whole
+                            // validity window and then jumps. A smooth line would
+                            // claim it drifted between two Januaries.
+                            type="stepAfter"
+                            dataKey={band}
+                            name={t(`pages.tariffs.priceHistory.bands.${band}` as Parameters<typeof t>[0], { defaultValue: band })}
+                            stroke={BAND_COLOR[band]}
+                            strokeWidth={2}
+                            dot={{ r: 3 }}
+                            activeDot={{ r: 5 }}
+                            connectNulls={false}
+                            isAnimationActive={false}
+                        />
+                    ))}
+                </LineChart>
+            </ResponsiveContainer>
+        </div>
+    )
+}

--- a/frontend/src/features/tariffs/priceHistory.ts
+++ b/frontend/src/features/tariffs/priceHistory.ts
@@ -1,0 +1,264 @@
+import type { TariffPeriod, TariffSeries, TariffVersion } from '../../types/api'
+
+/** What the y-axis of a series' price history is measured in. */
+export type PriceUnit = 'chf_per_kwh' | 'chf' | 'percent'
+
+export type BandKey = 'flat' | 'high' | 'low' | 'amount' | 'effective'
+
+export type PriceHistoryPoint = {
+    /** Boundary as an epoch millisecond value, so the x-axis can be proportional. */
+    t: number
+    date: string
+    /** Band value at this boundary; `null` means the band does not apply then. */
+    values: Partial<Record<BandKey, number | null>>
+    /** Extra context for the tooltip, e.g. the percentage behind a derived price. */
+    note?: string
+}
+
+export type PriceHistory = {
+    unit: PriceUnit
+    bands: BandKey[]
+    points: PriceHistoryPoint[]
+    /** Uncovered stretches, as epoch ms, for shading. */
+    gaps: Array<{ from: number, to: number }>
+    /** True when the values are computed rather than configured directly. */
+    derived: boolean
+}
+
+const BAND_ORDER: BandKey[] = ['flat', 'high', 'low']
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function ms(isoDate: string): number {
+    // Parsed as UTC midnight on purpose: every boundary goes through the same
+    // conversion, so the axis stays consistent regardless of the viewer's zone.
+    return Date.parse(`${isoDate}T00:00:00Z`)
+}
+
+function isoFromMs(value: number): string {
+    return new Date(value).toISOString().slice(0, 10)
+}
+
+function num(value: string | null | undefined): number | null {
+    if (value === null || value === undefined || value === '') return null
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+}
+
+function byValidFrom(left: { valid_from: string }, right: { valid_from: string }): number {
+    return left.valid_from < right.valid_from ? -1 : left.valid_from > right.valid_from ? 1 : 0
+}
+
+/**
+ * The one price that stands for a whole tariff version.
+ *
+ * Prefer the flat band, else the high band, else whatever comes first — the same
+ * rule the invoice engine and the contract PDF use, so a charted grid base
+ * matches what participants are actually billed against.
+ */
+function representativePrice(periods: TariffPeriod[]): number | null {
+    if (periods.length === 0) return null
+    const flat = periods.find((period) => period.period_type === 'flat')
+    const high = periods.find((period) => period.period_type === 'high')
+    return num((flat ?? high ?? periods[0]).price_chf_per_kwh)
+}
+
+/** Version of `versions` in force on `day`, or `undefined` inside a gap. */
+function versionOn<T extends { valid_from: string, valid_to?: string | null }>(
+    versions: T[], day: string,
+): T | undefined {
+    return versions.find(
+        (version) => version.valid_from <= day && (!version.valid_to || version.valid_to >= day),
+    )
+}
+
+/**
+ * Sum of the representative prices of every grid-energy tariff in force on
+ * `day` — the base a percentage-of-energy tariff is a fraction of.
+ */
+function gridBaseOn(allSeries: TariffSeries[], day: string): number {
+    return allSeries
+        .filter((series) => series.billing_mode === 'energy' && series.energy_type === 'grid')
+        .reduce((total, series) => {
+            const version = versionOn(series.versions, day)
+            return total + (version ? representativePrice(version.periods) ?? 0 : 0)
+        }, 0)
+}
+
+/** Where the last step should be drawn to, so an open-ended version is visible. */
+function terminalBoundary(versions: TariffVersion[], today: string): number {
+    const last = versions[versions.length - 1]
+    if (last.valid_to) return ms(last.valid_to)
+    return Math.max(ms(today), ms(last.valid_from))
+}
+
+/**
+ * Turn a tariff series into a step-chart dataset.
+ *
+ * Every point is a boundary at which something changed; values hold until the
+ * next boundary, which is why the chart must be stepped rather than
+ * interpolated — a price does not drift between two Januaries.
+ *
+ * A gap inserts an all-`null` boundary so the line breaks rather than implying
+ * the old price continued through a period nothing was billed at.
+ *
+ * `allSeries` is only needed for percentage-of-energy tariffs, whose own record
+ * holds no price: their effective rate is a fraction of the grid tariffs in
+ * force at the time, so it changes when *those* change too.
+ */
+export function buildPriceHistory(
+    series: TariffSeries,
+    allSeries: TariffSeries[],
+    today: string,
+): PriceHistory {
+    const versions = [...series.versions].sort(byValidFrom)
+    const gaps = series.gaps.map((gap) => ({ from: ms(gap.start), to: ms(gap.end) }))
+
+    if (series.billing_mode === 'percentage_of_energy') {
+        const points = percentagePoints(versions, allSeries, today)
+        return {
+            unit: 'chf_per_kwh',
+            bands: ['effective'],
+            derived: true,
+            // A percentage tariff with no grid tariff behind it prices at zero —
+            // the engine's base sum is zero, so it genuinely bills nothing. That
+            // is faithful but reads like a crash, so those stretches are shaded
+            // like the tariff's own gaps.
+            gaps: [...gaps, ...zeroBaseStretches(points)],
+            points,
+        }
+    }
+
+    if (series.billing_mode !== 'energy') {
+        return {
+            unit: 'chf',
+            bands: ['amount'],
+            derived: false,
+            gaps,
+            points: assemble(versions, ['amount'], today,
+                (version) => ({ amount: num(version.fixed_price_chf) })),
+        }
+    }
+
+    const bands = BAND_ORDER.filter(
+        (band) => versions.some((version) => version.periods.some((period) => period.period_type === band)),
+    )
+
+    const points = assemble(versions, bands, today, (version) => {
+        const values: Partial<Record<BandKey, number | null>> = {}
+        bands.forEach((band) => {
+            const period = version.periods.find((entry) => entry.period_type === band)
+            values[band] = period ? num(period.price_chf_per_kwh) : null
+        })
+        return values
+    })
+
+    return { unit: 'chf_per_kwh', bands: bands.length ? bands : ['flat'], derived: false, gaps, points }
+}
+
+/**
+ * Stretches where a derived price sits at zero because nothing backs it.
+ *
+ * Reported as gaps rather than left as a plunge to the axis: the number is what
+ * would really be billed, but without shading it looks like the price collapsed
+ * rather than like its basis went missing.
+ */
+function zeroBaseStretches(points: PriceHistoryPoint[]): Array<{ from: number, to: number }> {
+    const stretches: Array<{ from: number, to: number }> = []
+    points.forEach((point, index) => {
+        const next = points[index + 1]
+        if (!next) return
+        if (point.values.effective === 0) {
+            stretches.push({ from: point.t, to: next.t })
+        }
+    })
+    return stretches
+}
+
+/**
+ * Lay versions out as step-chart boundaries.
+ *
+ * Two versions that meet exactly need no point between them: with `stepAfter`
+ * the earlier point already holds its value up to the later one.
+ *
+ * A version followed by a gap needs *two* extra points — its value repeated at
+ * its real end date, then a null. Without the first, nothing draws the run at
+ * all, because a chart with `connectNulls={false}` will not draw a segment into
+ * a null: a nine-month version would collapse to a dot on its start date.
+ */
+function assemble(
+    versions: TariffVersion[],
+    bands: BandKey[],
+    today: string,
+    valuesFor: (version: TariffVersion) => Partial<Record<BandKey, number | null>>,
+): PriceHistoryPoint[] {
+    const points: PriceHistoryPoint[] = []
+    const nulls = () => Object.fromEntries(bands.map((band) => [band, null]))
+
+    versions.forEach((version, index) => {
+        const values = valuesFor(version)
+        points.push({ t: ms(version.valid_from), date: version.valid_from, values })
+
+        const next = versions[index + 1]
+        const endsOn = version.valid_to ? ms(version.valid_to) : null
+        if (next && endsOn !== null && ms(next.valid_from) === endsOn + DAY_MS) {
+            return // contiguous: the next point continues this step
+        }
+
+        const runEnd = endsOn ?? Math.max(ms(today), ms(version.valid_from))
+        if (runEnd > ms(version.valid_from)) {
+            points.push({ t: runEnd, date: isoFromMs(runEnd), values })
+        }
+        if (next && endsOn !== null) {
+            const uncoveredFrom = endsOn + DAY_MS
+            points.push({ t: uncoveredFrom, date: isoFromMs(uncoveredFrom), values: nulls() })
+        }
+    })
+
+    return points
+}
+
+/**
+ * Effective CHF/kWh for a percentage tariff, stepping at every boundary of
+ * *either* timeline: the percentage can change, and so can the grid tariffs it
+ * is a fraction of.
+ */
+function percentagePoints(
+    versions: TariffVersion[], allSeries: TariffSeries[], today: string,
+): PriceHistoryPoint[] {
+    const gridSeries = allSeries.filter(
+        (series) => series.billing_mode === 'energy' && series.energy_type === 'grid',
+    )
+    const boundaries = new Set<string>()
+    versions.forEach((version) => {
+        boundaries.add(version.valid_from)
+        // The day after a version ends is a boundary too, so a gap in the
+        // percentage tariff's own timeline breaks the line.
+        if (version.valid_to) boundaries.add(isoFromMs(ms(version.valid_to) + DAY_MS))
+    })
+    gridSeries.forEach((series) => series.versions.forEach((version) => {
+        boundaries.add(version.valid_from)
+        if (version.valid_to) boundaries.add(isoFromMs(ms(version.valid_to) + DAY_MS))
+    }))
+
+    const first = versions[0]?.valid_from
+    const end = versions.length ? isoFromMs(terminalBoundary(versions, today)) : today
+    const relevant = [...boundaries]
+        .filter((day) => first !== undefined && day >= first && day <= end)
+        .sort()
+    if (first !== undefined && !relevant.includes(end)) relevant.push(end)
+
+    return relevant.map((day) => {
+        const version = versionOn(versions, day)
+        if (!version) {
+            return { t: ms(day), date: day, values: { effective: null } }
+        }
+        const percentage = num(version.percentage) ?? 0
+        const base = gridBaseOn(allSeries, day)
+        return {
+            t: ms(day),
+            date: day,
+            values: { effective: Number(((base * percentage) / 100).toFixed(5)) },
+            note: `${percentage}% × ${base.toFixed(5)}`,
+        }
+    })
+}

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -955,6 +955,18 @@ export const de = {
             },
             allWeekdays: 'alle',
             chfPerKwh: 'CHF/kWh',
+            priceHistory: {
+                title: 'Preisverlauf',
+                derivedNote: 'Berechnet aus den damals g\u00fcltigen Netztarifen \u2014 \u00e4ndert sich also auch, wenn diese sich \u00e4ndern.',
+                noPrice: 'kein Preis \u2014 nicht abgedeckter Zeitraum',
+                bands: {
+                    flat: 'Einheitstarif',
+                    high: 'Hochtarif (HT)',
+                    low: 'Niedertarif (NT)',
+                    amount: 'Betrag',
+                    effective: 'Effektiver Preis',
+                },
+            },
             versions: {
                 count_one: '{{count}} Version',
                 count_other: '{{count}} Versionen',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -926,6 +926,18 @@ export const en = {
             },
             allWeekdays: 'all',
             chfPerKwh: 'CHF/kWh',
+            priceHistory: {
+                title: 'Price history',
+                derivedNote: 'Calculated from the grid tariffs in force at the time, so it also changes when those do.',
+                noPrice: 'no price \u2014 uncovered period',
+                bands: {
+                    flat: 'Flat',
+                    high: 'High (HT)',
+                    low: 'Low (NT)',
+                    amount: 'Amount',
+                    effective: 'Effective price',
+                },
+            },
             versions: {
                 count_one: '{{count}} version',
                 count_other: '{{count}} versions',

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -962,6 +962,18 @@ export const fr = {
             },
             allWeekdays: 'tous',
             chfPerKwh: 'CHF/kWh',
+            priceHistory: {
+                title: 'Historique des prix',
+                derivedNote: 'Calcul\u00e9 \u00e0 partir des tarifs r\u00e9seau en vigueur \u00e0 l\u2019\u00e9poque : il change donc aussi lorsque ceux-ci changent.',
+                noPrice: 'aucun prix \u2014 p\u00e9riode non couverte',
+                bands: {
+                    flat: 'Tarif unique',
+                    high: 'Tarif haut (HT)',
+                    low: 'Tarif bas (NT)',
+                    amount: 'Montant',
+                    effective: 'Prix effectif',
+                },
+            },
             versions: {
                 count_one: '{{count}} version',
                 count_other: '{{count}} versions',

--- a/frontend/src/i18n/locales/it.ts
+++ b/frontend/src/i18n/locales/it.ts
@@ -962,6 +962,18 @@ export const it = {
             },
             allWeekdays: 'tutti',
             chfPerKwh: 'CHF/kWh',
+            priceHistory: {
+                title: 'Storico dei prezzi',
+                derivedNote: 'Calcolato dalle tariffe di rete in vigore all\u2019epoca, quindi cambia anche quando cambiano quelle.',
+                noPrice: 'nessun prezzo \u2014 periodo non coperto',
+                bands: {
+                    flat: 'Tariffa unica',
+                    high: 'Tariffa alta (HT)',
+                    low: 'Tariffa bassa (NT)',
+                    amount: 'Importo',
+                    effective: 'Prezzo effettivo',
+                },
+            },
             versions: {
                 count_one: '{{count}} versione',
                 count_other: '{{count}} versioni',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2530,3 +2530,28 @@ h3 {
   border-radius: 0.7rem;
   background: rgba(241, 245, 249, 0.7);
 }
+
+/* ── Tariff price history chart ──────────────────────────────────────────── */
+
+.tariff-price-history {
+  margin-top: 1.1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.24);
+}
+
+.tariff-price-history-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.35rem;
+}
+
+.tariff-price-history-header h4 {
+  margin: 0;
+}
+
+.tariff-price-history-note {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+}

--- a/frontend/src/pages/TariffsPage.tsx
+++ b/frontend/src/pages/TariffsPage.tsx
@@ -303,6 +303,7 @@ export function TariffsPage() {
             ) : (
                 <TariffCategorySections
                     tariffSections={tariffSections}
+                    allSeries={allSeries}
                     percentageBasePricing={percentageBasePricing}
                     settings={settings}
                     deleteTariffDisabled={deleteTariffPending || dialogLoading}

--- a/frontend/tests/tariff-price-history.test.ts
+++ b/frontend/tests/tariff-price-history.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from 'vitest'
+import { buildPriceHistory } from '../src/features/tariffs/priceHistory'
+import type { TariffPeriod, TariffSeries, TariffVersion } from '../src/types/api'
+
+const TODAY = '2026-07-30'
+
+function ms(day: string): number {
+  return Date.parse(`${day}T00:00:00Z`)
+}
+
+function period(period_type: TariffPeriod['period_type'], price: string): TariffPeriod {
+  return { id: `${period_type}-${price}`, tariff: 't', period_type, price_chf_per_kwh: price }
+}
+
+function version(
+  valid_from: string,
+  valid_to: string | null,
+  overrides: Partial<TariffVersion> = {},
+): TariffVersion {
+  return {
+    id: `v-${valid_from}`,
+    zev: 'z',
+    name: 'T',
+    category: 'energy',
+    billing_mode: 'energy',
+    energy_type: 'local',
+    valid_from,
+    valid_to,
+    periods: [],
+    ...overrides,
+  }
+}
+
+function series(versions: TariffVersion[], overrides: Partial<TariffSeries> = {}): TariffSeries {
+  return {
+    zev: 'z',
+    name: 'T',
+    category: 'energy',
+    billing_mode: 'energy',
+    energy_type: 'local',
+    version_count: versions.length,
+    active_version_id: null,
+    gaps: [],
+    // The API returns newest first; the builder must not depend on that.
+    versions: [...versions].reverse(),
+    ...overrides,
+  }
+}
+
+describe('buildPriceHistory — energy tariffs', () => {
+  it('emits one boundary per version plus a terminal point for the last step', () => {
+    const history = buildPriceHistory(series([
+      version('2025-01-01', '2025-12-31', { periods: [period('flat', '0.10000')] }),
+      version('2026-01-01', null, { periods: [period('flat', '0.12000')] }),
+    ]), [], TODAY)
+
+    expect(history.unit).toBe('chf_per_kwh')
+    expect(history.bands).toEqual(['flat'])
+    expect(history.points.map((point) => point.date)).toEqual(['2025-01-01', '2026-01-01', TODAY])
+    expect(history.points.map((point) => point.values.flat)).toEqual([0.1, 0.12, 0.12])
+  })
+
+  it('sorts oldest first even though the API returns newest first', () => {
+    const history = buildPriceHistory(series([
+      version('2024-01-01', '2024-12-31', { periods: [period('flat', '0.08000')] }),
+      version('2025-01-01', '2025-12-31', { periods: [period('flat', '0.10000')] }),
+      version('2026-01-01', null, { periods: [period('flat', '0.12000')] }),
+    ]), [], TODAY)
+
+    expect(history.points.map((point) => point.values.flat)).toEqual([0.08, 0.1, 0.12, 0.12])
+  })
+
+  it('keeps HT and NT as separate bands', () => {
+    const history = buildPriceHistory(series([
+      version('2025-01-01', '2025-12-31', { periods: [period('high', '0.28000'), period('low', '0.18000')] }),
+      version('2026-01-01', null, { periods: [period('high', '0.30000'), period('low', '0.19000')] }),
+    ]), [], TODAY)
+
+    expect(history.bands).toEqual(['high', 'low'])
+    expect(history.points.map((point) => point.values.high)).toEqual([0.28, 0.3, 0.3])
+    expect(history.points.map((point) => point.values.low)).toEqual([0.18, 0.19, 0.19])
+  })
+
+  it('orders bands flat, high, low regardless of how the periods arrive', () => {
+    const history = buildPriceHistory(series([
+      version('2025-01-01', null, {
+        periods: [period('low', '0.18000'), period('flat', '0.20000'), period('high', '0.28000')],
+      }),
+      version('2026-01-01', null, { periods: [period('flat', '0.21000')] }),
+    ]), [], TODAY)
+
+    expect(history.bands).toEqual(['flat', 'high', 'low'])
+  })
+
+  it('nulls a band that a later version dropped, so its line stops', () => {
+    const history = buildPriceHistory(series([
+      version('2025-01-01', '2025-12-31', { periods: [period('high', '0.28000'), period('low', '0.18000')] }),
+      version('2026-01-01', null, { periods: [period('flat', '0.24000')] }),
+    ]), [], TODAY)
+
+    expect(history.points.map((point) => point.values.high)).toEqual([0.28, null, null])
+    expect(history.points.map((point) => point.values.flat)).toEqual([null, 0.24, 0.24])
+  })
+
+  it('breaks the line across a gap instead of implying the old price continued', () => {
+    const history = buildPriceHistory(series([
+      version('2026-01-01', '2026-03-31', { periods: [period('flat', '0.10000')] }),
+      version('2026-05-01', null, { periods: [period('flat', '0.12000')] }),
+    ], { gaps: [{ start: '2026-04-01', end: '2026-04-30' }] }), [], TODAY)
+
+    // The run is closed at its real end date, then a null breaks the line.
+    expect(history.points.map((point) => [point.date, point.values.flat])).toEqual([
+      ['2026-01-01', 0.1],
+      ['2026-03-31', 0.1],
+      ['2026-04-01', null],
+      ['2026-05-01', 0.12],
+      [TODAY, 0.12],
+    ])
+    expect(history.gaps).toEqual([{ from: ms('2026-04-01'), to: ms('2026-04-30') }])
+  })
+
+  it('draws a version before a gap across its whole window, not as a dot', () => {
+    // Regression: with connectNulls disabled a chart will not draw a segment
+    // *into* a null, so without a closing point at the version's real end a
+    // nine-month version collapsed to a single dot on its start date.
+    const history = buildPriceHistory(series([
+      version('2024-01-01', '2024-09-30', { periods: [period('flat', '0.26000')] }),
+      version('2025-01-01', null, { periods: [period('flat', '0.31000')] }),
+    ], { gaps: [{ start: '2024-10-01', end: '2024-12-31' }] }), [], TODAY)
+
+    const run = history.points.filter((point) => point.values.flat === 0.26)
+    expect(run.map((point) => point.date)).toEqual(['2024-01-01', '2024-09-30'])
+  })
+
+  it('adds no redundant point between contiguous versions', () => {
+    const history = buildPriceHistory(series([
+      version('2025-01-01', '2025-12-31', { periods: [period('flat', '0.10000')] }),
+      version('2026-01-01', '2026-12-31', { periods: [period('flat', '0.12000')] }),
+    ]), [], TODAY)
+
+    expect(history.points.map((point) => point.date)).toEqual([
+      '2025-01-01', '2026-01-01', '2026-12-31',
+    ])
+  })
+
+  it('does not fabricate a terminal point before a version that starts in the future', () => {
+    const history = buildPriceHistory(series([
+      version('2026-01-01', '2026-06-30', { periods: [period('flat', '0.10000')] }),
+      version('2026-08-01', null, { periods: [period('flat', '0.12000')] }),
+    ]), [], TODAY)
+
+    // TODAY is 2026-07-30, before the last version opens, so the timeline must
+    // stop at that version rather than doubling back to today.
+    expect(history.points[history.points.length - 1].date).toBe('2026-08-01')
+    expect(history.points.every((point) => point.t <= ms('2026-08-01'))).toBe(true)
+  })
+
+  it('does not break the line when versions are exactly contiguous', () => {
+    const history = buildPriceHistory(series([
+      version('2026-01-01', '2026-06-30', { periods: [period('flat', '0.10000')] }),
+      version('2026-07-01', null, { periods: [period('flat', '0.12000')] }),
+    ]), [], TODAY)
+
+    expect(history.points.map((point) => point.values.flat)).toEqual([0.1, 0.12, 0.12])
+  })
+
+  it('ends at the last version\'s end date rather than today when the series is retired', () => {
+    const history = buildPriceHistory(series([
+      version('2024-01-01', '2024-06-30', { periods: [period('flat', '0.10000')] }),
+      version('2024-07-01', '2024-12-31', { periods: [period('flat', '0.11000')] }),
+    ]), [], TODAY)
+
+    expect(history.points[history.points.length - 1].date).toBe('2024-12-31')
+  })
+
+  it('treats a version with no price bands as an absent value, not zero', () => {
+    const history = buildPriceHistory(series([
+      version('2025-01-01', '2025-12-31', { periods: [period('flat', '0.10000')] }),
+      version('2026-01-01', null, { periods: [] }),
+    ]), [], TODAY)
+
+    expect(history.points.map((point) => point.values.flat)).toEqual([0.1, null, null])
+  })
+})
+
+describe('buildPriceHistory — fixed fees', () => {
+  it('charts the configured amount in CHF', () => {
+    const history = buildPriceHistory(series([
+      version('2025-01-01', '2025-12-31', { billing_mode: 'monthly_fee', energy_type: null, fixed_price_chf: '5.00' }),
+      version('2026-01-01', null, { billing_mode: 'monthly_fee', energy_type: null, fixed_price_chf: '6.50' }),
+    ], { billing_mode: 'monthly_fee', energy_type: null }), [], TODAY)
+
+    expect(history.unit).toBe('chf')
+    expect(history.bands).toEqual(['amount'])
+    expect(history.derived).toBe(false)
+    expect(history.points.map((point) => point.values.amount)).toEqual([5, 6.5, 6.5])
+  })
+
+  it('handles a negative amount, which is a credit rather than a charge', () => {
+    const history = buildPriceHistory(series([
+      version('2025-01-01', '2025-12-31', { billing_mode: 'shared_monthly_fee', energy_type: null, fixed_price_chf: '-100.00' }),
+      version('2026-01-01', null, { billing_mode: 'shared_monthly_fee', energy_type: null, fixed_price_chf: '-120.00' }),
+    ], { billing_mode: 'shared_monthly_fee', energy_type: null }), [], TODAY)
+
+    expect(history.points.map((point) => point.values.amount)).toEqual([-100, -120, -120])
+  })
+})
+
+describe('buildPriceHistory — percentage of energy', () => {
+  const gridSeries = series([
+    version('2025-01-01', '2025-12-31', {
+      name: 'Grid', energy_type: 'grid', periods: [period('flat', '0.20000')],
+    }),
+    version('2026-01-01', null, {
+      name: 'Grid', energy_type: 'grid', periods: [period('flat', '0.30000')],
+    }),
+  ], { name: 'Grid', energy_type: 'grid' })
+
+  const pctSeries = series([
+    version('2025-01-01', null, {
+      name: 'Local', billing_mode: 'percentage_of_energy', percentage: '50.00', periods: [],
+    }),
+  ], { name: 'Local', billing_mode: 'percentage_of_energy', version_count: 1 })
+
+  it('derives the effective price from the grid tariffs in force at the time', () => {
+    const history = buildPriceHistory(pctSeries, [pctSeries, gridSeries], TODAY)
+
+    expect(history.unit).toBe('chf_per_kwh')
+    expect(history.bands).toEqual(['effective'])
+    expect(history.derived).toBe(true)
+    expect(history.points.map((point) => [point.date, point.values.effective])).toEqual([
+      ['2025-01-01', 0.1],
+      ['2026-01-01', 0.15],
+      [TODAY, 0.15],
+    ])
+  })
+
+  it('steps when the grid price changes even though the percentage never did', () => {
+    const history = buildPriceHistory(pctSeries, [pctSeries, gridSeries], TODAY)
+    const values = history.points.map((point) => point.values.effective)
+
+    expect(new Set(values).size).toBeGreaterThan(1)
+  })
+
+  it('sums several simultaneous grid tariffs, as the engine does', () => {
+    const secondGrid = series([
+      version('2025-01-01', null, {
+        name: 'Netznutzung', energy_type: 'grid', periods: [period('flat', '0.10000')],
+      }),
+    ], { name: 'Netznutzung', energy_type: 'grid', version_count: 1 })
+
+    const history = buildPriceHistory(pctSeries, [pctSeries, gridSeries, secondGrid], TODAY)
+
+    // 2025: (0.20 + 0.10) x 50% = 0.15
+    expect(history.points[0].values.effective).toBe(0.15)
+  })
+
+  it('prefers the flat band, then HT, when a grid version has several', () => {
+    const htNtGrid = series([
+      version('2025-01-01', null, {
+        name: 'Grid', energy_type: 'grid',
+        periods: [period('high', '0.28000'), period('low', '0.18000')],
+      }),
+    ], { name: 'Grid', energy_type: 'grid', version_count: 1 })
+
+    const history = buildPriceHistory(pctSeries, [pctSeries, htNtGrid], TODAY)
+
+    // HT is used when no flat band exists: 0.28 x 50% = 0.14
+    expect(history.points[0].values.effective).toBe(0.14)
+  })
+
+  it('reports the percentage and base in a note for the tooltip', () => {
+    const history = buildPriceHistory(pctSeries, [pctSeries, gridSeries], TODAY)
+
+    expect(history.points[0].note).toBe('50% × 0.20000')
+  })
+
+  it('yields zero rather than crashing when no grid tariff exists', () => {
+    const history = buildPriceHistory(pctSeries, [pctSeries], TODAY)
+
+    expect(history.points.every((point) => point.values.effective === 0)).toBe(true)
+  })
+
+  it('shades stretches where the price is zero because nothing backs it', () => {
+    // The engine's grid base sum is zero there, so zero really is what would be
+    // billed — but unshaded it reads as a price collapse rather than a missing
+    // basis.
+    const history = buildPriceHistory(pctSeries, [pctSeries], TODAY)
+
+    expect(history.gaps.length).toBeGreaterThan(0)
+    expect(history.gaps[0].from).toBe(ms('2025-01-01'))
+  })
+
+  it('shades a grid-tariff gap, during which the derived price falls to zero', () => {
+    const gappyGrid = series([
+      version('2025-01-01', '2025-06-30', {
+        name: 'Grid', energy_type: 'grid', periods: [period('flat', '0.20000')],
+      }),
+      version('2025-09-01', null, {
+        name: 'Grid', energy_type: 'grid', periods: [period('flat', '0.30000')],
+      }),
+    ], { name: 'Grid', energy_type: 'grid' })
+
+    const history = buildPriceHistory(pctSeries, [pctSeries, gappyGrid], TODAY)
+    const zeroPoint = history.points.find((point) => point.values.effective === 0)
+
+    expect(zeroPoint?.date).toBe('2025-07-01')
+    expect(history.gaps.some((gap) => gap.from === ms('2025-07-01'))).toBe(true)
+  })
+})


### PR DESCRIPTION
Third and last PR of the versioning series — #369 (backend), #370 (UI), this one. A tariff with more than one version now shows a step chart of its prices over time, inside the details expander below the version history. A single-version tariff shows nothing, since there is no history to compare.

## Stepped, not interpolated

A price holds for its whole validity window and then jumps. A smooth line would claim it drifted between two Januaries, so every band is `type="stepAfter"` with `connectNulls={false}`.

## Three shapes, because prices don't live in one place

| Billing mode | Charted | Unit |
|---|---|---|
| `energy` | one line per price band, so HT and NT stay comparable across years | CHF/kWh |
| fixed fees (incl. `shared_*`) | the configured amount | CHF |
| `percentage_of_energy` | **derived** effective price | CHF/kWh |

The percentage case is the one that needed thought. Such a tariff holds no price of its own — its rate is a fraction of the grid tariffs in force at the time. So the chart derives it, stepping at boundaries from **either** timeline. A local tariff set at 50% of grid steps every time the grid price moves, even though the percentage itself never changed — which is exactly the question "how has my local price moved" is asking. The derivation reuses the engine's own rule (prefer flat, else HT, else first band; sum across all grid-energy tariffs), so a charted base matches what participants are billed against. The chart says so, and the tooltip shows `50% × 0.20000`.

## Gaps

The line breaks across a gap and the stretch is shaded, rather than implying the old price continued through a period nothing was billed at.

For **derived** prices there is a second case: when no grid tariff is in force, the engine's base sum is zero, so a percentage tariff genuinely bills nothing. That is faithful, but a bare plunge to the axis reads as a price collapse rather than a missing basis — so those stretches are shaded like any other gap.

## Verified in the browser

I did not touch your 19 real tariffs. I created a scratch HT/NT tariff spanning 2023–2026 with a deliberate Q4-2024 gap, plus a percentage tariff whose own value changes only once, drove the page, and deleted everything after — you are back to exactly 19 series.

Two defects came out of *looking at the rendered chart*, neither of which the unit tests or the DOM probes would have caught:

**1. A nine-month version rendered as a dot.** With `connectNulls={false}` a chart will not draw a segment *into* a null, so a version followed by a gap had no horizontal extent at all — its 2024-01-01 → 2024-09-30 run collapsed onto its start date. Fixed by closing each run at its real end date before emitting the null that breaks the line. Pinned by `draws a version before a gap across its whole window, not as a dot`.

**2. The derived price plunged to zero unexplained** during the grid tariff's gap — correct arithmetic, misleading picture. Now shaded, as above.

Also worth recording: my first DOM probe reported `gap shading rects: 0` and empty axis ticks, and I nearly wrote those up as bugs. Both were wrong selectors — the screenshot showed the shading and the tick labels rendering correctly all along. The image was the reliable check, not the assertions.

## Tests

`priceHistory.ts` is a pure module with **22 unit tests** in `frontend/tests/`, because the boundary arithmetic is where an off-by-one hides: inclusive bounds, oldest-first sorting despite the API returning newest-first, band sets changing between versions, exactly-contiguous versions needing no extra point, retired series ending at their end date rather than today, a future-dated version not getting a terminal point that predates it, negative fixed amounts, multiple simultaneous grid tariffs summing, flat-over-HT preference, and both gap cases.

Frontend suite now **93 passed** (was 71). `tsc -b` clean, eslint clean, build clean.

Translations in all four locales.
