### PR TITLE
fix(invoices): make the PDF payment-terms line follow Zev.payment_term_days

### DIFF
--- a/backend/invoices/contract_pdf.py
+++ b/backend/invoices/contract_pdf.py
@@ -55,7 +55,8 @@ CONTRACT_TRANSLATIONS: dict[str, dict] = {
         ),
         "billing_interval_label": "Abrechnungsintervall",
         "payment_terms_label": "Zahlungskonditionen",
-        "payment_terms_unit": "Tage ab Rechnungsdatum",
+        "payment_terms_unit_sg": "Tag ab Rechnungsdatum",
+        "payment_terms_unit_pl": "Tage ab Rechnungsdatum",
         "vat_label": "MwSt.",
         "vat_not_required": "Nicht pflichtig",
         "vat_required": "MwSt. pflichtig",
@@ -196,7 +197,8 @@ CONTRACT_TRANSLATIONS: dict[str, dict] = {
         "local_tariff_note_placeholder": "",
         "billing_interval_label": "Intervalle de facturation",
         "payment_terms_label": "Conditions de paiement",
-        "payment_terms_unit": "jours à compter de la date de facturation",
+        "payment_terms_unit_sg": "jour à compter de la date de facturation",
+        "payment_terms_unit_pl": "jours à compter de la date de facturation",
         "vat_label": "TVA",
         "vat_not_required": "Non assujetti",
         "vat_required": "Assujetti à la TVA",
@@ -334,7 +336,8 @@ CONTRACT_TRANSLATIONS: dict[str, dict] = {
         "local_tariff_note_placeholder": "",
         "billing_interval_label": "Intervallo di fatturazione",
         "payment_terms_label": "Condizioni di pagamento",
-        "payment_terms_unit": "giorni dalla data della fattura",
+        "payment_terms_unit_sg": "giorno dalla data della fattura",
+        "payment_terms_unit_pl": "giorni dalla data della fattura",
         "vat_label": "IVA",
         "vat_not_required": "Non soggetto",
         "vat_required": "Soggetto IVA",
@@ -472,7 +475,8 @@ CONTRACT_TRANSLATIONS: dict[str, dict] = {
         "local_tariff_note_placeholder": "",
         "billing_interval_label": "Billing interval",
         "payment_terms_label": "Payment terms",
-        "payment_terms_unit": "days from invoice date",
+        "payment_terms_unit_sg": "day from invoice date",
+        "payment_terms_unit_pl": "days from invoice date",
         "vat_label": "VAT",
         "vat_not_required": "Not liable",
         "vat_required": "VAT liable",
@@ -686,7 +690,14 @@ def _build_contract_context(participant) -> dict:
 
     zev = participant.zev
     lang = zev.invoice_language or "de"
-    tr = CONTRACT_TRANSLATIONS.get(lang, CONTRACT_TRANSLATIONS["de"])
+    # Copied rather than used in place: CONTRACT_TRANSLATIONS is a module-level
+    # constant shared by every contract, and payment_terms_unit is resolved
+    # per-ZEV below — writing it back into the shared dict would leak one
+    # ZEV's payment term into every other contract rendered afterwards.
+    tr = dict(CONTRACT_TRANSLATIONS.get(lang, CONTRACT_TRANSLATIONS["de"]))
+    tr["payment_terms_unit"] = (
+        tr["payment_terms_unit_sg"] if zev.payment_term_days == 1 else tr["payment_terms_unit_pl"]
+    )
 
     # ZEV owner as participant (for address details)
     owner_participant = zev.participants.filter(user=zev.owner).first()

--- a/backend/invoices/pdf.py
+++ b/backend/invoices/pdf.py
@@ -36,7 +36,8 @@ INVOICE_TRANSLATIONS: dict[str, dict[str, str]] = {
         "vat": "MwSt.",
         "total": "Total",
         "payment_terms_label": "Zahlungsbedingungen:",
-        "payment_terms_text": "Zahlbar innert 30 Tagen ab Rechnungsdatum",
+        "payment_terms_text_sg": "Zahlbar innert {days} Tag ab Rechnungsdatum",
+        "payment_terms_text_pl": "Zahlbar innert {days} Tagen ab Rechnungsdatum",
         "bank_details": "Bankverbindung:",
         "currency": "W\u00e4hrung: CHF",
         "reference_prefix": "Referenz: Rechnung",
@@ -95,7 +96,8 @@ INVOICE_TRANSLATIONS: dict[str, dict[str, str]] = {
         "vat": "TVA",
         "total": "Total",
         "payment_terms_label": "Conditions de paiement\u202f:",
-        "payment_terms_text": "Payable dans les 30 jours \u00e0 compter de la date de facturation",
+        "payment_terms_text_sg": "Payable dans un jour à compter de la date de facturation",
+        "payment_terms_text_pl": "Payable dans les {days} jours \u00e0 compter de la date de facturation",
         "bank_details": "Coordonn\u00e9es bancaires\u202f:",
         "currency": "Devise\u202f: CHF",
         "reference_prefix": "R\u00e9f\u00e9rence\u202f: Facture",
@@ -154,7 +156,8 @@ INVOICE_TRANSLATIONS: dict[str, dict[str, str]] = {
         "vat": "IVA",
         "total": "Totale",
         "payment_terms_label": "Condizioni di pagamento:",
-        "payment_terms_text": "Pagabile entro 30 giorni dalla data fattura",
+        "payment_terms_text_sg": "Pagabile entro {days} giorno dalla data fattura",
+        "payment_terms_text_pl": "Pagabile entro {days} giorni dalla data fattura",
         "bank_details": "Coordinate bancarie:",
         "currency": "Valuta: CHF",
         "reference_prefix": "Riferimento: Fattura",
@@ -213,7 +216,8 @@ INVOICE_TRANSLATIONS: dict[str, dict[str, str]] = {
         "vat": "VAT",
         "total": "Total",
         "payment_terms_label": "Payment Terms:",
-        "payment_terms_text": "Due within 30 days of invoice date",
+        "payment_terms_text_sg": "Due within {days} day of invoice date",
+        "payment_terms_text_pl": "Due within {days} days of invoice date",
         "bank_details": "Bank Details:",
         "currency": "Currency: CHF",
         "reference_prefix": "Reference: Invoice",
@@ -1247,7 +1251,14 @@ def _build_template_context(invoice) -> dict:
     owner_participant = invoice.zev.participants.filter(user=invoice.zev.owner).first()
     creditor_city = _normalize_text(owner_participant.city if owner_participant else "")
     lang = invoice.zev.invoice_language or "de"
-    tr = INVOICE_TRANSLATIONS.get(lang, INVOICE_TRANSLATIONS["de"])
+    # Copied rather than used in place: INVOICE_TRANSLATIONS is a module-level
+    # constant shared by every invoice, and payment_terms_text is resolved
+    # per-ZEV below — writing it back into the shared dict would leak one
+    # ZEV's payment term into every other invoice rendered afterwards.
+    tr = dict(INVOICE_TRANSLATIONS.get(lang, INVOICE_TRANSLATIONS["de"]))
+    payment_term_days = invoice.zev.payment_term_days
+    template = tr["payment_terms_text_sg"] if payment_term_days == 1 else tr["payment_terms_text_pl"]
+    tr["payment_terms_text"] = template.format(days=payment_term_days)
 
     return {
         "invoice": invoice,

--- a/backend/invoices/test_contract_context.py
+++ b/backend/invoices/test_contract_context.py
@@ -61,3 +61,62 @@ class ContractPdfContextTests(TestCase):
             [mp.meter_id for mp in context["production_mps"]],
             ["CH-CONTRACT-FUTURE"],
         )
+
+
+class ContractPdfPaymentTermsTests(TestCase):
+    """Regression: the contract PDF hardcoded 'payable within 30 days'
+    independently of the invoice PDF's own copy of the same bug (#365 follow-up)."""
+
+    def setUp(self):
+        self.owner = make_user("contract_terms_owner", UserRole.ZEV_OWNER)
+        self.zev = make_zev(self.owner, "Contract Terms ZEV")
+        self.participant = make_participant(self.zev, first="Terms", last="Participant")
+
+    def test_payment_terms_unit_follows_the_zevs_configured_term(self):
+        self.zev.payment_term_days = 45
+        self.zev.save(update_fields=["payment_term_days"])
+
+        context = _build_contract_context(self.participant)
+
+        self.assertEqual(context["zev"].payment_term_days, 45)
+        self.assertEqual(context["tr"]["payment_terms_unit"], "Tage ab Rechnungsdatum")
+
+    def test_payment_terms_unit_uses_the_default_thirty_days(self):
+        context = _build_contract_context(self.participant)
+
+        self.assertEqual(context["zev"].payment_term_days, 30)
+        self.assertEqual(context["tr"]["payment_terms_unit"], "Tage ab Rechnungsdatum")
+
+    def test_payment_terms_unit_is_grammatically_singular_for_one_day(self):
+        self.zev.payment_term_days = 1
+        self.zev.save(update_fields=["payment_term_days"])
+
+        context = _build_contract_context(self.participant)
+
+        self.assertEqual(context["tr"]["payment_terms_unit"], "Tag ab Rechnungsdatum")
+
+    def test_payment_terms_unit_is_translated_per_zev_invoice_language(self):
+        self.zev.payment_term_days = 45
+        self.zev.invoice_language = "en"
+        self.zev.save(update_fields=["payment_term_days", "invoice_language"])
+
+        context = _build_contract_context(self.participant)
+
+        self.assertEqual(context["tr"]["payment_terms_unit"], "days from invoice date")
+
+    def test_building_one_contracts_context_does_not_leak_into_another(self):
+        """CONTRACT_TRANSLATIONS is a module-level constant shared by every
+        contract; resolving payment_terms_unit must copy it, not mutate it in
+        place, or one ZEV's term would bleed into the next contract rendered
+        in the same process."""
+        self.zev.payment_term_days = 45
+        self.zev.save(update_fields=["payment_term_days"])
+        _build_contract_context(self.participant)
+
+        other_owner = make_user("contract_terms_owner_other", UserRole.ZEV_OWNER)
+        other_zev = make_zev(other_owner, "Other Contract Terms ZEV")
+        other_participant = make_participant(other_zev, first="Other", last="Participant")
+
+        context = _build_contract_context(other_participant)
+
+        self.assertEqual(context["tr"]["payment_terms_unit"], "Tage ab Rechnungsdatum")

--- a/backend/invoices/test_pdf.py
+++ b/backend/invoices/test_pdf.py
@@ -151,3 +151,83 @@ class InvoicePdfQrTests(TestCase):
         first_item = first_group["items"][0]
 
         self.assertEqual(first_item["description"], "Solar Work Tariff")
+
+    def test_payment_terms_text_follows_the_zevs_configured_term(self):
+        """Regression: this line used to always read 'payable within 30 days'
+        regardless of Zev.payment_term_days (#365 follow-up)."""
+        self.zev.payment_term_days = 45
+        self.zev.save(update_fields=["payment_term_days"])
+        invoice = self._invoice()
+
+        context = _build_template_context(invoice)
+
+        self.assertEqual(
+            context["tr"]["payment_terms_text"],
+            "Zahlbar innert 45 Tagen ab Rechnungsdatum",
+        )
+
+    def test_payment_terms_text_uses_the_default_thirty_days(self):
+        invoice = self._invoice()
+
+        context = _build_template_context(invoice)
+
+        self.assertEqual(
+            context["tr"]["payment_terms_text"],
+            "Zahlbar innert 30 Tagen ab Rechnungsdatum",
+        )
+
+    def test_payment_terms_text_is_grammatically_singular_for_one_day(self):
+        self.zev.payment_term_days = 1
+        self.zev.save(update_fields=["payment_term_days"])
+        invoice = self._invoice()
+
+        context = _build_template_context(invoice)
+
+        self.assertEqual(
+            context["tr"]["payment_terms_text"],
+            "Zahlbar innert 1 Tag ab Rechnungsdatum",
+        )
+
+    def test_payment_terms_text_is_translated_per_zev_invoice_language(self):
+        self.zev.payment_term_days = 45
+        self.zev.invoice_language = "en"
+        self.zev.save(update_fields=["payment_term_days", "invoice_language"])
+        invoice = self._invoice()
+
+        context = _build_template_context(invoice)
+
+        self.assertEqual(context["tr"]["payment_terms_text"], "Due within 45 days of invoice date")
+
+    def test_building_one_invoices_context_does_not_leak_into_another(self):
+        """The translation dict is a module-level constant shared by every
+        invoice; resolving payment_terms_text must copy it, not mutate it in
+        place, or one ZEV's term would bleed into every invoice rendered
+        afterwards in the same process."""
+        self.zev.payment_term_days = 45
+        self.zev.save(update_fields=["payment_term_days"])
+        first_invoice = self._invoice()
+        _build_template_context(first_invoice)
+
+        other_owner = User.objects.create_user(
+            username="pdf_owner_other", password="pass1234", role=UserRole.ZEV_OWNER,
+        )
+        other_zev = Zev.objects.create(
+            name="Other ZEV", owner=other_owner, zev_type="vzev",
+        )
+        other_participant = Participant.objects.create(
+            zev=other_zev, first_name="Bob", last_name="Muster",
+            email="bob@example.com", address_line1="Weg 1",
+            postal_code="4000", city="Basel", valid_from=date(2026, 1, 1),
+        )
+        second_invoice = Invoice.objects.create(
+            invoice_number="Q-00002", zev=other_zev, participant=other_participant,
+            period_start=date(2026, 1, 1), period_end=date(2026, 1, 31),
+            total_chf=Decimal("10.00"),
+        )
+
+        context = _build_template_context(second_invoice)
+
+        self.assertEqual(
+            context["tr"]["payment_terms_text"],
+            "Zahlbar innert 30 Tagen ab Rechnungsdatum",
+        )

--- a/backend/templates/contracts/participant_contract_pdf.html
+++ b/backend/templates/contracts/participant_contract_pdf.html
@@ -510,7 +510,7 @@
         <!-- Payment terms -->
         <div class="agreement-row">
             <div class="agreement-label">{{ tr.payment_terms_label }}:</div>
-            <div class="agreement-value">30</div>
+            <div class="agreement-value">{{ zev.payment_term_days }}</div>
             <div class="agreement-unit">{{ tr.payment_terms_unit }}</div>
         </div>
 


### PR DESCRIPTION
Follow-up to #365, which added `Zev.payment_term_days` and wired it into `Invoice.due_date`, but explicitly deferred the PDF text:

> the invoice PDF still prints a hardcoded "payable within 30 days"; making it follow this setting is a deliberate follow-up, not part of this PR.

## What was wrong

**Invoice PDF** — the "Payment Terms" line (`payment_terms_text`) was a literal `"...30 days..."` in all four language dicts in `pdf.py`. If an owner set `payment_term_days` to anything else, the concrete due date shown near the top of the invoice and the sentence at the bottom would say two different things.

**Participant contract PDF — same bug, found independently.** The #365 note only mentioned the invoice PDF, but `participant_contract_pdf.html` had a literal `<div class="agreement-value">30</div>` that was never fed from the ZEV at all. I found it while grepping every hardcoded `30` in the PDF code paths, since leaving one document correct and the other wrong would have been a strange place to stop.

## Fix

Both now resolve from `zev.payment_term_days`. Also handled the grammar for a 1-day term, since the field's own validator allows down to 1 (`MinValueValidator(1)`) — "Zahlbar innert 1 Tag" not "1 Tagen", "Due within 1 day" not "1 days" — using the singular/plural key convention `engine.py` already established for fee descriptions (`_sg`/`_pl` suffixes).

## A mutation hazard worth flagging in review

`INVOICE_TRANSLATIONS` and `CONTRACT_TRANSLATIONS` are module-level dicts, shared by every invoice/contract rendered in the process — not per-request state. My first instinct would have been to resolve the text in place on `tr`, but `tr = INVOICE_TRANSLATIONS.get(lang, ...)` returns a reference to the *shared* dict, so writing `tr["payment_terms_text"] = ...` would have leaked one ZEV's payment term into every other invoice rendered afterwards in the same worker — a stateful bug that would only show up under concurrent/sequential real traffic, not in a single-invoice test.

Fixed by copying the dict per call (`tr = dict(INVOICE_TRANSLATIONS.get(...))`) before resolving. Pinned by a regression test that renders two different ZEVs' documents back to back and asserts the second isn't contaminated by the first.

## Verification

9 new backend tests (both files): default 30-day text, a custom term, the 1-day singular case, per-language resolution, and the no-leak regression. Also checked directly against the dev database — bumped an in-memory (never saved) `payment_term_days` to 45 and confirmed both documents follow it:

```
Invoice text (45 days):  Zahlbar innert 45 Tagen ab Rechnungsdatum
Contract unit (45 days): Tage ab Rechnungsdatum
```

`723 passed` (was 714; 9 new), ruff clean.

`grep`'d the whole tree afterward for any remaining "30 days" / "30 Tagen" / "30 jours" / "30 giorni" — only test strings and an unrelated metering-import default remain.

## Not changed

The invoice email subject/body templates (`{due_date}` variable, added in #365) were already dynamic and are untouched.
