### PR TITLE
fix(docker): wait for migrations before seeding demo data

### DIFF
--- a/scripts/start-demo-environment.sh
+++ b/scripts/start-demo-environment.sh
@@ -35,6 +35,18 @@ echo "Using compose command: $COMPOSE_CMD_RESOLVED"
 echo "Starting OpenZEV demo stack..."
 (cd "$ROOT_DIR" && sh -lc "$COMPOSE_CMD_RESOLVED up -d --build")
 
+echo "Waiting for database migrations to finish..."
+attempts=0
+until (cd "$ROOT_DIR" && sh -lc "$COMPOSE_CMD_RESOLVED exec -T backend python manage.py migrate --check >/dev/null 2>&1"); do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 60 ]; then
+        echo "Timed out waiting for migrations to finish; last probe output:" >&2
+        (cd "$ROOT_DIR" && sh -lc "$COMPOSE_CMD_RESOLVED exec -T backend python manage.py migrate --check") >&2 || true
+        exit 1
+    fi
+    sleep 2
+done
+
 echo "Seeding demo data..."
 (cd "$ROOT_DIR" && sh -lc "$COMPOSE_CMD_RESOLVED exec -T backend python manage.py seed_demo")
 


### PR DESCRIPTION
## Summary
`scripts/start-demo-environment.sh` ran `seed_demo` immediately after `compose up -d`, racing the backend container's startup `migrate`. On a fresh database (`compose down -v`) the seed ran before the schema existed and crashed with `relation "accounts_user" does not exist`; re-running succeeded once migrate finished.

This adds a bounded poll of `migrate --check` (read-only; exits non-zero while unapplied migrations remain) before seeding, so the seed only runs against a fully migrated schema. On timeout the probe is re-run once without output suppression so the underlying cause (container down, DB unreachable, or a broken migration) is visible instead of a bare "timed out" message.

## Linked spec
- No spec needed because: isolated dev-tooling bugfix in a shell script; no API, model, or workflow impact.

## Validation
- Backend tests run: N/A — shell-script-only change, no Python touched
- Frontend build run: N/A
- Frontend tests run: N/A
- Manual checks: `sh -n` passes; poll logic verified in isolation (retries then succeeds; timeout exits 1 and surfaces the probe error). Full `compose down -v && scripts/start-demo-environment.sh` run confirmed working against the live stack — migrations were awaited and the seed completed.
- Screenshots: N/A

## Checklist
- N/A: spec updated/linked (isolated dev-tooling bugfix)
- N/A: ADR updated/linked (no architecture decision)
- N/A: backend and frontend updated together (no API contract change)
