### PR TITLE
refactor(pdf-stats): key participant names off the assignment windows

### DIFF
--- a/backend/invoices/pdf_stats.py
+++ b/backend/invoices/pdf_stats.py
@@ -7,6 +7,7 @@ from django.db import models as _dj
 
 from allocation.split import split_consumption
 from allocation.windows import AssignmentWindows
+from metering.analytics import _participant_names
 
 from .engine import _period_to_dt
 
@@ -78,11 +79,6 @@ def _compute_period_participant_stats(invoice) -> tuple[dict, list[dict]]:
     start_dt = _period_to_dt(ps)
     end_dt = _period_to_dt(pe) + _dt.timedelta(days=1)
 
-    _participant_names = {
-        str(p.id): f"{p.first_name} {p.last_name}".strip()
-        for p in zev.participants.all()
-    }
-
     # All metering points in this ZEV. The pool covers every meter regardless
     # of assignment (ADR 0013): unassigned meters still feed the community
     # pool, even though their readings are billed to nobody. Attribution to
@@ -137,6 +133,11 @@ def _compute_period_participant_stats(invoice) -> tuple[dict, list[dict]]:
     # double-count transfers.
     windows = AssignmentWindows.for_zev(zev, ps, pe)
 
+    # Names are keyed off the assignment windows, not the current participant
+    # list: the invoice is a historical document, and a holder who has since
+    # left the ZEV must keep their name in the period stats.
+    participant_names = _participant_names(windows.participant_ids)
+
     participant_rows = (
         MeterReading.objects.filter(
             metering_point__in=cons_mps,
@@ -165,7 +166,7 @@ def _compute_period_participant_stats(invoice) -> tuple[dict, list[dict]]:
         if pid not in participant_map:
             participant_map[pid] = {
                 "participant_id": pid,
-                "participant_name": _participant_names.get(pid, ""),
+                "participant_name": participant_names.get(pid, ""),
                 "total_consumed_kwh": Decimal("0"),
                 "total_produced_kwh": Decimal("0"),
                 "from_zev_kwh": Decimal("0"),
@@ -194,7 +195,7 @@ def _compute_period_participant_stats(invoice) -> tuple[dict, list[dict]]:
         if pid not in participant_map:
             participant_map[pid] = {
                 "participant_id": pid,
-                "participant_name": _participant_names.get(pid, ""),
+                "participant_name": participant_names.get(pid, ""),
                 "total_consumed_kwh": Decimal("0"),
                 "total_produced_kwh": Decimal("0"),
                 "from_zev_kwh": Decimal("0"),

--- a/backend/invoices/test_pdf.py
+++ b/backend/invoices/test_pdf.py
@@ -1279,6 +1279,46 @@ class PeriodParticipantStatsTests(TestCase):
         assert by_name["Alice Muster"]["total_consumed_kwh"] == 2.0
         assert "Bob Beispiel" not in by_name
 
+    def test_a_holder_who_left_the_zev_keeps_their_name_in_the_period_stats(self):
+        """The stats are a historical document: a participant who held a meter
+        during the billed period but has since left the ZEV must still be
+        named — the lookup is keyed off the assignment windows, not the
+        current participant list."""
+        alice = self._participant("Alice Muster", self.PERIOD_START)
+        bob = self._participant("Bob Beispiel", self.PERIOD_START)
+        self.participant = bob
+        metering_point = MeteringPoint.objects.create(
+            zev=self.zev, meter_type=MeteringPointType.CONSUMPTION)
+        MeteringPointAssignment.objects.create(
+            metering_point=metering_point, participant=alice,
+            valid_from=self.PERIOD_START, valid_to=date(2026, 1, 15))
+        MeteringPointAssignment.objects.create(
+            metering_point=metering_point, participant=bob,
+            valid_from=date(2026, 1, 16), valid_to=None)
+        self._reading(metering_point, date(2026, 1, 5), "4")
+        self._reading(metering_point, date(2026, 1, 20), "6")
+
+        # Alice leaves the ZEV after the period: her assignments stay with the
+        # metering point, but she is no longer in zev.participants.
+        other_zev = Zev.objects.create(
+            name="Other ZEV",
+            owner=User.objects.create_user(
+                username="other_owner", password="pass1234", role=UserRole.ZEV_OWNER),
+            zev_type="vzev",
+            start_date=self.PERIOD_START,
+            billing_interval="monthly",
+            invoice_prefix="OT",
+        )
+        alice.zev = other_zev
+        alice.save()
+
+        _, stats = self._stats()
+        by_id = {s["participant_id"]: s for s in stats}
+
+        assert by_id[str(alice.id)]["participant_name"] == "Alice Muster"
+        assert by_id[str(alice.id)]["total_consumed_kwh"] == 4.0
+        assert by_id[str(bob.id)]["participant_name"] == "Bob Beispiel"
+
     def test_stats_reconcile_with_the_engine_for_full_period_assignments(self):
         """For unchanged data the PDF stats split matches the billed invoice
         totals exactly."""


### PR DESCRIPTION
## Summary

_compute_period_participant_stats resolved participant names from zev.participants.all(), so a holder who left the ZEV after the billed period dropped out of the lookup and rendered with a blank name in the PDF period stats — the invoice is a historical document and must name the people who actually held meters in its period. Names are now resolved from the assignment windows (windows.participant_ids) via the shared metering.analytics._participant_names helper. Adds a regression test: a holder transferred to another ZEV after the period keeps her name and energy in the stats.

## Linked spec

- No spec needed because: isolated bug fix in PDF period-stats rendering — no API, workflow, or billing-calculation change; the period-stats naming behavior is not described in a baseline spec.

## Validation

- Backend tests run: python -m pytest -q — 894 passed
- Focused: python -m pytest invoices/test_pdf.py -q — all pass; ruff check — clean
- Frontend build/tests: N/A (backend-only change)
- Manual checks: none
- Screenshots: none

## Checklist

- N/A: spec update — isolated backend fix, no spec change
- N/A: ADR update — no architecture decision changed
- N/A: backend and frontend together — backend-only, no API contract change
