### PR TITLE
docs(adr): drop implemented follow-ups from ADR 0013

### DIFF
--- a/docs/adr/0013-shared-allocation-service.md
+++ b/docs/adr/0013-shared-allocation-service.md
@@ -123,6 +123,8 @@ Verification (at time of implementation):
 - `AssignmentWindows` windows are immutable (tuple) after construction
 - The generate endpoint reports allocation failures (`AllocationError`) as 400 with the underlying error instead of the 409 reserved for existing invoices (`invoices/tests.py`); the celery bulk task's audit event already carries the exact exception message
 - `generate_invoices_for_zev` isolates failures per participant and reports generated/failed counts with per-participant errors (`invoices/test_batch_actions.py`)
+- The metering data-quality status reports holder-less readings (`unassigned_days` / `unassigned_readings`) and flags per-meter overlapping assignment windows (`assignment_overlap`), so one corrupt meter degrades to one bad row (`metering/tests.py`)
+- Query-count guards pin the single-fetch invariant and upper-bound per-consumer query counts across the billing path (`invoices/test_allocation_query_counts.py`)
 - Full backend suite passes (`python -m pytest -q`)
 
 Follow-ups from review (not this change):
@@ -131,8 +133,5 @@ Follow-ups from review (not this change):
 - **Allocation read-model**: an `iter_allocated_readings()` iterator yielding an `AllocatedReading` dataclass would remove the duplicated fetch-and-filter orchestration across consumers. The ADR centralizes the formulas; the orchestration is still per-consumer.
 - **Naming vocabulary**: `from_zev` vs `local` map to public API fields (`from_zev_kwh`, `from_grid_kwh`) consumed by the frontend; renaming is a breaking API change and would need frontend updates in the same PR.
 - **Gap-report feature**: surface excluded readings in the invoice document (not just the engine log) — product decision.
-- **Query-count tests**: the allocation service adds at most one query per consumer (windows fetch); pinning this with `assertNumQueries` is a follow-up.
 - **DB exclusion constraint**: application `save()` enforcement is single-object only — two concurrent transactions can both pass `_validate_no_overlap()` and both `INSERT` overlapping windows, and `QuerySet.update()` / `bulk_create()` / raw SQL bypass `save()` entirely. A Postgres `ExclusionConstraint` on a `daterange` of `(metering_point, valid_from, valid_to)` would close that race at the DB layer if concurrent admin/script writers become a real risk; the runtime `AssignmentWindows` guard remains the backstop until then.
 - **System-wide local-civil-date semantics**: if business wants assignment validity, periods, and tariffs on Zurich civil dates, it must be decided for the whole system together (ADR 0001/0007 territory), not per-feature.
-- **Per-participant batch isolation**: `generate_invoices_for_zev` is a bare list comprehension — one bad metering point aborts the whole ZEV billing run. Isolate per participant (needs a product decision on what the operator sees for partial success).
-- **Holder-less meter visibility**: a metering point with no assignment overlapping the period counts in the physical pool but is billed to nobody, with no warning today. Surface such readings as a data-quality check next to the existing metering-quality checks, so an operator can assign the meter (e.g. to an *Allgemein* / community participant) or confirm the exclusion.


### PR DESCRIPTION
## Summary
Three ADR 0013 follow-ups are implemented but still listed as open:

- "Per-participant batch isolation" — shipped in #394; its bullet removal was re-added during #396's merge-conflict resolution
- "Holder-less meter visibility" — shipped in #396; its bullet removal was dropped in the same resolution
- "Query-count tests" — shipped in #397/#398

Removes the three bullets and adds verification lines for the holder-less data-quality check and the query-count guards. All remaining follow-ups verified as genuinely open; the "Allocation read-model" bullet is left to #403.

## Linked spec
- No spec needed because: docs-only cleanup, no behavior change

## Validation
- Backend tests run: N/A — docs-only change
- Frontend build run: N/A
- Frontend tests run: N/A
- Manual checks: N/A
- Screenshots: N/A

## Checklist
- N/A: spec update — docs-only cleanup
- [x] ADR updated/linked for architecture decisions
- N/A: backend and frontend updated together — no code change
