### PR TITLE
chore(backend): remove dead code and consolidate test helpers

### DIFF
--- a/backend/accounts/cookies.py
+++ b/backend/accounts/cookies.py
@@ -21,7 +21,7 @@ ADMIN_ACCESS_COOKIE = "openzev_admin_access"
 ADMIN_REFRESH_COOKIE = "openzev_admin_refresh"
 
 
-def cookie_kwargs() -> dict:
+def _cookie_kwargs() -> dict:
     """Shared kwargs for all auth cookies: httpOnly, Secure in prod, SameSite=Lax."""
     return {
         "httponly": True,
@@ -42,7 +42,7 @@ def set_auth_cookies(
     jwt_settings = settings.SIMPLE_JWT
     access_max_age = int(jwt_settings.get("ACCESS_TOKEN_LIFETIME", timedelta(minutes=60)).total_seconds())
     refresh_max_age = int(jwt_settings.get("REFRESH_TOKEN_LIFETIME", timedelta(days=7)).total_seconds())
-    kw = cookie_kwargs()
+    kw = _cookie_kwargs()
     response.set_cookie(access_cookie, access, max_age=access_max_age, **kw)
     response.set_cookie(refresh_cookie, refresh, max_age=refresh_max_age, **kw)
 

--- a/backend/accounts/permissions.py
+++ b/backend/accounts/permissions.py
@@ -11,8 +11,3 @@ class IsZevOwnerOrAdmin(BasePermission):
         return request.user.is_authenticated and (
             request.user.is_zev_owner or request.user.is_admin
         )
-
-
-class IsParticipantOrAbove(BasePermission):
-    def has_permission(self, request, view):
-        return request.user.is_authenticated

--- a/backend/accounts/schema.py
+++ b/backend/accounts/schema.py
@@ -12,7 +12,7 @@ class ApiKeyAuthenticationScheme(OpenApiAuthenticationExtension):
     target_class = "accounts.authentication.ApiKeyAuthentication"
     name = "ApiKeyAuth"
 
-    def get_security_definition(self, auto_schema):
+    def get_security_definition(self, _auto_schema):
         return {
             "type": "apiKey",
             "in": "header",
@@ -33,7 +33,7 @@ class CookieJWTAuthenticationScheme(OpenApiAuthenticationExtension):
     target_class = "accounts.authentication.CookieJWTAuthentication"
     name = "CookieJwtAuth"
 
-    def get_security_definition(self, auto_schema):
+    def get_security_definition(self, _auto_schema):
         return {
             "type": "http",
             "scheme": "bearer",

--- a/backend/accounts/test_oauth.py
+++ b/backend/accounts/test_oauth.py
@@ -34,7 +34,6 @@ from .models import (
 FRONTEND = "http://localhost:5173"
 PROVIDERS_PUBLIC = "/api/v1/auth/oauth/providers/"
 PROVIDERS_CONFIG = "/api/v1/auth/oauth/providers/config/"
-TOKEN_EXCHANGE = "/api/v1/auth/oauth/token-exchange/"
 SOCIAL_ACCOUNTS = "/api/v1/auth/me/social-accounts/"
 
 

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -283,7 +283,9 @@ def me(request):
                     impersonator = User.objects.get(pk=impersonator_id)
                     data["impersonated_by"] = UserSerializer(impersonator).data
                 except User.DoesNotExist:
-                    pass
+                    logger.warning(
+                        "impersonation claim references deleted user %s", impersonator_id
+                    )
         return Response(data)
     serializer = UserSerializer(request.user, data=request.data, partial=True, context={"request": request})
     serializer.is_valid(raise_exception=True)

--- a/backend/allocation/test_read_model.py
+++ b/backend/allocation/test_read_model.py
@@ -24,7 +24,8 @@ from allocation.read_model import (
 from allocation.split import split_consumption, split_production
 from allocation.windows import AssignmentWindows
 from metering.models import MeterReading, ReadingDirection
-from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
+from testing.helpers import make_named_participant
+from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Zev
 
 User = get_user_model()
 
@@ -57,8 +58,8 @@ class ReadModelTests(TestCase):
         )
         self.zev.refresh_from_db()
 
-        self.alice = self._participant("Alice Muster", PERIOD_START, date(2026, 1, 14))
-        self.bob = self._participant("Bob Beispiel", date(2026, 1, 16))
+        self.alice = make_named_participant(self.zev, "Alice Muster", PERIOD_START, date(2026, 1, 14))
+        self.bob = make_named_participant(self.zev, "Bob Beispiel", date(2026, 1, 16))
 
         # Consumption meter transferred Alice -> Bob with a gap (Jan 15).
         self.consumption_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-RM-CONS-1")
@@ -80,15 +81,7 @@ class ReadModelTests(TestCase):
 
         self.windows = AssignmentWindows.for_zev(self.zev, PERIOD_START, PERIOD_END)
 
-    # ── fixture builders (mirror invoices/test_allocation_reconciliation.py) ──
-
-    def _participant(self, name, valid_from, valid_to=None):
-        first, last = name.split(" ", 1)
-        return Participant.objects.create(
-            zev=self.zev, first_name=first, last_name=last,
-            email=f"{name.replace(' ', '').lower()}@example.com",
-            valid_from=valid_from, valid_to=valid_to,
-        )
+    # ── fixture builders ──
 
     def _mp(self, meter_type, meter_id):
         return MeteringPoint.objects.create(zev=self.zev, meter_type=meter_type, meter_id=meter_id)

--- a/backend/feasibility/defaults.py
+++ b/backend/feasibility/defaults.py
@@ -6,7 +6,6 @@ can determine a figure from actual tariffs/metering data.
 """
 from decimal import Decimal
 
-SPECIFIC_YIELD_KWH_PER_KWP = Decimal("950")
 RETAIL_PRICE_CHF_PER_KWH = Decimal("0.32")
 FEED_IN_PRICE_CHF_PER_KWH = Decimal("0.09")
 INTERNAL_ENERGY_PRICE_CHF_PER_KWH = Decimal("0.20")

--- a/backend/invoices/annual_statement.py
+++ b/backend/invoices/annual_statement.py
@@ -7,7 +7,6 @@ Produces a year-end summary document for a participant showing:
 - Savings compared to grid tariff
 - Energy self-sufficiency ratio
 """
-import logging
 from datetime import date, datetime, timezone as dt_timezone
 from decimal import Decimal, ROUND_HALF_UP
 
@@ -25,8 +24,6 @@ from metering.models import MeterReading, ReadingDirection
 from zev.models import MeteringPointAssignment
 from .models import Invoice, InvoiceStatus
 from .pdf import _format_date_value, _render_template
-
-logger = logging.getLogger(__name__)
 
 ANNUAL_STATEMENT_TEMPLATE = "invoices/annual_statement_pdf.html"
 

--- a/backend/invoices/contract_pdf.py
+++ b/backend/invoices/contract_pdf.py
@@ -3,7 +3,6 @@ Contract PDF generation for ZEV participation agreements.
 Renders an HTML template via Django's template engine and converts it to PDF
 using WeasyPrint.
 """
-import logging
 from datetime import date
 from decimal import Decimal
 
@@ -13,8 +12,6 @@ from .pdf_render import render_pdf
 
 from tariffs.models import BillingMode, EnergyType, PeriodType
 from zev.models import MeteringPointType
-
-logger = logging.getLogger(__name__)
 
 CONTRACT_TEMPLATE_NAME = "contracts/participant_contract_pdf.html"
 

--- a/backend/invoices/pdf_charts.py
+++ b/backend/invoices/pdf_charts.py
@@ -1,11 +1,7 @@
 """Invoice PDF SVG chart builders — energy flow, comparison, and hourly profile."""
 
-import logging
-
 from .engine import _period_to_dt
 from .pdf_stats import _compute_period_participant_stats
-
-logger = logging.getLogger(__name__)
 
 # Shared palette for SVG charts — matches the invoice template brand.
 _CHART_LOCAL = "#1f5c3a"

--- a/backend/invoices/test_allocation_query_counts.py
+++ b/backend/invoices/test_allocation_query_counts.py
@@ -30,6 +30,7 @@ from invoices.test_allocation_reconciliation import (
     PERIOD_START,
     _ReconciliationBase,
 )
+from testing.helpers import make_named_participant
 from zev.models import MeteringPointType, Zev
 
 User = get_user_model()
@@ -55,8 +56,8 @@ class AllocationQueryCountTests(_ReconciliationBase):
             invoice_prefix="MM",
         )
         self.zev.refresh_from_db()
-        self.alice = self._participant("Alice Muster", PERIOD_START)
-        self.bob = self._participant("Bob Beispiel", date(2026, 1, 16))
+        self.alice = make_named_participant(self.zev, "Alice Muster", PERIOD_START)
+        self.bob = make_named_participant(self.zev, "Bob Beispiel", date(2026, 1, 16))
 
         self.cons1 = self._mp(MeteringPointType.CONSUMPTION, "CH-MM-CONS-1")
         self.cons2 = self._mp(MeteringPointType.CONSUMPTION, "CH-MM-CONS-2")

--- a/backend/invoices/test_allocation_reconciliation.py
+++ b/backend/invoices/test_allocation_reconciliation.py
@@ -26,7 +26,8 @@ from invoices.engine import generate_invoice
 from invoices.pdf_stats import _compute_period_participant_stats
 from metering.analytics import owner_dashboard_summary
 from metering.models import MeterReading, ReadingDirection
-from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
+from testing.helpers import make_named_participant
+from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Zev
 
 User = get_user_model()
 
@@ -38,14 +39,6 @@ ENERGY_QUANTUM = Decimal("0.0001")
 
 class _ReconciliationBase(TestCase):
     """Shared fixture builders and consumers for reconciliation scenarios."""
-
-    def _participant(self, name, valid_from, valid_to=None):
-        first, last = name.split(" ", 1)
-        return Participant.objects.create(
-            zev=self.zev, first_name=first, last_name=last,
-            email=f"{name.replace(' ', '').lower()}@example.com",
-            valid_from=valid_from, valid_to=valid_to,
-        )
 
     def _mp(self, meter_type, meter_id):
         return MeteringPoint.objects.create(
@@ -159,8 +152,8 @@ class EnginePdfStatsAnalyticsReconciliationTests(_ReconciliationBase):
             invoice_prefix="RC",
         )
         self.zev.refresh_from_db()
-        self.alice = self._participant("Alice Muster", PERIOD_START, date(2026, 1, 14))
-        self.bob = self._participant("Bob Beispiel", date(2026, 1, 16))
+        self.alice = make_named_participant(self.zev, "Alice Muster", PERIOD_START, date(2026, 1, 14))
+        self.bob = make_named_participant(self.zev, "Bob Beispiel", date(2026, 1, 16))
 
         self.consumption_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-RC-CONS-1")
         self._assign(self.consumption_mp, self.alice, PERIOD_START, date(2026, 1, 14))
@@ -280,8 +273,8 @@ class MultiMeterBidirectionalReconciliationTests(_ReconciliationBase):
             invoice_prefix="MM",
         )
         self.zev.refresh_from_db()
-        self.alice = self._participant("Alice Muster", PERIOD_START)
-        self.bob = self._participant("Bob Beispiel", date(2026, 1, 16))
+        self.alice = make_named_participant(self.zev, "Alice Muster", PERIOD_START)
+        self.bob = make_named_participant(self.zev, "Bob Beispiel", date(2026, 1, 16))
 
         self.cons1 = self._mp(MeteringPointType.CONSUMPTION, "CH-MM-CONS-1")
         self.cons2 = self._mp(MeteringPointType.CONSUMPTION, "CH-MM-CONS-2")
@@ -500,8 +493,8 @@ class UnassignedProductionReconciliationTests(_ReconciliationBase):
             invoice_prefix="UP",
         )
         self.zev.refresh_from_db()
-        self.alice = self._participant("Alice Muster", PERIOD_START)
-        self.bob = self._participant("Bob Beispiel", PERIOD_START)
+        self.alice = make_named_participant(self.zev, "Alice Muster", PERIOD_START)
+        self.bob = make_named_participant(self.zev, "Bob Beispiel", PERIOD_START)
 
         self.cons1 = self._mp(MeteringPointType.CONSUMPTION, "CH-UP-CONS-1")
         self.prod1 = self._mp(MeteringPointType.PRODUCTION, "CH-UP-PROD-1")
@@ -566,7 +559,7 @@ class AnnualStatementPhysicalPoolTests(_ReconciliationBase):
         )
         self.zev.refresh_from_db()
 
-        self.alice = self._participant("Alice Muster", PERIOD_START)
+        self.alice = make_named_participant(self.zev, "Alice Muster", PERIOD_START)
 
         self.consumption_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-AP-CONS")
         self._assign(self.consumption_mp, self.alice, PERIOD_START)
@@ -624,7 +617,7 @@ class AnnualStatementDirectionTypePairingTests(_ReconciliationBase):
         )
         self.zev.refresh_from_db()
 
-        self.alice = self._participant("Alice Muster", PERIOD_START)
+        self.alice = make_named_participant(self.zev, "Alice Muster", PERIOD_START)
 
         self.consumption_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-PZ-CONS")
         self._assign(self.consumption_mp, self.alice, PERIOD_START)

--- a/backend/invoices/test_helpers.py
+++ b/backend/invoices/test_helpers.py
@@ -7,16 +7,12 @@ newer tests gradually move to factories in ``testing.factories``.
 from datetime import date
 from decimal import Decimal
 
-from accounts.models import User
 from invoices.models import Invoice, InvoiceStatus
+from testing.helpers import make_user as make_user
 from zev.models import Participant, Zev
 
 
 _counter = 0
-
-
-def make_user(username, role, password="pass1234"):
-    return User.objects.create_user(username=username, password=password, role=role)
 
 
 def make_zev(owner, name="Test ZEV"):

--- a/backend/invoices/test_pdf.py
+++ b/backend/invoices/test_pdf.py
@@ -11,6 +11,7 @@ from django.test import TestCase
 from django.utils import timezone
 from tariffs.models import TariffCategory
 from metering.models import MeterReading, ReadingDirection
+from testing.helpers import make_named_participant
 from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
 
 from .models import Invoice, InvoiceItem, InvoiceStatus
@@ -347,7 +348,7 @@ class InvoicePdfQrTests(TestCase):
         self.assertIn('class="line-items"', html)
         self.assertIn('quantity-cell', html)
         self.assertNotIn('<th>{{ tr.unit }}</th>', html)  # unit merged into quantity
-        self.assertIn('amount-card--savings', html)
+        self.assertIn('savings-breakdown', html)  # savings card variant renders
 
     def test_template_context_enables_inline_qr_payment_for_small_invoices(self):
         invoice = self._invoice()
@@ -1206,14 +1207,6 @@ class PeriodParticipantStatsTests(TestCase):
         )
         self.zev.refresh_from_db()
 
-    def _participant(self, name, valid_from, valid_to=None):
-        first, last = name.split(" ", 1)
-        return Participant.objects.create(
-            zev=self.zev, first_name=first, last_name=last,
-            email=f"{name.replace(' ', '').lower()}@example.com",
-            valid_from=valid_from, valid_to=valid_to,
-        )
-
     def _reading(self, metering_point, day, kwh):
         return MeterReading.objects.create(
             metering_point=metering_point,
@@ -1237,8 +1230,8 @@ class PeriodParticipantStatsTests(TestCase):
     def test_mid_period_transfer_is_attributed_per_reading(self):
         """A metering point handed over mid-period attributes each reading to
         its holder without double-counting (join fan-out regression)."""
-        alice = self._participant("Alice Muster", self.PERIOD_START, date(2026, 1, 15))
-        bob = self._participant("Bob Beispiel", date(2026, 1, 16))
+        alice = make_named_participant(self.zev, "Alice Muster", self.PERIOD_START, date(2026, 1, 15))
+        bob = make_named_participant(self.zev, "Bob Beispiel", date(2026, 1, 16))
         self.participant = alice
         metering_point = MeteringPoint.objects.create(
             zev=self.zev, meter_type=MeteringPointType.CONSUMPTION)
@@ -1258,8 +1251,8 @@ class PeriodParticipantStatsTests(TestCase):
         assert by_name["Bob Beispiel"]["total_consumed_kwh"] == 6.0
 
     def test_readings_in_an_assignment_gap_appear_in_no_participants_stats(self):
-        alice = self._participant("Alice Muster", self.PERIOD_START, date(2026, 1, 10))
-        bob = self._participant("Bob Beispiel", date(2026, 1, 20))
+        alice = make_named_participant(self.zev, "Alice Muster", self.PERIOD_START, date(2026, 1, 10))
+        bob = make_named_participant(self.zev, "Bob Beispiel", date(2026, 1, 20))
         self.participant = alice
         metering_point = MeteringPoint.objects.create(
             zev=self.zev, meter_type=MeteringPointType.CONSUMPTION)
@@ -1284,8 +1277,8 @@ class PeriodParticipantStatsTests(TestCase):
         during the billed period but has since left the ZEV must still be
         named — the lookup is keyed off the assignment windows, not the
         current participant list."""
-        alice = self._participant("Alice Muster", self.PERIOD_START)
-        bob = self._participant("Bob Beispiel", self.PERIOD_START)
+        alice = make_named_participant(self.zev, "Alice Muster", self.PERIOD_START)
+        bob = make_named_participant(self.zev, "Bob Beispiel", self.PERIOD_START)
         self.participant = bob
         metering_point = MeteringPoint.objects.create(
             zev=self.zev, meter_type=MeteringPointType.CONSUMPTION)
@@ -1323,7 +1316,7 @@ class PeriodParticipantStatsTests(TestCase):
         """For unchanged data the PDF stats split matches the billed invoice
         totals exactly."""
         from .engine import generate_invoice
-        alice = self._participant("Alice Muster", self.PERIOD_START)
+        alice = make_named_participant(self.zev, "Alice Muster", self.PERIOD_START)
         self.participant = alice
         metering_point = MeteringPoint.objects.create(
             zev=self.zev, meter_type=MeteringPointType.CONSUMPTION)

--- a/backend/invoices/test_reports.py
+++ b/backend/invoices/test_reports.py
@@ -43,14 +43,14 @@ class ReportTestCase(TestCase):
         self.other_zev = make_zev(self.other_owner, "Other ZEV")
         self.other_participant = make_participant(self.other_zev, first="Otto", last="Fremd")
 
+    def _get(self, url, user, **params):
+        auth(self.client, user)
+        return self.client.get(url, params)
+
 
 class AnnualStatementTests(ReportTestCase):
-    def _get(self, user, **params):
-        auth(self.client, user)
-        return self.client.get(ANNUAL_STATEMENT, params)
-
     def test_admin_can_read_any_zev(self):
-        resp = self._get(self.admin, year=2026, zev_id=str(self.zev.pk),
+        resp = self._get(ANNUAL_STATEMENT, self.admin, year=2026, zev_id=str(self.zev.pk),
                          participant_id=str(self.participant.pk))
 
         self.assertEqual(resp.status_code, 200)
@@ -59,13 +59,13 @@ class AnnualStatementTests(ReportTestCase):
         self.assertTrue(resp["Content-Disposition"].startswith("inline"))
 
     def test_owner_can_read_own_zev(self):
-        resp = self._get(self.owner, year=2026, zev_id=str(self.zev.pk),
+        resp = self._get(ANNUAL_STATEMENT, self.owner, year=2026, zev_id=str(self.zev.pk),
                          participant_id=str(self.participant.pk))
 
         self.assertEqual(resp.status_code, 200)
 
     def test_owner_cannot_read_another_owners_zev(self):
-        resp = self._get(self.owner, year=2026, zev_id=str(self.other_zev.pk),
+        resp = self._get(ANNUAL_STATEMENT, self.owner, year=2026, zev_id=str(self.other_zev.pk),
                          participant_id=str(self.other_participant.pk))
 
         self.assertEqual(resp.status_code, 403)
@@ -73,7 +73,7 @@ class AnnualStatementTests(ReportTestCase):
     def test_participant_gets_their_own_without_naming_ids(self):
         """A participant never passes zev_id/participant_id; the ids they *do*
         pass are ignored, so they cannot request someone else's statement."""
-        resp = self._get(self.puser, year=2026,
+        resp = self._get(ANNUAL_STATEMENT, self.puser, year=2026,
                          zev_id=str(self.other_zev.pk),
                          participant_id=str(self.other_participant.pk))
 
@@ -81,28 +81,28 @@ class AnnualStatementTests(ReportTestCase):
         self.assertIn("annual-statement-2026-Muster.pdf", resp["Content-Disposition"])
 
     def test_participant_without_a_record_is_404(self):
-        resp = self._get(make_user("rpt_orphan", UserRole.PARTICIPANT), year=2026)
+        resp = self._get(ANNUAL_STATEMENT, make_user("rpt_orphan", UserRole.PARTICIPANT), year=2026)
 
         self.assertEqual(resp.status_code, 404)
 
     def test_year_is_required_and_must_be_numeric(self):
-        missing = self._get(self.admin, zev_id=str(self.zev.pk), participant_id=str(self.participant.pk))
+        missing = self._get(ANNUAL_STATEMENT, self.admin, zev_id=str(self.zev.pk), participant_id=str(self.participant.pk))
         self.assertEqual(missing.status_code, 400)
         self.assertEqual(missing.data["error"], "year is required.")
 
-        bad = self._get(self.admin, year="not-a-year", zev_id=str(self.zev.pk),
+        bad = self._get(ANNUAL_STATEMENT, self.admin, year="not-a-year", zev_id=str(self.zev.pk),
                         participant_id=str(self.participant.pk))
         self.assertEqual(bad.status_code, 400)
         self.assertEqual(bad.data["error"], "year must be a number.")
 
     def test_owner_must_name_both_ids(self):
-        resp = self._get(self.owner, year=2026, zev_id=str(self.zev.pk))
+        resp = self._get(ANNUAL_STATEMENT, self.owner, year=2026, zev_id=str(self.zev.pk))
 
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.data["error"], "participant_id and zev_id are required.")
 
     def test_unknown_zev_is_404(self):
-        resp = self._get(self.admin, year=2026, zev_id="00000000-0000-0000-0000-000000000000",
+        resp = self._get(ANNUAL_STATEMENT, self.admin, year=2026, zev_id="00000000-0000-0000-0000-000000000000",
                          participant_id=str(self.participant.pk))
 
         self.assertEqual(resp.status_code, 404)
@@ -110,7 +110,7 @@ class AnnualStatementTests(ReportTestCase):
     def test_participant_from_another_zev_is_404(self):
         """The participant lookup is scoped to the resolved ZEV, so naming a
         valid participant of a different ZEV must not leak their statement."""
-        resp = self._get(self.admin, year=2026, zev_id=str(self.zev.pk),
+        resp = self._get(ANNUAL_STATEMENT, self.admin, year=2026, zev_id=str(self.zev.pk),
                          participant_id=str(self.other_participant.pk))
 
         self.assertEqual(resp.status_code, 404)
@@ -122,14 +122,10 @@ class AnnualStatementTests(ReportTestCase):
 
 
 class AnnualStatementsZipTests(ReportTestCase):
-    def _get(self, user, **params):
-        auth(self.client, user)
-        return self.client.get(STATEMENTS_ZIP, params)
-
     def test_owner_downloads_a_zip_of_every_participant(self):
         make_participant(self.zev, first="Bea", last="Zweit")
 
-        resp = self._get(self.owner, year=2026, zev_id=str(self.zev.pk))
+        resp = self._get(STATEMENTS_ZIP, self.owner, year=2026, zev_id=str(self.zev.pk))
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp["Content-Type"], "application/zip")
@@ -141,49 +137,45 @@ class AnnualStatementsZipTests(ReportTestCase):
         )
 
     def test_participant_is_refused(self):
-        resp = self._get(self.puser, year=2026, zev_id=str(self.zev.pk))
+        resp = self._get(STATEMENTS_ZIP, self.puser, year=2026, zev_id=str(self.zev.pk))
 
         self.assertEqual(resp.status_code, 403)
 
     def test_owner_cannot_read_another_owners_zev(self):
-        resp = self._get(self.owner, year=2026, zev_id=str(self.other_zev.pk))
+        resp = self._get(STATEMENTS_ZIP, self.owner, year=2026, zev_id=str(self.other_zev.pk))
 
         self.assertEqual(resp.status_code, 403)
 
     def test_year_and_zev_id_are_both_required(self):
         for params in ({"year": 2026}, {"zev_id": "x"}):
             with self.subTest(params=params):
-                resp = self._get(self.owner, **params)
+                resp = self._get(STATEMENTS_ZIP, self.owner, **params)
                 self.assertEqual(resp.status_code, 400)
                 self.assertEqual(resp.data["error"], "year and zev_id are required.")
 
     def test_zev_without_participants_for_that_year_is_404(self):
         """Participants are filtered by validity window, so a year before the
         ZEV had anyone yields 404 rather than an empty archive."""
-        resp = self._get(self.owner, year=2020, zev_id=str(self.zev.pk))
+        resp = self._get(STATEMENTS_ZIP, self.owner, year=2020, zev_id=str(self.zev.pk))
 
         self.assertEqual(resp.status_code, 404)
 
     def test_participants_who_left_before_the_year_are_excluded(self):
         Participant.objects.filter(pk=self.participant.pk).update(valid_to=date(2024, 6, 30))
 
-        resp = self._get(self.owner, year=2026, zev_id=str(self.zev.pk))
+        resp = self._get(STATEMENTS_ZIP, self.owner, year=2026, zev_id=str(self.zev.pk))
 
         self.assertEqual(resp.status_code, 404)
 
 
 class FinancialSummaryTests(ReportTestCase):
-    def _get(self, user, **params):
-        auth(self.client, user)
-        return self.client.get(FINANCIAL_SUMMARY, params)
-
     def test_owner_cannot_read_another_owners_zev(self):
-        resp = self._get(self.owner, year=2026, zev_id=str(self.other_zev.pk))
+        resp = self._get(FINANCIAL_SUMMARY, self.owner, year=2026, zev_id=str(self.other_zev.pk))
 
         self.assertEqual(resp.status_code, 403)
 
     def test_zev_id_is_required_for_an_owner(self):
-        resp = self._get(self.owner, year=2026)
+        resp = self._get(FINANCIAL_SUMMARY, self.owner, year=2026)
 
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.data["error"], "zev_id is required.")
@@ -193,26 +185,26 @@ class FinancialSummaryTests(ReportTestCase):
         admin has none of their own in it."""
         owner_participant = make_participant(self.zev, user=self.owner, first="Olga", last="Wirt")
 
-        resp = self._get(self.admin, year=2026, zev_id=str(self.zev.pk))
+        resp = self._get(FINANCIAL_SUMMARY, self.admin, year=2026, zev_id=str(self.zev.pk))
 
         self.assertEqual(resp.status_code, 200)
         self.assertIn(f"financial-summary-2026-{owner_participant.last_name}.pdf",
                       resp["Content-Disposition"])
 
     def test_without_any_default_participant_it_is_400(self):
-        resp = self._get(self.admin, year=2026, zev_id=str(self.zev.pk))
+        resp = self._get(FINANCIAL_SUMMARY, self.admin, year=2026, zev_id=str(self.zev.pk))
 
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.data["error"], "participant_id is required (no default participant found).")
 
     def test_participant_from_another_zev_is_404(self):
-        resp = self._get(self.admin, year=2026, zev_id=str(self.zev.pk),
+        resp = self._get(FINANCIAL_SUMMARY, self.admin, year=2026, zev_id=str(self.zev.pk),
                          participant_id=str(self.other_participant.pk))
 
         self.assertEqual(resp.status_code, 404)
 
     def test_participant_ignores_supplied_ids_and_gets_their_own(self):
-        resp = self._get(self.puser, year=2026, zev_id=str(self.other_zev.pk),
+        resp = self._get(FINANCIAL_SUMMARY, self.puser, year=2026, zev_id=str(self.other_zev.pk),
                          participant_id=str(self.other_participant.pk))
 
         self.assertEqual(resp.status_code, 200)
@@ -228,10 +220,6 @@ class MalformedInputTests(ReportTestCase):
     handler, and an out-of-range year raised ValueError from date(year, 1, 1)
     deep inside PDF generation.
     """
-
-    def _get(self, url, user, **params):
-        auth(self.client, user)
-        return self.client.get(url, params)
 
     def test_malformed_zev_id_is_404(self):
         for url in (ANNUAL_STATEMENT, STATEMENTS_ZIP, FINANCIAL_SUMMARY):

--- a/backend/metering/importers/sdatch_importer.py
+++ b/backend/metering/importers/sdatch_importer.py
@@ -7,7 +7,6 @@ The format is based on the ebIX standard with Swiss extensions.
 Reference: SDAT-CH specification, swisseldex / Edirom
 """
 import uuid
-import logging
 from datetime import datetime, timezone, timedelta
 from decimal import Decimal
 
@@ -15,8 +14,6 @@ from lxml import etree
 
 from zev.models import MeteringPoint
 from metering.models import MeterReading, ImportLog, ImportSource
-
-logger = logging.getLogger(__name__)
 
 # Namespaces used in SDAT-CH MeteringData documents
 NSMAP = {

--- a/backend/metering/test_import_csv.py
+++ b/backend/metering/test_import_csv.py
@@ -3,12 +3,12 @@
 from datetime import date, datetime, timezone
 from decimal import Decimal
 
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from rest_framework.test import APIClient
 
 from accounts.models import UserRole
 from metering.models import ImportLog, MeterReading, ReadingDirection
+from metering.testing import preview_csv, upload_csv
 from testing.helpers import authenticate as auth, make_user
 from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
 
@@ -45,16 +45,8 @@ class CsvImportTests(TestCase):
             meter_type=MeteringPointType.CONSUMPTION,
         )
 
-    def _upload(self, name, content, **fields):
-        upload = SimpleUploadedFile(name, content, content_type="text/csv")
-        return self.client.post("/api/v1/metering/import/csv/", {"file": upload, **fields}, format="multipart")
-
-    def _preview(self, name, content, **fields):
-        upload = SimpleUploadedFile(name, content, content_type="text/csv")
-        return self.client.post("/api/v1/metering/import/preview-csv/", {"file": upload, **fields}, format="multipart")
-
     def test_malformed_csv_payload_is_reported_without_crash(self):
-        resp = self._upload("bad.csv", b"wrong_col1,wrong_col2\nfoo,bar\n")
+        resp = upload_csv(self.client, "bad.csv", b"wrong_col1,wrong_col2\nfoo,bar\n")
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 0)
@@ -68,7 +60,7 @@ class CsvImportTests(TestCase):
             b"CH-IMPORT-1,2026-01-01T02:00:00+02:00,1.5000,in\n"
         )
 
-        resp = self._upload("tz.csv", csv_bytes)
+        resp = upload_csv(self.client, "tz.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 1)
@@ -82,7 +74,7 @@ class CsvImportTests(TestCase):
             b"CH-IMPORT-1,2026-01-02T00:00:00Z,2.0000,in\n"
         )
 
-        resp = self._upload("dupe.csv", csv_bytes)
+        resp = upload_csv(self.client, "dupe.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 1)
@@ -96,11 +88,11 @@ class CsvImportTests(TestCase):
             b"CH-IMPORT-1,2026-01-03T00:00:00Z,3.0000,in\n"
         )
 
-        first_resp = self._upload("idempotent-first.csv", csv_bytes)
+        first_resp = upload_csv(self.client, "idempotent-first.csv", csv_bytes)
         self.assertEqual(first_resp.status_code, 201)
         self.assertEqual(first_resp.data["rows_imported"], 1)
 
-        second_resp = self._upload("idempotent-second.csv", csv_bytes)
+        second_resp = upload_csv(self.client, "idempotent-second.csv", csv_bytes)
 
         self.assertEqual(second_resp.status_code, 201)
         self.assertEqual(second_resp.data["rows_imported"], 0)
@@ -117,11 +109,11 @@ class CsvImportTests(TestCase):
             b"CH-IMPORT-1,2026-01-04T00:00:00Z,4.5000,in\n"
         )
 
-        first_resp = self._upload("overwrite-first.csv", initial_csv)
+        first_resp = upload_csv(self.client, "overwrite-first.csv", initial_csv)
         self.assertEqual(first_resp.status_code, 201)
         self.assertEqual(first_resp.data["rows_imported"], 1)
 
-        overwrite_resp = self._upload("overwrite-second.csv", updated_csv, overwrite_existing="true")
+        overwrite_resp = upload_csv(self.client, "overwrite-second.csv", updated_csv, overwrite_existing="true")
 
         self.assertEqual(overwrite_resp.status_code, 201)
         self.assertEqual(overwrite_resp.data["rows_imported"], 1)
@@ -142,7 +134,7 @@ class CsvImportTests(TestCase):
             b"CH-MISSING,2026-01-05T00:15:00Z,2.0000,in\n"
         )
 
-        resp = self._preview("preview.csv", csv_bytes)
+        resp = preview_csv(self.client, "preview.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data["rows_total"], 2)
@@ -155,7 +147,7 @@ class CsvImportTests(TestCase):
     def test_headerless_csv_uses_index_column_mapping(self):
         csv_bytes = b"CH-IMPORT-1;2026-01-06T00:00:00Z;6,2500;in\n"
 
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "headerless.csv",
             csv_bytes,
             has_header="false",
@@ -174,7 +166,7 @@ class CsvImportTests(TestCase):
     def test_daily_15min_profile_imports_configured_slots(self):
         csv_bytes = b"meter_id,date,v1,v2\nCH-IMPORT-1,2026-01-07,1.0000,2.0000\n"
 
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "daily.csv",
             csv_bytes,
             format_profile="daily_15min",
@@ -198,7 +190,7 @@ class CsvImportTests(TestCase):
             b"CH-IMPORT-1,2026-01-08T00:00:00Z,1.0000,sideways\n"
         )
 
-        resp = self._upload("invalid-direction.csv", csv_bytes)
+        resp = upload_csv(self.client, "invalid-direction.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 0)
@@ -213,7 +205,7 @@ class CsvImportTests(TestCase):
             b"CH-IMPORT-1,2026-01-09T00:00:00Z,,in\n"
         )
 
-        resp = self._upload("missing-values.csv", csv_bytes)
+        resp = upload_csv(self.client, "missing-values.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 0)
@@ -228,7 +220,7 @@ class CsvImportTests(TestCase):
             b"CH-IMPORT-OTHER,2026-01-10T00:00:00Z,1.0000,in\n"
         )
 
-        resp = self._upload("other-zev.csv", csv_bytes)
+        resp = upload_csv(self.client, "other-zev.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 0)
@@ -254,7 +246,7 @@ class CsvImportTests(TestCase):
             b"CH-BIDI,2026-01-11T00:30:00Z,4.0000\n"
         )
 
-        resp = self._upload("inferred-direction.csv", csv_bytes)
+        resp = upload_csv(self.client, "inferred-direction.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 3)
@@ -272,7 +264,7 @@ class CsvImportTests(TestCase):
             b"CH-IMPORT-1,2026-01-12T00:00:00Z,1.0000,in\n"
         )
 
-        resp = self._upload("infer-zev.csv", csv_bytes)
+        resp = upload_csv(self.client, "infer-zev.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         log = ImportLog.objects.get(id=resp.data["id"])

--- a/backend/metering/test_import_csv_characterization.py
+++ b/backend/metering/test_import_csv_characterization.py
@@ -23,6 +23,7 @@ from rest_framework.test import APIClient
 
 from accounts.models import User, UserRole
 from metering.models import MeterReading
+from metering.testing import preview_csv, upload_csv
 from testing.helpers import authenticate as auth
 from zev.models import MeteringPoint, MeteringPointType, Zev
 
@@ -48,18 +49,6 @@ class CsvImportCharacterizationTests(TestCase):
         )
 
     # ── helpers ──────────────────────────────────────────────────────────────
-
-    def _upload(self, name, content, **fields):
-        upload = SimpleUploadedFile(name, content, content_type="text/csv")
-        return self.client.post(
-            "/api/v1/metering/import/csv/", {"file": upload, **fields}, format="multipart"
-        )
-
-    def _preview(self, name, content, **fields):
-        upload = SimpleUploadedFile(name, content, content_type="text/csv")
-        return self.client.post(
-            "/api/v1/metering/import/preview-csv/", {"file": upload, **fields}, format="multipart"
-        )
 
     @staticmethod
     def _xlsx_bytes(rows, *, extra_sheet_rows=None, active_index=0):
@@ -214,7 +203,7 @@ class CsvImportCharacterizationTests(TestCase):
         """
         csv_bytes = b"CH-IMPORT-1;meta;meta;07.03.2026;1,0;2,0;3,0;4,0\n"
 
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "production.csv",
             csv_bytes,
             has_header="false",
@@ -254,7 +243,7 @@ class CsvImportCharacterizationTests(TestCase):
             b"CH-IMPORT-1,08.03.2026 13:45,1.5000\n"
         )
 
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "fmt.csv", csv_bytes, timestamp_format="%d.%m.%Y %H:%M"
         )
 
@@ -270,7 +259,7 @@ class CsvImportCharacterizationTests(TestCase):
             b"CH-IMPORT-1,2026-03-09T00:00:00Z,1.5000\n"
         )
 
-        resp = self._upload("mismatch.csv", csv_bytes, timestamp_format="%d.%m.%Y")
+        resp = upload_csv(self.client, "mismatch.csv", csv_bytes, timestamp_format="%d.%m.%Y")
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 0)
@@ -280,7 +269,7 @@ class CsvImportCharacterizationTests(TestCase):
     # ── C. Date parsing without an explicit format ───────────────────────────
 
     def _daily_date_upload(self, name, raw_date):
-        return self._upload(
+        return upload_csv(self.client,
             name,
             b"meter_id,date,v1\nCH-IMPORT-1," + raw_date + b",1.0000\n",
             format_profile="daily_15min",
@@ -306,7 +295,7 @@ class CsvImportCharacterizationTests(TestCase):
         )
 
     def test_preview_daily_profile_falls_back_to_raw_string_for_unparsable_date(self):
-        resp = self._preview(
+        resp = preview_csv(self.client,
             "unparsable.csv",
             b"meter_id,date,v1\nCH-IMPORT-1,not-a-date,1.0000\n",
             format_profile="daily_15min",
@@ -320,7 +309,7 @@ class CsvImportCharacterizationTests(TestCase):
     # ── D. Standard timestamps ───────────────────────────────────────────────
 
     def test_naive_timestamp_is_assumed_utc(self):
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "naive.csv",
             b"meter_id,timestamp,energy_kwh\nCH-IMPORT-1,2026-05-01 05:00:00,1.0000\n",
         )
@@ -331,7 +320,7 @@ class CsvImportCharacterizationTests(TestCase):
         )
 
     def test_date_only_timestamp_becomes_midnight_utc(self):
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "dateonly.csv",
             b"meter_id,timestamp,energy_kwh\nCH-IMPORT-1,2026-05-02,1.0000\n",
         )
@@ -342,7 +331,7 @@ class CsvImportCharacterizationTests(TestCase):
         )
 
     def test_unparsable_timestamp_is_skipped_and_reported(self):
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "badts.csv",
             b"meter_id,timestamp,energy_kwh\nCH-IMPORT-1,definitely-not-a-date,1.0000\n",
         )
@@ -365,7 +354,7 @@ class CsvImportCharacterizationTests(TestCase):
             b"CH-UNKNOWN,2026-06-02T00:00:00Z,2.0000\n"
         )
 
-        resp = self._upload("blankline.csv", csv_bytes)
+        resp = upload_csv(self.client, "blankline.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_total"], 2)
@@ -380,7 +369,7 @@ class CsvImportCharacterizationTests(TestCase):
             b"CH-IMPORT-1,2026-06-03T00:00:00Z\n"
         )
 
-        resp = self._upload("short.csv", csv_bytes)
+        resp = upload_csv(self.client, "short.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 0)
@@ -392,7 +381,7 @@ class CsvImportCharacterizationTests(TestCase):
             b"CH-IMPORT-1,2026-06-04T00:00:00Z,1.0000\n"
         )
 
-        resp = self._upload("bom.csv", csv_bytes)
+        resp = upload_csv(self.client, "bom.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 1)
@@ -403,13 +392,13 @@ class CsvImportCharacterizationTests(TestCase):
             b'CH-IMPORT-1,2026-06-05T00:00:00Z,1.0000,"a,b"\n'
         )
 
-        resp = self._upload("quoted.csv", csv_bytes)
+        resp = upload_csv(self.client, "quoted.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 1)
 
     def test_column_index_out_of_range_reports_the_range(self):
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "oor.csv",
             b"meter_id,timestamp,energy_kwh\nCH-IMPORT-1,2026-06-06T00:00:00Z,1.0000\n",
             col_meter_id="99",
@@ -425,7 +414,7 @@ class CsvImportCharacterizationTests(TestCase):
         )
 
     def test_unknown_column_name_is_reported_by_name(self):
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "unknown.csv",
             b"meter_id,timestamp,energy_kwh\nCH-IMPORT-1,2026-06-07T00:00:00Z,1.0000\n",
             col_meter_id="nope",
@@ -440,7 +429,7 @@ class CsvImportCharacterizationTests(TestCase):
     def test_daily_profile_reports_an_error_per_missing_interval_column(self):
         csv_bytes = b"meter_id,date,v1,v2\nCH-IMPORT-1,2026-06-08,1.0000,2.0000\n"
 
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "shortslots.csv",
             csv_bytes,
             format_profile="daily_15min",
@@ -462,7 +451,7 @@ class CsvImportCharacterizationTests(TestCase):
         """An all-numeric column infers int64, whose str() is '1234'."""
         csv_bytes = b"meter_id,timestamp,energy_kwh\n1234,2026-07-01T00:00:00Z,1.0000\n"
 
-        resp = self._upload("numeric.csv", csv_bytes)
+        resp = upload_csv(self.client, "numeric.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 1)
@@ -484,7 +473,7 @@ class CsvImportCharacterizationTests(TestCase):
             b",2026-07-02T00:15:00Z,2.0000\n"
         )
 
-        resp = self._upload("numeric-blank.csv", csv_bytes)
+        resp = upload_csv(self.client, "numeric-blank.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 1)
@@ -499,7 +488,7 @@ class CsvImportCharacterizationTests(TestCase):
         NaN reaches the database."""
         csv_bytes = b"meter_id,timestamp,energy_kwh\nCH-IMPORT-1,2026-07-03T00:00:00Z,nan\n"
 
-        resp = self._upload("nan.csv", csv_bytes)
+        resp = upload_csv(self.client, "nan.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 0)
@@ -508,7 +497,7 @@ class CsvImportCharacterizationTests(TestCase):
     def test_literal_infinite_energy_value_is_rejected(self):
         csv_bytes = b"meter_id,timestamp,energy_kwh\nCH-IMPORT-1,2026-07-04T00:00:00Z,inf\n"
 
-        resp = self._upload("inf.csv", csv_bytes)
+        resp = upload_csv(self.client, "inf.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 0)
@@ -517,7 +506,7 @@ class CsvImportCharacterizationTests(TestCase):
     def test_four_decimal_energy_is_preserved_exactly(self):
         csv_bytes = b"meter_id,timestamp,energy_kwh\nCH-IMPORT-1,2026-07-05T00:00:00Z,1.2345\n"
 
-        resp = self._upload("decimals.csv", csv_bytes)
+        resp = upload_csv(self.client, "decimals.csv", csv_bytes)
 
         self.assertEqual(resp.data["rows_imported"], 1)
         reading = MeterReading.objects.get(metering_point=self.metering_point)
@@ -529,7 +518,7 @@ class CsvImportCharacterizationTests(TestCase):
             b"CH-IMPORT-1;2026-07-06T00:00:00Z;6,2500\n"
         )
 
-        resp = self._upload("commadec.csv", csv_bytes, delimiter=";")
+        resp = upload_csv(self.client, "commadec.csv", csv_bytes, delimiter=";")
 
         self.assertEqual(resp.data["rows_imported"], 1)
         reading = MeterReading.objects.get(metering_point=self.metering_point)
@@ -545,7 +534,7 @@ class CsvImportCharacterizationTests(TestCase):
             b'"   ",2026-07-07T00:00:00Z,1.0000\n'
         )
 
-        resp = self._upload("wsmeter.csv", csv_bytes)
+        resp = upload_csv(self.client, "wsmeter.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertTrue(
@@ -559,7 +548,7 @@ class CsvImportCharacterizationTests(TestCase):
             b",2026-07-08T00:00:00Z,1.0000\n"
         )
 
-        resp = self._upload("blankmeter.csv", csv_bytes)
+        resp = upload_csv(self.client, "blankmeter.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertTrue(
@@ -575,7 +564,7 @@ class CsvImportCharacterizationTests(TestCase):
             b"CH-IMPORT-1,2026-07-09T00:00:00Z,1.0000\n"
         )
 
-        resp = self._upload("nodirection.csv", csv_bytes, col_direction="does_not_exist")
+        resp = upload_csv(self.client, "nodirection.csv", csv_bytes, col_direction="does_not_exist")
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 1)
@@ -590,7 +579,7 @@ class CsvImportCharacterizationTests(TestCase):
         )
         csv_bytes = b"meter_id,timestamp,energy_kwh\n" + rows
 
-        resp = self._preview("many.csv", csv_bytes)
+        resp = preview_csv(self.client, "many.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data["rows_total"], 35)
@@ -608,7 +597,7 @@ class CsvImportCharacterizationTests(TestCase):
             import_source="manual",
         )
 
-        resp = self._preview(
+        resp = preview_csv(self.client,
             "existing.csv",
             b"meter_id,date,v1\nCH-IMPORT-1,2026-08-03,1.0000\n",
             format_profile="daily_15min",
@@ -621,7 +610,7 @@ class CsvImportCharacterizationTests(TestCase):
         self.assertEqual(resp.data["preview_rows"][0]["timestamp"], "2026-08-03")
 
     def test_preview_column_error_returns_total_with_no_preview_rows(self):
-        resp = self._preview(
+        resp = preview_csv(self.client,
             "colerr.csv",
             b"meter_id,timestamp,energy_kwh\nCH-IMPORT-1,2026-08-04T00:00:00Z,1.0000\n",
             col_timestamp="missing_column",
@@ -652,7 +641,7 @@ class CsvImportCharacterizationTests(TestCase):
         self.assertEqual(MeterReading.objects.count(), 0)
 
     def test_multi_character_delimiter_is_rejected_with_a_helpful_message(self):
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "multidelim.csv",
             b"meter_id;;timestamp;;energy_kwh\nCH-IMPORT-1;;2026-09-01T00:00:00Z;;1.0000\n",
             delimiter=";;",
@@ -662,7 +651,7 @@ class CsvImportCharacterizationTests(TestCase):
         self.assertIn("single character", resp.data["error"])
 
     def test_tab_delimiter_can_be_requested_as_a_backslash_escape(self):
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "tabs.csv",
             b"meter_id\ttimestamp\tenergy_kwh\nCH-IMPORT-1\t2026-09-02T00:00:00Z\t1.0000\n",
             delimiter="\\t",
@@ -672,7 +661,7 @@ class CsvImportCharacterizationTests(TestCase):
         self.assertEqual(resp.data["rows_imported"], 1)
 
     def test_non_utf8_file_is_rejected_with_a_helpful_message(self):
-        resp = self._upload(
+        resp = upload_csv(self.client,
             "latin1.csv",
             "meter_id,timestamp,energy_kwh,note\nCH-IMPORT-1,2026-09-03T00:00:00Z,1.0,Zürich\n".encode(
                 "latin-1"
@@ -703,7 +692,7 @@ class CsvImportCharacterizationTests(TestCase):
             b"CH-IMPORT-1,2026-09-04T00:00:00Z,1.5000,EXTRA\n"
         )
 
-        resp = self._upload("extrafield.csv", csv_bytes)
+        resp = upload_csv(self.client, "extrafield.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 1)
@@ -719,7 +708,7 @@ class CsvImportCharacterizationTests(TestCase):
             b"CH-IMPORT-1,2026-09-07T00:00:00Z\n"
         )
 
-        resp = self._upload("ragged.csv", csv_bytes)
+        resp = upload_csv(self.client, "ragged.csv", csv_bytes)
 
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 2)

--- a/backend/metering/testing.py
+++ b/backend/metering/testing.py
@@ -1,0 +1,24 @@
+"""Shared request helpers for the metering import tests.
+
+The CSV upload and preview endpoints were duplicated verbatim across
+``test_import_csv`` and ``test_import_csv_characterization`` before being
+consolidated here.
+"""
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+
+def upload_csv(client, name, content, **fields):
+    """POST a CSV file to the import endpoint, returning the response."""
+    upload = SimpleUploadedFile(name, content, content_type="text/csv")
+    return client.post(
+        "/api/v1/metering/import/csv/", {"file": upload, **fields}, format="multipart"
+    )
+
+
+def preview_csv(client, name, content, **fields):
+    """POST a CSV file to the preview endpoint, returning the response."""
+    upload = SimpleUploadedFile(name, content, content_type="text/csv")
+    return client.post(
+        "/api/v1/metering/import/preview-csv/", {"file": upload, **fields}, format="multipart"
+    )

--- a/backend/tariffs/serializers.py
+++ b/backend/tariffs/serializers.py
@@ -2,8 +2,6 @@ from rest_framework import serializers
 from django.core.exceptions import ValidationError as DjangoValidationError
 from .models import BillingMode, Tariff, TariffPeriod
 
-ENERGY_BILLING_MODES = {BillingMode.ENERGY, BillingMode.PERCENTAGE_OF_ENERGY}
-
 
 class TariffPeriodSerializer(serializers.ModelSerializer):
     def validate(self, attrs):

--- a/backend/templates/invoices/invoice_pdf.html
+++ b/backend/templates/invoices/invoice_pdf.html
@@ -5,12 +5,7 @@
     <meta charset="UTF-8">
     <title>Invoice {{ invoice.invoice_number }}</title>
     <style>
-        * {
-            box-sizing: border-box;
-            margin: 0;
-            padding: 0;
-        }
-
+        /* ══ 1. Tokens & base ════════════════════════════════════ */
         :root {
             --ink: #0f172a;
             --ink-soft: #334155;
@@ -32,6 +27,12 @@
             --subtotal-color: #24352c;
         }
 
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
         body {
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
             font-size: 9.5pt;
@@ -43,7 +44,29 @@
             padding: 12mm 16mm;
         }
 
-        /* ── Header ─────────────────────────────────────────────── */
+        /* ══ 2. Utilities ════════════════════════════════════════ */
+        .eyebrow {
+            color: var(--muted);
+            font-size: 6.8pt;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        /* Visually hidden but screen-reader accessible. */
+        .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
+        /* ══ 3. Document header ══════════════════════════════════ */
         .document-header {
             display: flex;
             justify-content: space-between;
@@ -133,7 +156,7 @@
             border: 0.5pt solid var(--brand-glow);
         }
 
-        /* ── Summary band ───────────────────────────────────────── */
+        /* ══ 4. Summary band ═════════════════════════════════════ */
         .invoice-summary {
             display: flex;
             gap: 10mm;
@@ -147,7 +170,6 @@
             min-width: 0;
         }
 
-        .eyebrow,
         .fact dt {
             color: var(--muted);
             font-size: 6.8pt;
@@ -325,7 +347,7 @@
             color: rgba(255,255,255,0.45);
         }
 
-        /* ── Line items ─────────────────────────────────────────── */
+        /* ══ 5. Line items ═══════════════════════════════════════ */
         .line-items {
             border-collapse: separate;
             border-spacing: 0;
@@ -419,12 +441,7 @@
         /* Each category is its own <tbody> rowgroup: this resets zebra parity
            per group and lets the side-label panel close cleanly at the group's
            bottom edge. */
-        .line-items .item-group:first-child {
-            border-top: 0;
-        }
-
         .line-items .item-group {
-            border-top: 1pt solid var(--line);
             break-inside: avoid;
         }
 
@@ -446,20 +463,7 @@
             border-bottom: none;
         }
 
-        /* Visually hidden but screen-reader accessible. */
-        .visually-hidden {
-            position: absolute;
-            width: 1px;
-            height: 1px;
-            padding: 0;
-            margin: -1px;
-            overflow: hidden;
-            clip: rect(0, 0, 0, 0);
-            white-space: nowrap;
-            border: 0;
-        }
-
-        /* ── Closing / totals ───────────────────────────────────── */
+        /* ══ 6. Closing & totals ═════════════════════════════════ */
         .invoice-closing {
             display: flex;
             gap: 8mm;
@@ -536,7 +540,7 @@
             color: var(--muted);
         }
 
-        /* ── Inline QR page ─────────────────────────────────────── */
+        /* ══ 7. Inline QR page variant ═══════════════════════════ */
         /* Reserve the full Swiss payment-part height at the bottom so the
            QR-Rechnung sits on the same page as short invoices.
            Uses @page margin-bottom + position: running() so content
@@ -546,12 +550,45 @@
             page: invoice-payment;
         }
 
-        .invoice-with-inline-qr .invoice-body {
+        /* ══ 8. Dedicated payment page ═══════════════════════════ */
+        .payment-page {
+            break-before: page;
+            page: payment;
             position: relative;
-            z-index: 1;
+            height: 285mm; /* 297 -12 */
         }
 
-        /* ── Insights page ──────────────────────────────────────── */
+        .payment-notice {
+            color: var(--muted);
+            font-size: 8.5pt;
+            left: 16mm;
+            position: absolute;
+            top: 14mm;
+            max-width: 170mm;
+            line-height: 1.4;
+        }
+
+        .payment-notice strong {
+            color: var(--brand-deep);
+        }
+
+        .qr-section {
+            width: 210mm;
+        }
+
+        .payment-page .qr-section {
+            position: absolute;
+            left: 0;
+            bottom: 0;
+        }
+
+        .qr-section svg {
+            display: block;
+            height: 106mm;
+            width: 210mm;
+        }
+
+        /* ══ 9. Insights page ════════════════════════════════════ */
         .insights-page {
             break-before: page;
             page: insights;
@@ -693,7 +730,7 @@
             width: 100%;
         }
 
-        /* ── Consistent 3-col meta ── */
+        /* ══ 10. Page furniture: running header/footer meta ══════ */
         .page-meta {
             width: 210mm;
             margin: 0;
@@ -738,44 +775,14 @@
         .page-meta .meta-right { text-align: right; flex: 1; }
         .page-meta .meta-center::after { content: counter(page) " / " counter(pages); }
 
-        /* ── Dedicated payment page ─────────────────────────────── */
-        .payment-page {
-            break-before: page;
-            page: payment;
-            position: relative;
-            height: 285mm; /* 297 -12 */
-        }
-
-        .payment-notice {
-            color: var(--muted);
-            font-size: 8.5pt;
-            left: 16mm;
-            position: absolute;
-            top: 14mm;
-            max-width: 170mm;
-            line-height: 1.4;
-        }
-
-        .payment-notice strong {
-            color: var(--brand-deep);
-        }
-
-        .qr-section {
-            width: 210mm;
-        }
-
-        .payment-page .qr-section {
-            position: absolute;
-            left: 0;
-            bottom: 0;
-        }
-
-        .qr-section svg {
-            display: block;
-            height: 106mm;
-            width: 210mm;
-        }
-
+        /* ══ 11. @page rules ═════════════════════════════════════ */
+        /* How this prints: the running header/footer and the QR slip are
+           normal <div>s in the body, repositioned into page margin boxes
+           via `position: running()` + `element()` in named pages
+           (default, payment, insights, invoice-payment). Each named page
+           also defines its own margins — the inline-QR variant reserves
+           the bottom 106mm for the slip, and `:first` suppresses the top
+           margin on page 1. */
         @page {
             size: A4;
             margin: 0 0 12mm 0;
@@ -900,7 +907,7 @@
                     </div>
                 </dl>
                 {% if savings_data %}
-                <aside class="amount-card amount-card--savings" aria-label="{{ tr.savings_title }}">
+                <aside class="amount-card" aria-label="{{ tr.savings_title }}">
                     <div class="amount-card-shine" aria-hidden="true"></div>
                     <div class="eyebrow">
                         {{ tr.savings_from }}

--- a/backend/testing/helpers.py
+++ b/backend/testing/helpers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from rest_framework_simplejwt.tokens import RefreshToken
 
 from accounts.models import User
+from zev.models import Participant
 
 
 def make_user(username: str, role: str, password: str = "pass1234") -> User:
@@ -27,6 +28,23 @@ def make_user(username: str, role: str, password: str = "pass1234") -> User:
     )
 
 
+def make_named_participant(zev, name, valid_from, valid_to=None) -> Participant:
+    """Create a participant, splitting ``name`` like ``"Alice Muster"``.
+
+    The email is derived from the full name, matching the fixture builder that
+    was previously duplicated across the allocation and invoice test modules.
+    """
+    first, last = name.split(" ", 1)
+    return Participant.objects.create(
+        zev=zev,
+        first_name=first,
+        last_name=last,
+        email=f"{name.replace(' ', '').lower()}@example.com",
+        valid_from=valid_from,
+        valid_to=valid_to,
+    )
+
+
 def authenticate(client, user) -> None:
     """Authenticate ``client`` as ``user`` via a Bearer token.
 
@@ -35,8 +53,3 @@ def authenticate(client, user) -> None:
     """
     refresh = RefreshToken.for_user(user)
     client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
-
-
-def access_token_for(user) -> str:
-    """Return a raw access token string for ``user`` (useful for cookie tests)."""
-    return str(RefreshToken.for_user(user).access_token)

--- a/backend/zev/permissions.py
+++ b/backend/zev/permissions.py
@@ -47,10 +47,6 @@ class ZevManagementPermission(BaseZevScopedPermission):
         return True
 
 
-class ParticipantManagementPermission(BaseZevScopedPermission):
-    pass
-
-
 class MeteringPointPermission(BaseZevScopedPermission):
     allow_participant_safe_methods = True
 

--- a/backend/zev/views.py
+++ b/backend/zev/views.py
@@ -26,9 +26,9 @@ from .serializers import (
     MeteringPointAssignmentSerializer,
 )
 from .permissions import (
+    BaseZevScopedPermission,
     MeteringPointAssignmentPermission,
     MeteringPointPermission,
-    ParticipantManagementPermission,
     ZevManagementPermission,
 )
 from .services import send_participant_invitation, create_zev_for_existing_owner
@@ -303,7 +303,7 @@ class ZevViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
 
 class ParticipantViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     serializer_class = ParticipantSerializer
-    permission_classes = [IsAuthenticated, ParticipantManagementPermission]
+    permission_classes = [IsAuthenticated, BaseZevScopedPermission]
     zev_owner_filter = "zev__owner"
     participant_filter = "user"
     scope_parent_path = ("zev",)


### PR DESCRIPTION
## Summary
Remove unused backend symbols and redundant permission aliases, and consolidate repeated test helpers without changing API behavior, model state, or authorization rules.

Key changes:
- Remove unused permission classes, constants, logger declarations, and test constants.
- Replace the empty `ParticipantManagementPermission` alias with its behaviorally identical `BaseZevScopedPermission` base class.
- Make the auth-cookie kwargs helper private; log stale impersonator claims instead of silently swallowing them.
- Consolidate participant/user fixture builders and authenticated request helpers; consolidate multipart CSV upload/preview helpers used by metering import tests.
- Simplify report, allocation, PDF, and metering test setup.
- Remove redundant invoice PDF CSS selectors without changing template data or rendering contracts.

## Linked spec
- Spec: `docs/specs/2026-03-community-and-access.md` (permission-class name) and `docs/specs/2026-03-invoice-lifecycle-and-communication.md` (PDF CSS).
- ADR: none.
- Runtime permission behavior is unchanged; the linked baseline specs are updated for the permission-class name.

## Validation
- Backend tests run: `python -m pytest` — 998 passed, 185 subtests passed.
- Frontend build/test: N/A (no frontend files changed).
- Manual checks: confirmed `ParticipantManagementPermission` is behaviorally identical to `BaseZevScopedPermission`; verified all removed symbols had no remaining consumers; reviewed representative invoice and PDF rendering — no visual change observed.
- Screenshots: N/A for backend cleanup.

## Checklist
- [x] Spec updated/linked
- N/A: no architecture decision changed
- N/A: backend-only, no API contract change
