### PR TITLE
fix(zev): scope writes to the caller's own ZEV, not just reads

### DIFF
--- a/backend/audit/mixins.py
+++ b/backend/audit/mixins.py
@@ -44,7 +44,12 @@ class AuditedUpdateMixin:
     def perform_update(self, serializer):
         tracked_fields = self.get_audit_tracked_fields(serializer)
         before = build_instance_snapshot(self.get_object(), tracked_fields)
-        instance = serializer.save()
+        # Through ``super()`` rather than ``serializer.save()``: this mixin sits
+        # in front of ``ZevScopedQuerySetMixin``, whose ``perform_update``
+        # enforces that the write stays inside the caller's own ZEV. Saving
+        # directly would step over that check.
+        super().perform_update(serializer)
+        instance = serializer.instance
         after = build_instance_snapshot(instance, tracked_fields)
 
         record_audit_event(

--- a/backend/metering/views.py
+++ b/backend/metering/views.py
@@ -32,6 +32,7 @@ class MeterReadingViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
     zev_owner_filter = "metering_point__zev__owner"
     participant_filter = "metering_point__assignments__participant__user"
     participant_distinct = True
+    scope_parent_path = ("metering_point", "zev")
 
     def get_queryset(self):
         return self.scope_queryset(MeterReading.objects.select_related("metering_point__zev"))

--- a/backend/tariffs/views.py
+++ b/backend/tariffs/views.py
@@ -75,6 +75,7 @@ class TariffViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelVi
     permission_classes = [IsAuthenticated, IsZevOwnerOrAdmin]
     zev_owner_filter = "zev__owner"
     participant_filter = None
+    scope_parent_path = ("zev",)
 
     audit_action_category = AuditActionCategory.TARIFF
     audit_action_type = "tariff.update"
@@ -88,7 +89,7 @@ class TariffViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelVi
         return self.scope_queryset(Tariff.objects.all())
 
     def perform_create(self, serializer):
-        tariff = serializer.save()
+        tariff = super().perform_create(serializer)
         _record_tariff_event(
             request=self.request,
             action_type="tariff.create",
@@ -347,6 +348,7 @@ class TariffPeriodViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.M
     permission_classes = [IsAuthenticated, IsZevOwnerOrAdmin]
     zev_owner_filter = "tariff__zev__owner"
     participant_filter = None
+    scope_parent_path = ("tariff", "zev")
 
     audit_action_category = AuditActionCategory.TARIFF
     audit_action_type = "tariff_period.update"
@@ -362,7 +364,7 @@ class TariffPeriodViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.M
         return self.scope_queryset(TariffPeriod.objects.all())
 
     def perform_create(self, serializer):
-        period = serializer.save()
+        period = super().perform_create(serializer)
         _record_tariff_event(
             request=self.request,
             action_type="tariff_period.create",

--- a/backend/zev/scoping.py
+++ b/backend/zev/scoping.py
@@ -1,5 +1,5 @@
 """
-Shared role-based queryset scoping for ZEV-related viewsets.
+Shared role-based scoping for ZEV-related viewsets.
 
 Every ZEV-scoped viewset applies the same three-tier visibility rule:
 
@@ -10,11 +10,20 @@ Every ZEV-scoped viewset applies the same three-tier visibility rule:
 
 Centralizing the rule makes the tenant-isolation logic auditable in one
 place instead of being re-implemented per viewset.
+
+Reads and writes are scoped here together on purpose. Scoping only the
+queryset protects what a caller can *see* while leaving what they can *write*
+open: DRF consults ``has_object_permission`` for detail routes but never on
+create, so a payload naming another community's ZEV was accepted (#424). The
+write rule is the mirror of the read rule — you may only create or move an
+object into a ZEV you would be allowed to see.
 """
+
+from rest_framework import serializers
 
 
 class ZevScopedQuerySetMixin:
-    """Mixin for DRF viewsets that scopes querysets by user role.
+    """Mixin for DRF viewsets that scopes reads and writes by user role.
 
     Class attributes:
 
@@ -25,11 +34,18 @@ class ZevScopedQuerySetMixin:
       participants get an empty queryset (owner-only resource).
     - ``participant_distinct``: set to ``True`` when the participant filter
       traverses a to-many relation and may produce duplicate rows.
+    - ``scope_parent_path``: attribute chain from a write payload to the ZEV
+      the object would belong to. The first element is the key in
+      ``validated_data``; any further elements walk from that object to its
+      ``Zev``. ``("zev",)`` means the payload carries the ZEV itself;
+      ``("metering_point", "zev")`` means it carries a metering point whose
+      ``.zev`` is the one that matters. ``None`` disables the write check.
     """
 
     zev_owner_filter: str
     participant_filter: str | None = None
     participant_distinct: bool = False
+    scope_parent_path: tuple[str, ...] | None = None
 
     def scope_queryset(self, qs):
         user = self.request.user
@@ -43,3 +59,50 @@ class ZevScopedQuerySetMixin:
         if self.participant_distinct:
             qs = qs.distinct()
         return qs
+
+    # ── Write scoping ─────────────────────────────────────────────────────
+
+    def resolve_scope_zev(self, validated_data):
+        """The ZEV a written object would belong to, or ``None`` if not determinable.
+
+        ``None`` means the payload does not name the parent — a PATCH that
+        leaves the relation alone, say — so there is no move to check.
+        """
+        if not self.scope_parent_path:
+            return None
+        key, *rest = self.scope_parent_path
+        target = validated_data.get(key)
+        for attribute in rest:
+            if target is None:
+                return None
+            target = getattr(target, attribute, None)
+        return target
+
+    def assert_within_scope(self, validated_data):
+        """Refuse a write that would land the object in someone else's ZEV.
+
+        Raised as a field validation error rather than a permission denial so
+        it reads like the rest of DRF's related-field errors, and so the
+        response says which field was wrong without describing the ZEV behind
+        it.
+        """
+        target_zev = self.resolve_scope_zev(validated_data)
+        if target_zev is None:
+            return
+        user = self.request.user
+        if user.is_admin or target_zev.owner_id == user.pk:
+            return
+        field = self.scope_parent_path[0]
+        raise serializers.ValidationError(
+            {field: ["You do not have access to the ZEV this would belong to."]}
+        )
+
+    def perform_create(self, serializer):
+        self.assert_within_scope(serializer.validated_data)
+        super().perform_create(serializer)
+        return serializer.instance
+
+    def perform_update(self, serializer):
+        self.assert_within_scope(serializer.validated_data)
+        super().perform_update(serializer)
+        return serializer.instance

--- a/backend/zev/test_write_scoping.py
+++ b/backend/zev/test_write_scoping.py
@@ -1,0 +1,263 @@
+"""Tenant isolation on writes: a ZEV owner may only write into their own ZEV.
+
+Scoping the queryset protects what a caller can *see*. It does not protect what
+they can *write*: DRF consults ``has_object_permission`` on detail routes but
+never on create, so before #424 a payload naming another community's ZEV was
+accepted on every ZEV-scoped endpoint — and an owner could also move one of
+their own objects into someone else's community with a PATCH.
+
+The failure mode is "returns 201 when it should not", which an assertion on a
+successful create can never catch, so each case asserts the rejection *and*
+that nothing landed in the victim's ZEV.
+"""
+
+from datetime import date
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from accounts.models import UserRole
+from metering.models import MeterReading
+from tariffs.models import BillingMode, EnergyType, Tariff, TariffCategory, TariffPeriod
+from testing.helpers import authenticate as auth, make_user
+from zev.models import (
+    MeteringPoint,
+    MeteringPointAssignment,
+    MeteringPointType,
+    Participant,
+    Zev,
+)
+
+PARTICIPANTS = "/api/v1/zev/participants/"
+METERING_POINTS = "/api/v1/zev/metering-points/"
+ASSIGNMENTS = "/api/v1/zev/metering-point-assignments/"
+TARIFFS = "/api/v1/tariffs/tariffs/"
+TARIFF_PERIODS = "/api/v1/tariffs/periods/"
+READINGS = "/api/v1/metering/readings/"
+
+
+class _TwoCommunities(TestCase):
+    """One victim community and one attacker community, each with an owner."""
+
+    def setUp(self):
+        self.victim = make_user("ws_victim", UserRole.ZEV_OWNER)
+        self.attacker = make_user("ws_attacker", UserRole.ZEV_OWNER)
+        self.admin = make_user("ws_admin", UserRole.ADMIN)
+
+        self.victim_zev = Zev.objects.create(name="Victim ZEV", owner=self.victim)
+        self.attacker_zev = Zev.objects.create(name="Attacker ZEV", owner=self.attacker)
+
+        self.victim_participant = Participant.objects.create(
+            zev=self.victim_zev, first_name="Vera", last_name="Victim",
+            email="vera@example.com", valid_from=date(2026, 1, 1),
+        )
+        self.victim_meter = MeteringPoint.objects.create(
+            zev=self.victim_zev, meter_id="VICTIM-METER",
+            meter_type=MeteringPointType.CONSUMPTION,
+        )
+        self.victim_tariff = self._tariff(self.victim_zev, "Victim Tariff")
+
+        self.attacker_participant = Participant.objects.create(
+            zev=self.attacker_zev, first_name="Alan", last_name="Attacker",
+            email="alan@example.com", valid_from=date(2026, 1, 1),
+        )
+        self.attacker_meter = MeteringPoint.objects.create(
+            zev=self.attacker_zev, meter_id="ATTACKER-METER",
+            meter_type=MeteringPointType.CONSUMPTION,
+        )
+        self.attacker_tariff = self._tariff(self.attacker_zev, "Attacker Tariff")
+
+        self.client = APIClient()
+        auth(self.client, self.attacker)
+
+    def _tariff(self, zev, name):
+        return Tariff.objects.create(
+            zev=zev, name=name, category=TariffCategory.ENERGY,
+            billing_mode=BillingMode.ENERGY, energy_type=EnergyType.LOCAL,
+            valid_from=date(2026, 1, 1),
+        )
+
+    def assertRefused(self, response, field):
+        """A 400 naming the offending relation, not a silent success."""
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn(field, response.json())
+
+
+class CreateIntoAnotherCommunityTests(_TwoCommunities):
+    def test_participant(self):
+        response = self.client.post(PARTICIPANTS, {
+            "zev": str(self.victim_zev.id), "first_name": "Injected",
+            "last_name": "Person", "email": "injected@example.com",
+            "valid_from": "2026-01-01",
+        }, format="json")
+        self.assertRefused(response, "zev")
+        self.assertEqual(self.victim_zev.participants.count(), 1)
+
+    def test_participant_creates_no_account(self):
+        """``ParticipantSerializer.create`` provisions a login, so a refused
+        create must not leave a usable account behind."""
+        from accounts.models import User
+
+        before = User.objects.count()
+        self.client.post(PARTICIPANTS, {
+            "zev": str(self.victim_zev.id), "first_name": "Injected",
+            "last_name": "Person", "email": "injected@example.com",
+            "valid_from": "2026-01-01",
+        }, format="json")
+        self.assertEqual(User.objects.count(), before)
+
+    def test_metering_point(self):
+        response = self.client.post(METERING_POINTS, {
+            "zev": str(self.victim_zev.id), "meter_id": "INJECTED-METER",
+            "meter_type": "consumption",
+        }, format="json")
+        self.assertRefused(response, "zev")
+        self.assertFalse(MeteringPoint.objects.filter(meter_id="INJECTED-METER").exists())
+
+    def test_metering_point_assignment(self):
+        response = self.client.post(ASSIGNMENTS, {
+            "metering_point": str(self.victim_meter.id),
+            "participant": str(self.victim_participant.id),
+            "valid_from": "2026-01-01",
+        }, format="json")
+        self.assertRefused(response, "metering_point")
+        self.assertFalse(
+            MeteringPointAssignment.objects.filter(metering_point=self.victim_meter).exists()
+        )
+
+    def test_tariff(self):
+        response = self.client.post(TARIFFS, {
+            "zev": str(self.victim_zev.id), "name": "Injected Tariff",
+            "category": "energy", "billing_mode": "energy", "energy_type": "local",
+            "valid_from": "2026-01-01",
+        }, format="json")
+        self.assertRefused(response, "zev")
+        self.assertEqual(self.victim_zev.tariffs.count(), 1)
+
+    def test_tariff_period(self):
+        response = self.client.post(TARIFF_PERIODS, {
+            "tariff": str(self.victim_tariff.id), "period_type": "flat",
+            "price_chf_per_kwh": "0.20",
+        }, format="json")
+        self.assertRefused(response, "tariff")
+        self.assertFalse(TariffPeriod.objects.filter(tariff=self.victim_tariff).exists())
+
+    def test_meter_reading(self):
+        response = self.client.post(READINGS, {
+            "metering_point": str(self.victim_meter.id),
+            "timestamp": "2026-01-01T00:00:00Z", "energy_kwh": "1.0", "direction": "in",
+        }, format="json")
+        self.assertRefused(response, "metering_point")
+        self.assertFalse(MeterReading.objects.filter(metering_point=self.victim_meter).exists())
+
+
+class MoveIntoAnotherCommunityTests(_TwoCommunities):
+    """The other direction: donating one of your own objects to a stranger.
+
+    ``get_object()`` already stops an owner editing somebody else's row, but
+    nothing stopped them rewriting their *own* row's ZEV to point elsewhere.
+    """
+
+    def test_participant(self):
+        response = self.client.patch(
+            f"{PARTICIPANTS}{self.attacker_participant.id}/",
+            {"zev": str(self.victim_zev.id)}, format="json",
+        )
+        self.assertRefused(response, "zev")
+        self.attacker_participant.refresh_from_db()
+        self.assertEqual(self.attacker_participant.zev, self.attacker_zev)
+
+    def test_metering_point(self):
+        response = self.client.patch(
+            f"{METERING_POINTS}{self.attacker_meter.id}/",
+            {"zev": str(self.victim_zev.id)}, format="json",
+        )
+        self.assertRefused(response, "zev")
+        self.attacker_meter.refresh_from_db()
+        self.assertEqual(self.attacker_meter.zev, self.attacker_zev)
+
+    def test_tariff(self):
+        response = self.client.patch(
+            f"{TARIFFS}{self.attacker_tariff.id}/",
+            {"zev": str(self.victim_zev.id)}, format="json",
+        )
+        self.assertRefused(response, "zev")
+        self.attacker_tariff.refresh_from_db()
+        self.assertEqual(self.attacker_tariff.zev, self.attacker_zev)
+
+
+class LegitimateWritesStillWorkTests(_TwoCommunities):
+    """The guard must not cost an owner the use of their own community."""
+
+    def test_owner_can_create_in_their_own_zev(self):
+        response = self.client.post(PARTICIPANTS, {
+            "zev": str(self.attacker_zev.id), "first_name": "Legit",
+            "last_name": "Member", "email": "legit@example.com",
+            "valid_from": "2026-01-01",
+        }, format="json")
+        self.assertEqual(response.status_code, 201, response.content)
+
+    def test_owner_can_patch_their_own_object_without_naming_the_zev(self):
+        response = self.client.patch(
+            f"{PARTICIPANTS}{self.attacker_participant.id}/",
+            {"city": "Zurich"}, format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.attacker_participant.refresh_from_db()
+        self.assertEqual(self.attacker_participant.city, "Zurich")
+
+    def test_owner_can_restate_their_own_zev_on_patch(self):
+        """A full PUT-style payload repeats ``zev``; that is not a move."""
+        response = self.client.patch(
+            f"{PARTICIPANTS}{self.attacker_participant.id}/",
+            {"zev": str(self.attacker_zev.id), "city": "Bern"}, format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_owner_can_assign_their_own_meter_to_their_own_participant(self):
+        response = self.client.post(ASSIGNMENTS, {
+            "metering_point": str(self.attacker_meter.id),
+            "participant": str(self.attacker_participant.id),
+            "valid_from": "2026-01-01",
+        }, format="json")
+        self.assertEqual(response.status_code, 201, response.content)
+
+    def test_admin_may_write_into_any_community(self):
+        admin_client = APIClient()
+        auth(admin_client, self.admin)
+        response = admin_client.post(PARTICIPANTS, {
+            "zev": str(self.victim_zev.id), "first_name": "Admin",
+            "last_name": "Added", "email": "adminadded@example.com",
+            "valid_from": "2026-01-01",
+        }, format="json")
+        self.assertEqual(response.status_code, 201, response.content)
+        self.assertEqual(self.victim_zev.participants.count(), 2)
+
+
+class AuditTrailStillRecordedTests(_TwoCommunities):
+    """``AuditedUpdateMixin`` now saves through ``super()``; the diff it records
+    must survive that change."""
+
+    def test_update_still_records_a_diff(self):
+        from audit.models import AuditEvent
+
+        self.client.patch(
+            f"{PARTICIPANTS}{self.attacker_participant.id}/",
+            {"city": "Winterthur"}, format="json",
+        )
+        event = AuditEvent.objects.filter(action_type="participant.update").latest("created_at")
+        self.assertEqual(event.changes_json["city"]["after"], "Winterthur")
+
+    def test_create_still_records_an_event(self):
+        from audit.models import AuditEvent
+
+        self.client.post(PARTICIPANTS, {
+            "zev": str(self.attacker_zev.id), "first_name": "Audited",
+            "last_name": "Member", "email": "audited@example.com",
+            "valid_from": "2026-01-01",
+        }, format="json")
+        self.assertTrue(
+            AuditEvent.objects.filter(
+                action_type="participant.create", target_display__icontains="Audited"
+            ).exists()
+        )

--- a/backend/zev/views.py
+++ b/backend/zev/views.py
@@ -306,6 +306,7 @@ class ParticipantViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.Mo
     permission_classes = [IsAuthenticated, ParticipantManagementPermission]
     zev_owner_filter = "zev__owner"
     participant_filter = "user"
+    scope_parent_path = ("zev",)
 
     audit_action_category = AuditActionCategory.PARTICIPANT
     audit_action_type = "participant.update"
@@ -319,7 +320,7 @@ class ParticipantViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.Mo
         return self.scope_queryset(Participant.objects.prefetch_related("metering_point_assignments"))
 
     def perform_create(self, serializer):
-        participant = serializer.save()
+        participant = super().perform_create(serializer)
         record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.PARTICIPANT,
@@ -584,6 +585,7 @@ class MeteringPointViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.
     zev_owner_filter = "zev__owner"
     participant_filter = "assignments__participant__user"
     participant_distinct = True
+    scope_parent_path = ("zev",)
 
     audit_action_category = AuditActionCategory.METERING
     audit_action_type = "metering_point.update"
@@ -597,7 +599,7 @@ class MeteringPointViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.
         return self.scope_queryset(MeteringPoint.objects.select_related("zev"))
 
     def perform_create(self, serializer):
-        metering_point = serializer.save()
+        metering_point = super().perform_create(serializer)
         record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.METERING,
@@ -688,6 +690,7 @@ class MeteringPointAssignmentViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin,
     permission_classes = [IsAuthenticated, MeteringPointAssignmentPermission]
     zev_owner_filter = "metering_point__zev__owner"
     participant_filter = "participant__user"
+    scope_parent_path = ("metering_point", "zev")
 
     audit_action_category = AuditActionCategory.METERING
     audit_action_type = "metering_assignment.update"
@@ -716,7 +719,7 @@ class MeteringPointAssignmentViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin,
         return qs
 
     def perform_create(self, serializer):
-        assignment = serializer.save()
+        assignment = super().perform_create(serializer)
         record_audit_event(
             request=self.request,
             action_category=AuditActionCategory.METERING,

--- a/docs/specs/2026-03-community-and-access.md
+++ b/docs/specs/2026-03-community-and-access.md
@@ -189,6 +189,50 @@ Defined in `accounts/permissions.py` and `zev/permissions.py`.
    `zev.participants.filter(user=user).exists()`.
 5. Else → deny.
 
+### 4.4 Write scoping (`ZevScopedQuerySetMixin`)
+
+`has_object_permission` runs on detail routes only — DRF has no object to
+check on create, so it is never consulted there. A permission class alone
+therefore governs *which existing rows* a caller may touch, not *which ZEV a
+new row may be filed under*. Until #424 a `zev_owner` could post a payload
+naming another community's ZEV and have it accepted on every ZEV-scoped
+endpoint, and could move one of their own rows into a foreign ZEV with a
+`PATCH`.
+
+`ZevScopedQuerySetMixin` closes both directions, alongside the read scoping it
+already owned. Each viewset declares `scope_parent_path`: the attribute chain
+from a write payload to the ZEV the row would belong to.
+
+| Viewset | `scope_parent_path` |
+|---|---|
+| `ParticipantViewSet` | `("zev",)` |
+| `MeteringPointViewSet` | `("zev",)` |
+| `MeteringPointAssignmentViewSet` | `("metering_point", "zev")` |
+| `TariffViewSet` | `("zev",)` |
+| `TariffPeriodViewSet` | `("tariff", "zev")` |
+| `MeterReadingViewSet` | `("metering_point", "zev")` |
+
+**`assert_within_scope(validated_data)`**, run from `perform_create` and
+`perform_update` before the save:
+1. Resolve the target ZEV via `scope_parent_path`. Not present in the payload
+   (a `PATCH` that leaves the relation alone) → nothing to check, allow.
+2. `admin` → allow.
+3. `zev.owner == user` → allow.
+4. Else → `ValidationError` on the relation field (HTTP 400).
+
+Rejection is a field validation error rather than a permission denial so it
+reads like DRF's other related-field errors and names the offending field
+without describing the ZEV behind it.
+
+Two consequences for anything added later:
+
+- A new ZEV-scoped viewset must declare `scope_parent_path`, or its create
+  route is unscoped. `None` disables the check.
+- `perform_create` / `perform_update` overrides must go through
+  `super()` rather than calling `serializer.save()` directly, or they step
+  over the check. `AuditedUpdateMixin` sits in front of the scoping mixin and
+  cooperates for this reason.
+
 ---
 
 ## 5. Authentication and account lifecycle


### PR DESCRIPTION
Closes #424.

## The gap

`ZevScopedQuerySetMixin` scoped the queryset — what a caller can **see**. Nothing scoped what they can **write**. DRF consults `has_object_permission` on detail routes but never on create, and no serializer validated the ZEV named in the payload.

The issue described this for participants. It was every ZEV-scoped write endpoint, in both directions:

| | before | after |
|---|---|---|
| create participant in a foreign ZEV | **201**, lands in victim's community | 400 |
| create metering point in a foreign ZEV | **201**, lands | 400 |
| create assignment on a foreign meter | **201**, lands | 400 |
| create tariff in a foreign ZEV | **201**, lands | 400 |
| create tariff period on a foreign tariff | **201**, lands | 400 |
| create reading on a foreign meter | **201**, lands | 400 |
| PATCH my participant → foreign ZEV | **200**, object moves out | 400 |
| PATCH my metering point → foreign ZEV | **200**, moves | 400 |
| PATCH my tariff → foreign ZEV | **200**, moves | 400 |

The participant case was the sharpest: `ParticipantSerializer.create` provisions a login and the serializer returns `initial_password`, so the attacker ended up holding working credentials for an account inside someone else's community.

## The fix

Write scoping lives with the read rule it mirrors: *you may only create or move an object into a ZEV you would be allowed to see.*

Each viewset declares `scope_parent_path` — the attribute chain from a write payload to the owning ZEV:

```python
scope_parent_path = ("zev",)                    # payload carries the ZEV
scope_parent_path = ("metering_point", "zev")   # payload carries a parent
```

`perform_create` / `perform_update` resolve it and check ownership before the save. Rejection is a field validation error, so it reads like DRF's other related-field errors and names the offending field without describing the ZEV behind the id.

Two supporting changes:

- **`AuditedUpdateMixin.perform_update` now saves through `super()`** instead of calling `serializer.save()`. It sits in front of the scoping mixin, so saving directly stepped straight over the check. Same for the `perform_create` overrides that exist for audit logging.
- A payload that does **not** name the parent — a `PATCH` leaving the relation alone — is not a move and is not checked, so ordinary edits are unaffected. Admins are unrestricted, as before.

## Deliberately not changed

Both checked rather than assumed:

- The **metering import** endpoints already scope correctly. CSV import passes `zev=None` so `_meter_queryset_for_user` falls through to the ownership filter; SDAT-CH takes a `zev_id` but rejects one the caller does not own. (`_meter_queryset_for_user(user, zev=…)` *does* skip the ownership check when given an explicit ZEV — safe today because its only such caller checks first, but worth knowing if a second one appears.)
- **`ZevViewSet.create`** is already admin-only.

## Verification

- All nine vectors: 400, nothing written. Ordinary owner writes, admin writes, and no-op PATCHes still succeed.
- 17 new tests, each asserting the rejection **and** that nothing landed — the failure mode is "returns 201 when it should not", which an assertion on a successful create cannot catch.
- Five mutations each fail the new tests, including reverting either mixin to `serializer.save()` — the regression a future contributor is most likely to reintroduce.
- `1019` backend tests pass, ruff clean, OpenAPI schema unchanged (same 20 pre-existing warnings as `main`).
- Exercised against the running stack on the real demo database: normal create/patch/delete unaffected.

Spec updated: `docs/specs/2026-03-community-and-access.md` §4.4 documents the rule, the per-viewset paths, and the two constraints it puts on anything added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)