### PR TITLE
fix(zev): honour ?zev_id= on the ZEV-scoped list endpoints

### DIFF
--- a/backend/metering/views.py
+++ b/backend/metering/views.py
@@ -286,15 +286,13 @@ class MeterReadingViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
         """
         date_from_str = request.query_params.get("date_from")
         date_to_str = request.query_params.get("date_to")
-        zev_id = request.query_params.get("zev_id")
 
         today = date_type.today()
         date_from = date_type.fromisoformat(date_from_str) if date_from_str else today - timedelta(days=30)
         date_to = date_type.fromisoformat(date_to_str) if date_to_str else today
 
+        # ``zev_id`` is already applied by ``scope_queryset``.
         qs = self.get_queryset()
-        if zev_id:
-            qs = qs.filter(metering_point__zev_id=zev_id)
         mp_ids = qs.values_list("metering_point_id", flat=True).distinct()
         metering_points = MeteringPoint.objects.filter(id__in=mp_ids)
 

--- a/backend/tariffs/views.py
+++ b/backend/tariffs/views.py
@@ -128,11 +128,9 @@ class TariffViewSet(AuditedUpdateMixin, ZevScopedQuerySetMixin, viewsets.ModelVi
     def list_series(self, request):
         """Tariffs grouped into series, newest version first, with gaps flagged."""
         today = timezone.localdate()
+        # ``?zev_id=`` is applied by ``scope_queryset`` for every ZEV-scoped
+        # viewset, so this action no longer filters it a second time.
         tariffs = self.get_queryset().prefetch_related('periods')
-
-        zev_id = request.query_params.get('zev_id')
-        if zev_id:
-            tariffs = tariffs.filter(zev_id=zev_id)
 
         grouped: dict[tuple, list] = {}
         for tariff in tariffs:

--- a/backend/zev/scoping.py
+++ b/backend/zev/scoping.py
@@ -19,6 +19,8 @@ write rule is the mirror of the read rule — you may only create or move an
 object into a ZEV you would be allowed to see.
 """
 
+import uuid
+
 from rest_framework import serializers
 
 
@@ -48,6 +50,20 @@ class ZevScopedQuerySetMixin:
     scope_parent_path: tuple[str, ...] | None = None
 
     def scope_queryset(self, qs):
+        """Everything a caller is allowed to see, narrowed by ``?zev_id=``.
+
+        Both are applied here because every ZEV-scoped viewset already funnels
+        its ``get_queryset`` through this method. Leaving the parameter to each
+        viewset is how it came to be accepted and silently ignored on six of
+        them (#411).
+
+        The filter cannot widen what a caller sees: it only ever adds a
+        conjunctive ``filter()`` to the role-scoped queryset, so naming
+        somebody else's ZEV yields an empty list rather than their data.
+        """
+        return self._narrow_by_zev_id(self._scope_by_role(qs))
+
+    def _scope_by_role(self, qs):
         user = self.request.user
         if user.is_admin:
             return qs
@@ -59,6 +75,35 @@ class ZevScopedQuerySetMixin:
         if self.participant_distinct:
             qs = qs.distinct()
         return qs
+
+    @property
+    def zev_lookup(self) -> str:
+        """ORM path from this model to its ``Zev``, derived from the role filter.
+
+        ``zev_owner_filter`` is by definition the path to that ZEV's ``owner``,
+        so dropping the final segment yields the path to the ZEV itself:
+        ``"metering_point__zev__owner"`` -> ``"metering_point__zev"``. Deriving
+        it keeps the two in step — a viewset that changes its relation path
+        cannot end up filtering on a stale one — and ``""`` correctly denotes
+        the ZEV viewset, whose model *is* the ZEV.
+        """
+        head, _, _ = self.zev_owner_filter.rpartition("__")
+        return head
+
+    def _narrow_by_zev_id(self, qs):
+        raw = self.request.query_params.get("zev_id")
+        if not raw:
+            return qs
+        try:
+            zev_id = uuid.UUID(str(raw))
+        except (ValueError, AttributeError, TypeError):
+            # Previously ignored along with the rest of the parameter, which
+            # returned every ZEV the caller could see and looked like success.
+            raise serializers.ValidationError(
+                {"zev_id": ["Must be a valid UUID."]}
+            ) from None
+        lookup = f"{self.zev_lookup}__id" if self.zev_lookup else "id"
+        return qs.filter(**{lookup: zev_id})
 
     # ── Write scoping ─────────────────────────────────────────────────────
 

--- a/backend/zev/test_scoping.py
+++ b/backend/zev/test_scoping.py
@@ -10,8 +10,11 @@ pytestmark = pytest.mark.django_db
 
 
 class _FakeRequest:
-    def __init__(self, user):
+    """Stands in for a DRF ``Request``: the mixin reads both of these."""
+
+    def __init__(self, user, query_params=None):
         self.user = user
+        self.query_params = query_params or {}
 
 
 class _ZevScope(ZevScopedQuerySetMixin):
@@ -19,16 +22,16 @@ class _ZevScope(ZevScopedQuerySetMixin):
     participant_filter = "participants__user"
     participant_distinct = True
 
-    def __init__(self, user):
-        self.request = _FakeRequest(user)
+    def __init__(self, user, query_params=None):
+        self.request = _FakeRequest(user, query_params)
 
 
 class _OwnerOnlyScope(ZevScopedQuerySetMixin):
     zev_owner_filter = "owner"
     participant_filter = None
 
-    def __init__(self, user):
-        self.request = _FakeRequest(user)
+    def __init__(self, user, query_params=None):
+        self.request = _FakeRequest(user, query_params)
 
 
 class TestZevScopedQuerySetMixin:

--- a/backend/zev/test_zev_id_filter.py
+++ b/backend/zev/test_zev_id_filter.py
@@ -1,0 +1,202 @@
+"""``?zev_id=`` on the ZEV-scoped list endpoints.
+
+Every one of these accepted the parameter and ignored it, answering 200 with
+every ZEV the caller could see (#411) — while the custom actions beside them
+honoured it, so a caller had every reason to assume it worked. The sharp case
+was ``/metering/readings/?zev_id=X``, which returned the whole instance's
+readings to an admin and looked scoped.
+
+The failure mode is *returning too much*, so an assertion on a non-empty result
+proves nothing. Each case pins the exact set, and every endpoint is checked
+against a ZEV that exists but is not the one asked for.
+"""
+
+from datetime import date, datetime, timezone
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from accounts.models import UserRole
+from invoices.models import Invoice, InvoiceStatus
+from metering.models import MeterReading
+from tariffs.models import BillingMode, EnergyType, Tariff, TariffCategory, TariffPeriod
+from testing.helpers import authenticate as auth, make_user
+from zev.models import (
+    MeteringPoint,
+    MeteringPointAssignment,
+    MeteringPointType,
+    Participant,
+    Zev,
+)
+
+PARTICIPANTS = "/api/v1/zev/participants/"
+METERING_POINTS = "/api/v1/zev/metering-points/"
+ASSIGNMENTS = "/api/v1/zev/metering-point-assignments/"
+TARIFFS = "/api/v1/tariffs/tariffs/"
+READINGS = "/api/v1/metering/readings/"
+INVOICES = "/api/v1/invoices/invoices/"
+ZEVS = "/api/v1/zev/zevs/"
+
+
+def _rows(response):
+    body = response.json()
+    return body["results"] if isinstance(body, dict) and "results" in body else body
+
+
+class _TwoPopulatedCommunities(TestCase):
+    """Two complete communities, so an unfiltered list is never a subset of one."""
+
+    def setUp(self):
+        self.admin = make_user("zf_admin", UserRole.ADMIN)
+        self.owner_a = make_user("zf_owner_a", UserRole.ZEV_OWNER)
+        self.owner_b = make_user("zf_owner_b", UserRole.ZEV_OWNER)
+        self.zev_a = Zev.objects.create(name="Community A", owner=self.owner_a, invoice_prefix="AAA")
+        self.zev_b = Zev.objects.create(name="Community B", owner=self.owner_b, invoice_prefix="BBB")
+
+        for zev, tag in ((self.zev_a, "A"), (self.zev_b, "B")):
+            participant = Participant.objects.create(
+                zev=zev, first_name=tag, last_name="Member",
+                email=f"{tag.lower()}@example.com", valid_from=date(2026, 1, 1),
+            )
+            meter = MeteringPoint.objects.create(
+                zev=zev, meter_id=f"{tag}-METER", meter_type=MeteringPointType.CONSUMPTION,
+            )
+            MeteringPointAssignment.objects.create(
+                metering_point=meter, participant=participant, valid_from=date(2026, 1, 1),
+            )
+            MeterReading.objects.create(
+                metering_point=meter, timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                energy_kwh="1.0", direction="in",
+            )
+            tariff = Tariff.objects.create(
+                zev=zev, name=f"{tag} Tariff", category=TariffCategory.ENERGY,
+                billing_mode=BillingMode.ENERGY, energy_type=EnergyType.LOCAL,
+                valid_from=date(2026, 1, 1),
+            )
+            TariffPeriod.objects.create(
+                tariff=tariff, period_type="flat", price_chf_per_kwh="0.20",
+            )
+            Invoice.objects.create(
+                zev=zev, participant=participant, invoice_number=f"{tag}-00001",
+                period_start=date(2026, 1, 1), period_end=date(2026, 1, 31),
+                status=InvoiceStatus.DRAFT,
+            )
+            setattr(self, f"participant_{tag.lower()}", participant)
+            setattr(self, f"meter_{tag.lower()}", meter)
+
+        self.client = APIClient()
+        auth(self.client, self.admin)
+
+
+class AdminFilteringTests(_TwoPopulatedCommunities):
+    """An admin sees both communities, so the filter has something to do."""
+
+    def assertOnlyCommunityA(self, url, field, expected):
+        unfiltered = self.client.get(url)
+        self.assertEqual(len(_rows(unfiltered)), 2, f"{url} fixture should hold both communities")
+
+        filtered = self.client.get(url, {"zev_id": str(self.zev_a.id)})
+        self.assertEqual(filtered.status_code, 200, filtered.content)
+        self.assertEqual([row[field] for row in _rows(filtered)], [expected])
+
+    def test_participants(self):
+        self.assertOnlyCommunityA(PARTICIPANTS, "first_name", "A")
+
+    def test_metering_points(self):
+        self.assertOnlyCommunityA(METERING_POINTS, "meter_id", "A-METER")
+
+    def test_tariffs(self):
+        self.assertOnlyCommunityA(TARIFFS, "name", "A Tariff")
+
+    def test_invoices(self):
+        self.assertOnlyCommunityA(INVOICES, "invoice_number", "A-00001")
+
+    def test_metering_point_assignments(self):
+        filtered = self.client.get(ASSIGNMENTS, {"zev_id": str(self.zev_a.id)})
+        self.assertEqual(filtered.status_code, 200)
+        rows = _rows(filtered)
+        self.assertEqual(len(_rows(self.client.get(ASSIGNMENTS))), 2)
+        self.assertEqual([row["metering_point"] for row in rows], [str(self.meter_a.id)])
+
+    def test_meter_readings(self):
+        """The sharpest case: this one returned the whole instance's readings."""
+        self.assertEqual(len(_rows(self.client.get(READINGS))), 2)
+        filtered = self.client.get(READINGS, {"zev_id": str(self.zev_a.id)})
+        self.assertEqual(filtered.status_code, 200)
+        rows = _rows(filtered)
+        self.assertEqual([row["metering_point"] for row in rows], [str(self.meter_a.id)])
+
+    def test_zevs(self):
+        filtered = self.client.get(ZEVS, {"zev_id": str(self.zev_a.id)})
+        self.assertEqual([row["name"] for row in _rows(filtered)], ["Community A"])
+
+
+class NonExistentZevTests(_TwoPopulatedCommunities):
+    """A ZEV id nobody owns must empty the list, not fall back to everything."""
+
+    UNKNOWN = "00000000-0000-0000-0000-000000000000"
+
+    def test_every_endpoint_returns_nothing(self):
+        for url in (PARTICIPANTS, METERING_POINTS, ASSIGNMENTS, TARIFFS, READINGS, INVOICES, ZEVS):
+            with self.subTest(url=url):
+                response = self.client.get(url, {"zev_id": self.UNKNOWN})
+                self.assertEqual(response.status_code, 200, response.content)
+                self.assertEqual(_rows(response), [], f"{url} ignored the filter")
+
+
+class MalformedValueTests(_TwoPopulatedCommunities):
+    def test_a_non_uuid_is_refused_rather_than_ignored(self):
+        for url in (PARTICIPANTS, METERING_POINTS, TARIFFS, READINGS, INVOICES):
+            with self.subTest(url=url):
+                response = self.client.get(url, {"zev_id": "not-a-uuid"})
+                self.assertEqual(response.status_code, 400, response.content)
+                self.assertIn("zev_id", response.json())
+
+    def test_an_empty_value_is_treated_as_absent(self):
+        """``?zev_id=`` with no value is a client building a querystring from an
+        empty field, not a request to match a ZEV with no id."""
+        response = self.client.get(f"{PARTICIPANTS}?zev_id=")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(_rows(response)), 2)
+
+
+class FilterCannotWidenScopeTests(_TwoPopulatedCommunities):
+    """The filter narrows. It must never be a way to reach another community."""
+
+    def test_owner_naming_another_community_gets_nothing(self):
+        client = APIClient()
+        auth(client, self.owner_a)
+        for url in (PARTICIPANTS, METERING_POINTS, TARIFFS, READINGS, INVOICES):
+            with self.subTest(url=url):
+                response = client.get(url, {"zev_id": str(self.zev_b.id)})
+                self.assertEqual(response.status_code, 200, response.content)
+                self.assertEqual(_rows(response), [])
+
+    def test_owner_naming_their_own_community_still_works(self):
+        client = APIClient()
+        auth(client, self.owner_a)
+        response = client.get(PARTICIPANTS, {"zev_id": str(self.zev_a.id)})
+        self.assertEqual([row["first_name"] for row in _rows(response)], ["A"])
+
+    def test_participant_naming_a_foreign_community_gets_nothing(self):
+        member = make_user("zf_member", UserRole.PARTICIPANT)
+        self.participant_a.user = member
+        self.participant_a.save(update_fields=["user"])
+
+        client = APIClient()
+        auth(client, member)
+        response = client.get(METERING_POINTS, {"zev_id": str(self.zev_b.id)})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(_rows(response), [])
+
+
+class UnfilteredBehaviourUnchangedTests(_TwoPopulatedCommunities):
+    """Omitting the parameter must behave exactly as before."""
+
+    def test_admin_still_sees_both_communities(self):
+        self.assertEqual(len(_rows(self.client.get(PARTICIPANTS))), 2)
+
+    def test_owner_still_sees_only_their_own(self):
+        client = APIClient()
+        auth(client, self.owner_a)
+        self.assertEqual([row["first_name"] for row in _rows(client.get(PARTICIPANTS))], ["A"])

--- a/docs/specs/2026-03-community-and-access.md
+++ b/docs/specs/2026-03-community-and-access.md
@@ -189,7 +189,31 @@ Defined in `accounts/permissions.py` and `zev/permissions.py`.
    `zev.participants.filter(user=user).exists()`.
 5. Else → deny.
 
-### 4.4 Write scoping (`ZevScopedQuerySetMixin`)
+### 4.4 Read scoping and the `zev_id` filter (`ZevScopedQuerySetMixin`)
+
+`scope_queryset` returns the role-scoped queryset, then narrows it by the
+optional `?zev_id=` query parameter. Both live here because every ZEV-scoped
+viewset already funnels its `get_queryset` through this method; leaving the
+parameter to each viewset is how it came to be accepted and silently ignored
+on six of them (#411), while the custom actions beside them honoured it.
+
+| Behaviour | Result |
+|---|---|
+| parameter omitted, or empty (`?zev_id=`) | role scope only, unchanged |
+| a ZEV in the caller's scope | narrowed to that ZEV |
+| a ZEV outside the caller's scope | empty list (never that ZEV's data) |
+| a non-UUID value | `400` with `zev_id` in the body |
+
+The ORM path is derived, not declared: `zev_owner_filter` is by definition the
+path to the ZEV's `owner`, so dropping the last segment gives the path to the
+ZEV itself (`metering_point__zev__owner` → `metering_point__zev`). A viewset
+that changes its relation path therefore cannot end up filtering on a stale
+one. The empty path denotes `ZevViewSet`, whose model *is* the ZEV.
+
+The filter can only narrow: it adds a conjunctive `filter()` to the
+already-role-scoped queryset, so it is not a route to another tenant's data.
+
+### 4.5 Write scoping (`ZevScopedQuerySetMixin`)
 
 `has_object_permission` runs on detail routes only — DRF has no object to
 check on create, so it is never consulted there. A permission class alone


### PR DESCRIPTION
Closes #411.

> **Stacked on #425.** Both change `zev/scoping.py`, so this branches off it rather than `main` to avoid the conflict. Merge #425 first and this reduces to the single commit `a5e335e`. Retarget to `main` once #425 lands.

## The problem

Six list endpoints accepted `?zev_id=` and ignored it, answering 200 with everything in the caller's role scope — while the custom actions beside them honoured it, so a caller had every reason to assume it worked.

Against the real demo instance, before and after:

| endpoint | no filter | `?zev_id=<real>` | `?zev_id=<unknown>` |
|---|---|---|---|
| `/zev/participants/` | 3 | 3 | **0** (was 3) |
| `/zev/metering-points/` | 3 | 3 | **0** (was 3) |
| `/zev/metering-point-assignments/` | 3 | 3 | **0** (was 3) |
| `/tariffs/tariffs/` | 14 | 14 | **0** (was 14) |
| `/metering/readings/` | 34848 | 34848 | **0** (was 34848) |
| `/invoices/invoices/` | 2 | 2 | **0** (was 2) |

The `unknown` column is the bug: a script asking for one community's readings got the whole instance and no indication anything was wrong. For anything computing totals that is a silently wrong answer.

## The fix

The filter now lives in `ZevScopedQuerySetMixin.scope_queryset`, which every ZEV-scoped viewset already funnels `get_queryset` through. Leaving it to each viewset is precisely how it came to be missing from six of them; putting it there covers all seven endpoints in one place and makes it automatic for anything added later.

The ORM path is **derived, not declared**: `zev_owner_filter` is by definition the path to the ZEV's `owner`, so dropping its last segment gives the path to the ZEV — `metering_point__zev__owner` → `metering_point__zev`. A viewset that changes its relation path therefore cannot end up filtering on a stale one, and the empty path correctly denotes `ZevViewSet`, whose model *is* the ZEV.

Behaviour:

| input | result |
|---|---|
| omitted, or empty (`?zev_id=`) | unchanged — role scope only |
| a ZEV in scope | narrowed |
| a ZEV out of scope | empty list, never that ZEV's data |
| a non-UUID | `400` with `zev_id` in the body (was: ignored) |

**It cannot widen scope.** The filter adds a conjunctive `filter()` to the already-role-scoped queryset. Tested for owners and participants naming a foreign community — both get an empty list.

Also removes the now-duplicated manual filtering in `tariffs.list_series` and `metering.data_quality`.

## Deliberately not included

Rejecting **unknown** query parameters, which #411 raised as the second half and flagged as a separate decision. It needs an allowlist covering pagination, ordering and format params, and it changes behaviour for any caller passing stray keys. Worth its own issue if you want it.

## Verification

- 15 new tests, each pinning the **exact** result set. The failure mode is *returning too much*, so an assertion on a non-empty list proves nothing — every endpoint is checked against a ZEV that exists but is not the one asked for.
- Mutations: removing the filter, hardcoding the derived path, and dropping the UUID validation are all caught. Swapping the order of the two filters survives — correctly, since both are conjunctive and produce identical SQL; I corrected an earlier comment that had implied otherwise.
- `1034` backend tests pass, ruff clean.
- No frontend impact: every `zev_id` the frontend sends goes to a custom action that already honoured it; the plain list fetchers take no parameters.

Spec updated: `docs/specs/2026-03-community-and-access.md` §4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)