### PR TITLE
test(invoices): assert invoice markup, not the stylesheet that always renders

### DIFF
--- a/backend/invoices/test_pdf.py
+++ b/backend/invoices/test_pdf.py
@@ -37,10 +37,20 @@ from .pdf_translations import INVOICE_TRANSLATIONS
 from .template_context import build_sample_invoice_context
 
 
-def _render_template_html(invoice):
-    """Render the invoice template to an HTML string for structural assertions."""
+_STYLE_BLOCK_RE = re.compile(r"<style>.*?</style>", re.DOTALL)
+
+
+def _render_invoice_markup(invoice):
+    """Render the invoice template to markup, stylesheet removed.
+
+    The ``<style>`` block renders on every invoice, so a bare class name found
+    in the full HTML may be nothing but a CSS selector. Asserting against the
+    markup alone keeps a structural check from passing on the stylesheet while
+    the element it names is gone (#427).
+    """
     from .pdf import TEMPLATE_NAME
-    return _render_template(TEMPLATE_NAME, _build_template_context(invoice))
+    html = _render_template(TEMPLATE_NAME, _build_template_context(invoice))
+    return _STYLE_BLOCK_RE.sub("", html)
 
 
 class InvoicePdfQrTests(TestCase):
@@ -343,12 +353,26 @@ class InvoicePdfQrTests(TestCase):
         reader = PdfReader(io.BytesIO(pdf_bytes))
         self.assertGreaterEqual(len(reader.pages), 2)  # invoice + insights at minimum
 
-        html = _render_template_html(invoice)
-        # Structural checks on rendered HTML
-        self.assertIn('class="line-items"', html)
-        self.assertIn('quantity-cell', html)
-        self.assertNotIn('<th>{{ tr.unit }}</th>', html)  # unit merged into quantity
-        self.assertIn('savings-breakdown', html)  # savings card variant renders
+        markup = _render_invoice_markup(invoice)
+        # Structural checks on the rendered markup
+        self.assertIn('class="line-items"', markup)
+        self.assertIn('quantity-cell', markup)
+        self.assertNotIn('<th>{{ tr.unit }}</th>', markup)  # unit merged into quantity
+        self.assertIn('savings-breakdown', markup)  # savings card variant renders
+
+    def test_structural_markers_are_absent_when_their_element_does_not_render(self):
+        """Guards the assertions above.
+
+        Both markers also exist as CSS selectors, and the stylesheet renders on
+        every invoice — so asserting them against the full HTML passed even with
+        the elements deleted from the template (#427). An invoice with no items
+        has no line-item table and no savings card; if these markers still turn
+        up, the structural checks have stopped proving anything again.
+        """
+        markup = _render_invoice_markup(self._invoice())
+
+        self.assertNotIn('savings-breakdown', markup)
+        self.assertNotIn('quantity-cell', markup)
 
     def test_template_context_enables_inline_qr_payment_for_small_invoices(self):
         invoice = self._invoice()


### PR DESCRIPTION
Fixes #427.

## The problem

Four structural assertions in `test_default_template_uses_dedicated_invoice_and_payment_layouts` ran against the full rendered HTML — which includes the `<style>` block, lines 7–833 of `invoice_pdf.html`, present on every invoice. Two of the strings they look for are CSS selectors as well as markup classes:

| marker | CSS rule | markup |
|---|---|---|
| `savings-breakdown` | line 280 | line 917, inside `{% if savings_data %}` |
| `quantity-cell` | line 392 | line 972, `class="numeric quantity-cell"` |

So both `assertIn`s matched the stylesheet and never reached the element. The test even sets up a higher-rate grid item specifically so the savings card renders — and nothing checked that it had.

## The fix

Strip the stylesheet before asserting, rather than patching the two strings individually. That fixes both markers and every structural check added to this test later, which the string-by-string fix would not.

Renamed `_render_template_html` to `_render_invoice_markup` so the call site says what it returns.

The strip introduces a failure mode of its own: if the regex ever stops matching, it silently becomes a no-op and the original defect is back with no signal. `test_structural_markers_are_absent_when_their_element_does_not_render` pins that down — an invoice with no items renders neither element, so both markers must be absent from the markup.

## Verification

Mutation-tested. Each of these fails now; **all three passed before this change**:

| mutant | before | after |
|---|---|---|
| `{% if savings_data %}` → `{% if False %}` | 32 passed | 1 failed, 32 passed |
| `class="numeric quantity-cell"` → `class="numeric"` | 32 passed | 1 failed, 32 passed |
| stylesheet strip neutralised | n/a | 1 failed, 32 passed |

The third one is killed by the new guard test, which is the point of adding it.

Full backend suite: **1035 passed, 202 subtests**. `ruff check` clean. Test-only change — no production code touched.
