### PR TITLE
fix(accounts): restrict /auth/users/ to admins

### DIFF
--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -765,6 +765,60 @@ class OAuthProviderSecretWriteOnlyTests(TestCase):
 		provider.refresh_from_db()
 		self.assertEqual(provider.client_secret, "rotated-secret")
 
+class UserListCreateAdminOnlyTests(TestCase):
+	"""The user list used to hand every ZEV owner every active participant
+	account in the instance; listing and creating are admin-only."""
+
+	def setUp(self):
+		self.admin = User.objects.create_user(username="ul_admin", password="pass1234", role=UserRole.ADMIN)
+		self.owner = User.objects.create_user(username="ul_owner", password="pass1234", role=UserRole.ZEV_OWNER)
+		self.participant_user = User.objects.create_user(username="ul_participant", password="pass1234", role=UserRole.PARTICIPANT)
+
+		self.admin_client = APIClient()
+		_cookie_auth(self.admin_client, "ul_admin")
+		self.owner_client = APIClient()
+		_cookie_auth(self.owner_client, "ul_owner")
+		self.participant_client = APIClient()
+		_cookie_auth(self.participant_client, "ul_participant")
+
+	def test_owner_cannot_list_users(self):
+		response = self.owner_client.get("/api/v1/auth/users/")
+		self.assertEqual(response.status_code, 403)
+
+	def test_participant_cannot_list_users(self):
+		response = self.participant_client.get("/api/v1/auth/users/")
+		self.assertEqual(response.status_code, 403)
+
+	def test_anonymous_cannot_list_users(self):
+		response = APIClient().get("/api/v1/auth/users/")
+		self.assertEqual(response.status_code, 401)
+
+	def test_owner_cannot_create_users(self):
+		response = self.owner_client.post(
+			"/api/v1/auth/users/",
+			{"username": "ul_backdoor", "email": "backdoor@example.com", "first_name": "Back",
+			 "last_name": "Door", "password": "pass1234", "password2": "pass1234", "role": "participant"},
+			format="json",
+		)
+		self.assertEqual(response.status_code, 403)
+		self.assertFalse(User.objects.filter(username="ul_backdoor").exists())
+
+	def test_admin_can_list_all_users(self):
+		response = self.admin_client.get("/api/v1/auth/users/")
+		self.assertEqual(response.status_code, 200)
+		usernames = {row["username"] for row in response.json()["results"]}
+		self.assertEqual(usernames, {"ul_admin", "ul_owner", "ul_participant"})
+
+	def test_admin_can_create_users(self):
+		response = self.admin_client.post(
+			"/api/v1/auth/users/",
+			{"username": "ul_created", "email": "created@example.com", "first_name": "New",
+			 "last_name": "User", "password": "Uniquely-Long-9164!", "password2": "Uniquely-Long-9164!", "role": "participant"},
+			format="json",
+		)
+		self.assertEqual(response.status_code, 201, response.content)
+		self.assertTrue(User.objects.filter(username="ul_created").exists())
+
 
 class RbacEndpointMatrixTests(TestCase):
 	def _auth(self, client, user, password="pass1234"):

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -91,32 +91,14 @@ def logout_view(request):
 
 
 class UserListCreateView(generics.ListCreateAPIView):
-    """Admin: create users. Admin/ZEV owner: list participant accounts for linking."""
-    permission_classes = [IsAuthenticated]
+    """Admin: list and create users."""
+    permission_classes = [IsAdmin]
 
     def get_queryset(self):
-        user = self.request.user
-        if user.is_admin:
-            return User.objects.all().order_by("username")
-        if user.is_zev_owner:
-            return User.objects.filter(role=UserRole.PARTICIPANT, is_active=True).order_by("username")
-        raise PermissionDenied("Permission denied.")
+        return User.objects.all().order_by("username")
 
     def get_serializer_class(self):
         return UserCreateSerializer if self.request.method == "POST" else UserSerializer
-
-    def create(self, request, *args, **kwargs):
-        if not request.user.is_admin:
-            record_audit_event(
-                request=request,
-                action_category=AuditActionCategory.AUTH,
-                action_type="user.create",
-                target_type="accounts.User",
-                summary="Denied user creation attempt by non-admin.",
-                status=AuditEventStatus.DENIED,
-            )
-            raise PermissionDenied("Only admins can create users.")
-        return super().create(request, *args, **kwargs)
 
     def perform_create(self, serializer):
         user = serializer.save()

--- a/docs/specs/2026-03-community-and-access.md
+++ b/docs/specs/2026-03-community-and-access.md
@@ -374,16 +374,17 @@ not impersonating and the current path is not `/account`, redirect to
 
 ### 6.1 User list
 
-**Endpoint:** `GET /api/v1/auth/users/` (IsAuthenticated)
+**Endpoint:** `GET /api/v1/auth/users/` (IsAdmin)
 
-**Queryset scoping:**
-- `admin` → all users, ordered by username.
-- `zev_owner` → only `participant` role users that are active.
-- Other roles → 403 (PermissionDenied).
+Admin only — the user list is the instance-wide account registry; exposing it
+to owners would leak every participant's contact details across communities.
+Owners have no consumer for it: account linking is admin-only.
+
+**Queryset:** all users, ordered by username. Any non-admin role → 403.
 
 ### 6.2 User create
 
-**Endpoint:** `POST /api/v1/auth/users/` (IsAuthenticated; admin only in view logic)
+**Endpoint:** `POST /api/v1/auth/users/` (IsAdmin)
 
 **Payload:** `{ username, email, first_name, last_name, password, password2, role }`
 
@@ -619,7 +620,7 @@ The sidebar (`Layout.tsx`) shows sections conditionally:
 | GET / PATCH | `/me/` | IsAuthenticated | View/update own profile |
 | POST | `/me/change-password/` | IsAuthenticated | Change password (requires old password) |
 | POST | `/me/set-initial-password/` | IsAuthenticated | Set password for first time (verification flow) |
-| GET / POST | `/users/` | IsAuthenticated (create: admin only) | List users (scoped by role) / Create user |
+| GET / POST | `/users/` | IsAdmin | List users / Create user |
 | GET / PATCH / DELETE | `/users/{id}/` | IsAdmin | User detail (delete blocked if linked or last admin) |
 | POST | `/users/{user_id}/impersonate/` | IsAuthenticated (admin only) | Impersonate participant/owner |
 | GET / PATCH | `/app-settings/` | IsAuthenticated (update: admin only) | Application settings singleton |
@@ -662,7 +663,7 @@ backend's primary access control mechanism.
 | Participant | all | `zev.owner == user` | `user == request.user` | — |
 | MeteringPoint | all | `zev.owner == user` | assigned via MeteringPointAssignment | — |
 | MeteringPointAssignment | all | `metering_point.zev.owner == user` | `participant.user == user` | — |
-| User (list) | all | active participants only | PermissionDenied | PermissionDenied |
+| User (list) | all (`IsAdmin`) | PermissionDenied | PermissionDenied | PermissionDenied |
 | ImportLog | all | `zev.owner == user` OR `imported_by == user` | PermissionDenied | PermissionDenied |
 | MeterReading | all | ZEV-scoped meters | assigned meters | PermissionDenied |
 | Invoice | all | `zev.owner == user` | `participant.user == user` | — |
@@ -838,6 +839,7 @@ interface ParticipantAccountCreateResult { participant: Participant; account: Us
 | `VatRateSettingsTests` | 4 | Admin CRUD; non-admin blocked; overlap rejection; valid_to validation |
 | `OAuthProviderConfigTests` | 5 | Admin creates provider (internal host URLs, scheme-less URLs, default redirect URL); non-admin blocked; login initiate uses provider redirect URL |
 | `OAuthProviderSecretWriteOnlyTests` | 5 | `client_secret` is write-only: create/list/detail responses never contain it and report `has_client_secret`; create without a secret is refused; blank secret on update keeps the stored value; new secret on update rotates it |
+| `UserListCreateAdminOnlyTests` | 6 | Owner/participant/anonymous cannot list or create users; admin can list all users and create |
 | `RbacEndpointMatrixTests` | 6 | Full list/create/update/action-delete/unauthenticated matrix across all endpoints |
 | `OAuthTokenCleanupTaskTests` | 1 | Token cleanup task keeps active and removes expired entries |
 

--- a/docs/user-guide/16-api-keys.md
+++ b/docs/user-guide/16-api-keys.md
@@ -107,8 +107,9 @@ The rule behind the list: a key may not touch credentials or sessions. That is
 what keeps a leaked key a revocable credential rather than a permanent account
 takeover.
 
-Reading is still open where it is useful — `GET auth/me/` and `GET auth/users/`
-work normally.
+Reading is still open where it is useful — `GET auth/me/` works for any key.
+`GET auth/users/` is the instance-wide user list and is restricted to admin
+keys; a non-admin key is refused there.
 
 ## Rate limits
 


### PR DESCRIPTION
## Summary
GET /api/v1/auth/users/ was reachable by any ZEV owner and returned every
active participant account in the instance, including communities the
caller does not belong to. The view is now IsAdmin for both list and
create; the old "Denied user creation" branch in create() became
unreachable after that and is removed.

## Linked spec
- Spec: docs/specs/2026-03-community-and-access.md (sections 6.1, 6.2,
  endpoint table, scoping matrix)
- ADR: none (permission tightening only)

## Validation
- Backend tests run: python -m pytest — 1041 passed, 202 subtests passed;
  ruff check clean
- Frontend build run: not run (backend-only; all fetchUsers callers are
  already gated on role === 'admin')
- Frontend tests run: not run (same reason)
- Manual checks: none
- Screenshots: N/A (no UI change)

## Checklist
- [x] Spec updated/linked for larger or risky changes
- ADR N/A: permission tightening, no architecture decision
- Backend and frontend updated together where API contracts changed: N/A —
  response shape unchanged; every frontend consumer already admin-gated