### PR TITLE
fix(accounts): make OAuth client secret write-only

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -123,7 +123,8 @@ class FeatureFlagSerializer(serializers.ModelSerializer):
 
 
 class OAuthProviderSerializer(serializers.ModelSerializer):
-    """Full serializer for admin CRUD — includes client_secret."""
+    """Admin CRUD serializer; ``client_secret`` is write-only and a blank
+    value on update leaves the stored secret untouched."""
 
     # Use CharField to allow internal hostnames like "keycloak:8080" while
     # still enforcing a scheme/netloc via custom validators below.
@@ -131,6 +132,16 @@ class OAuthProviderSerializer(serializers.ModelSerializer):
     token_url = serializers.CharField(max_length=500)
     userinfo_url = serializers.CharField(max_length=500)
     redirect_url = serializers.CharField(max_length=500, required=False, allow_blank=True)
+    client_secret = serializers.CharField(
+        write_only=True,
+        required=False,
+        allow_blank=True,
+        trim_whitespace=False,
+    )
+    has_client_secret = serializers.SerializerMethodField()
+
+    def get_has_client_secret(self, obj) -> bool:
+        return bool(obj.client_secret)
 
     def validate_name(self, value):
         normalized = slugify((value or "").strip())
@@ -166,6 +177,14 @@ class OAuthProviderSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
+        secret = (attrs.get("client_secret") or "").strip()
+        if self.instance is None and not secret:
+            raise serializers.ValidationError(
+                {"client_secret": "A client secret is required when creating a provider."}
+            )
+        if self.instance is not None and not secret:
+            attrs.pop("client_secret", None)
+
         provider_name = attrs.get("name") or getattr(self.instance, "name", "")
         redirect_url = attrs.get("redirect_url")
 
@@ -184,6 +203,7 @@ class OAuthProviderSerializer(serializers.ModelSerializer):
         model = OAuthProvider
         fields = [
             "id", "name", "display_name", "client_id", "client_secret",
+            "has_client_secret",
             "authorization_url", "token_url", "userinfo_url", "redirect_url", "scope",
             "enabled", "created_at", "updated_at",
         ]

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -652,6 +652,120 @@ class OAuthProviderConfigTests(TestCase):
 		)
 
 
+class OAuthProviderSecretWriteOnlyTests(TestCase):
+	"""client_secret is never returned; blank on update keeps the stored secret."""
+
+	def _auth(self, client, user, password="pass1234"):
+		_cookie_auth(client, user.username, password)
+
+	def _payload(self, **overrides):
+		payload = {
+			"name": "github",
+			"display_name": "GitHub",
+			"client_id": "openzev",
+			"client_secret": "super-secret",
+			"authorization_url": "https://github.com/login/oauth/authorize",
+			"token_url": "https://github.com/login/oauth/access_token",
+			"userinfo_url": "https://api.github.com/user",
+			"scope": "read:user user:email",
+			"enabled": True,
+		}
+		payload.update(overrides)
+		return payload
+
+	def setUp(self):
+		self.client = APIClient()
+		self.admin = User.objects.create_user(username="oauth_writeonly", password="pass1234", role=UserRole.ADMIN)
+		self._auth(self.client, self.admin)
+
+	def test_create_response_never_contains_the_secret(self):
+		resp = self.client.post("/api/v1/auth/oauth/providers/config/", self._payload(), format="json")
+
+		self.assertEqual(resp.status_code, 201)
+		self.assertNotIn("client_secret", resp.data)
+		self.assertTrue(resp.data["has_client_secret"])
+
+	def test_list_and_detail_never_contain_the_secret(self):
+		provider = OAuthProvider.objects.create(
+			name="github",
+			display_name="GitHub",
+			client_id="openzev",
+			client_secret="super-secret",
+			authorization_url="https://github.com/login/oauth/authorize",
+			token_url="https://github.com/login/oauth/access_token",
+			userinfo_url="https://api.github.com/user",
+			scope="read:user user:email",
+			enabled=True,
+		)
+
+		list_resp = self.client.get("/api/v1/auth/oauth/providers/config/")
+		detail_resp = self.client.get(f"/api/v1/auth/oauth/providers/config/{provider.pk}/")
+
+		self.assertNotIn("client_secret", list_resp.data["results"][0])
+		self.assertTrue(list_resp.data["results"][0]["has_client_secret"])
+		self.assertNotIn("client_secret", detail_resp.data)
+		self.assertTrue(detail_resp.data["has_client_secret"])
+
+	def test_create_without_a_secret_is_refused(self):
+		resp = self.client.post(
+			"/api/v1/auth/oauth/providers/config/",
+			self._payload(client_secret=""),
+			format="json",
+		)
+
+		self.assertEqual(resp.status_code, 400)
+		self.assertIn("client_secret", resp.data)
+		self.assertFalse(OAuthProvider.objects.filter(name="github").exists())
+
+	def test_blank_secret_on_update_keeps_the_stored_secret(self):
+		provider = OAuthProvider.objects.create(
+			name="github",
+			display_name="GitHub",
+			client_id="openzev",
+			client_secret="super-secret",
+			authorization_url="https://github.com/login/oauth/authorize",
+			token_url="https://github.com/login/oauth/access_token",
+			userinfo_url="https://api.github.com/user",
+			scope="read:user user:email",
+			enabled=True,
+		)
+
+		resp = self.client.patch(
+			f"/api/v1/auth/oauth/providers/config/{provider.pk}/",
+			{"client_secret": "", "display_name": "GitHub Login"},
+			format="json",
+		)
+
+		self.assertEqual(resp.status_code, 200)
+		self.assertTrue(resp.data["has_client_secret"])
+		provider.refresh_from_db()
+		self.assertEqual(provider.client_secret, "super-secret")
+
+	def test_new_secret_on_update_rotates_the_stored_secret(self):
+		provider = OAuthProvider.objects.create(
+			name="github",
+			display_name="GitHub",
+			client_id="openzev",
+			client_secret="old-secret",
+			authorization_url="https://github.com/login/oauth/authorize",
+			token_url="https://github.com/login/oauth/access_token",
+			userinfo_url="https://api.github.com/user",
+			scope="read:user user:email",
+			enabled=True,
+		)
+
+		resp = self.client.patch(
+			f"/api/v1/auth/oauth/providers/config/{provider.pk}/",
+			{"client_secret": "rotated-secret"},
+			format="json",
+		)
+
+		self.assertEqual(resp.status_code, 200)
+		self.assertTrue(resp.data["has_client_secret"])
+		provider.refresh_from_db()
+		self.assertEqual(provider.client_secret, "rotated-secret")
+
+
 class RbacEndpointMatrixTests(TestCase):
 	def _auth(self, client, user, password="pass1234"):
 		_cookie_auth(client, user.username, password)

--- a/docs/specs/2026-03-admin-governance-and-settings.md
+++ b/docs/specs/2026-03-admin-governance-and-settings.md
@@ -364,6 +364,10 @@ remain available as redirects into the corresponding tab of
     - Uses `fetchOAuthProviderConfigs` with query key `['oauth-provider-configs']`.
     - Displays configured providers in a table with enabled badges and compact Edit/Delete actions.
     - Provider create/edit uses a shared modal form; delete uses `ConfirmDialog`.
+    - `client_secret` is write-only: API responses never contain it (only
+      `has_client_secret`), create without a secret is refused (400), and the
+      edit form shows the secret field blank with a hint — a blank submit omits
+      the key from the PATCH payload so the stored secret stays unchanged.
 
 Legacy routes `/admin/settings/regional`, `/admin/features`, and `/admin/oauth`
 redirect to the matching tab on this page.

--- a/docs/specs/2026-03-community-and-access.md
+++ b/docs/specs/2026-03-community-and-access.md
@@ -823,17 +823,23 @@ interface ParticipantAccountCreateResult { participant: Participant; account: Us
 
 ### 16.1 Backend test classes
 
-**`accounts/tests.py`** (528 lines, 7 test classes):
+**`accounts/tests.py`** (13 test classes):
 
 | Class | Tests | Description |
 |---|---|---|
 | `UserModelTests` | 3 | Role helper properties; superuser creation sets `role=ADMIN`; superuser creation rejects non-admin role |
 | `PasswordChangeFlagTests` | 1 | `must_change_password` cleared on password change |
+| `TokenLoginCredentialTests` | 1 | Email login issues httpOnly cookie JWTs instead of a response body token |
+| `RegistrationTests` | 4 | Self-registration accepts email only and generates a username; creates an inactive `zev_owner`; verification activates the account; disabled registration is refused |
+| `FeatureFlagsApiTests` | 5 | Anonymous 401 and non-admin 403 on list; admin can list and toggle; defaults sync on read |
 | `ImpersonationTests` | 4 | Admin can impersonate participant/owner; non-admin blocked; admin cannot impersonate admin |
 | `LinkedAccountSafetyTests` | 8 | Admin can edit linked account; cannot delete linked; can delete unlinked; cannot delete last admin (with audit-denied assertion); can delete self when other admin exists (with audit actor SET_NULL assertion); can delete other admin when multiple exist; cannot change own role (via both detail and me endpoints) |
 | `AppSettingsTests` | 3 | Authenticated user reads settings; admin updates; non-admin cannot update |
 | `VatRateSettingsTests` | 4 | Admin CRUD; non-admin blocked; overlap rejection; valid_to validation |
+| `OAuthProviderConfigTests` | 5 | Admin creates provider (internal host URLs, scheme-less URLs, default redirect URL); non-admin blocked; login initiate uses provider redirect URL |
+| `OAuthProviderSecretWriteOnlyTests` | 5 | `client_secret` is write-only: create/list/detail responses never contain it and report `has_client_secret`; create without a secret is refused; blank secret on update keeps the stored value; new secret on update rotates it |
 | `RbacEndpointMatrixTests` | 6 | Full list/create/update/action-delete/unauthenticated matrix across all endpoints |
+| `OAuthTokenCleanupTaskTests` | 1 | Token cleanup task keeps active and removes expired entries |
 
 **`zev/tests.py`** (554 lines, 6 test classes):
 

--- a/docs/user-guide/14-admin-console.md
+++ b/docs/user-guide/14-admin-console.md
@@ -55,7 +55,9 @@ Configure external OAuth login providers in **Admin Console → System Settings 
 
 - **Name** — Provider identifier (e.g. `github`)
 - **Display Name** — Human-readable label shown on the login page
-- **Client ID / Client Secret** — Credentials obtained from the provider
+- **Client ID / Client Secret** — Credentials obtained from the provider. The
+  secret is never shown again after saving: enter it when creating the
+  provider, and leave the field blank when editing to keep the existing secret.
 - **Authorization / Token / Userinfo URLs** — Provider endpoint URLs
 - **Redirect URL** — The callback URL registered with the provider (e.g.
   `https://app.example.com/api/v1/auth/oauth/callback/github/`)

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -1867,6 +1867,7 @@ export const de = {
         fieldDisplayName: 'Anzeigename',
         fieldClientId: 'Client-ID',
         fieldClientSecret: 'Client-Secret',
+        fieldClientSecretHint: 'Für diesen Anbieter ist ein Secret hinterlegt; leer lassen, um es beizubehalten.',
         fieldAuthorizationUrl: 'Autorisierungs-URL',
         fieldTokenUrl: 'Token-URL',
         fieldUserinfoUrl: 'Userinfo-URL',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1841,6 +1841,7 @@ export const en = {
         fieldDisplayName: 'Display name',
         fieldClientId: 'Client ID',
         fieldClientSecret: 'Client Secret',
+        fieldClientSecretHint: 'A secret is configured for this provider; leave blank to keep it.',
         fieldAuthorizationUrl: 'Authorization URL',
         fieldTokenUrl: 'Token URL',
         fieldUserinfoUrl: 'Userinfo URL',

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -1875,6 +1875,7 @@ export const fr = {
         fieldDisplayName: 'Nom d\'affichage',
         fieldClientId: 'ID client',
         fieldClientSecret: 'Secret client',
+        fieldClientSecretHint: 'Un secret est configuré pour ce fournisseur ; laissez vide pour le conserver.',
         fieldAuthorizationUrl: 'URL d\'autorisation',
         fieldTokenUrl: 'URL du token',
         fieldUserinfoUrl: 'URL userinfo',

--- a/frontend/src/i18n/locales/it.ts
+++ b/frontend/src/i18n/locales/it.ts
@@ -1875,6 +1875,7 @@ export const it = {
         fieldDisplayName: 'Nome visualizzato',
         fieldClientId: 'Client ID',
         fieldClientSecret: 'Client Secret',
+        fieldClientSecretHint: 'È configurato un segreto per questo provider; lascia vuoto per mantenerlo.',
         fieldAuthorizationUrl: 'URL di autorizzazione',
         fieldTokenUrl: 'URL del token',
         fieldUserinfoUrl: 'URL userinfo',

--- a/frontend/src/pages/AdminSystemSettingsPage.tsx
+++ b/frontend/src/pages/AdminSystemSettingsPage.tsx
@@ -170,7 +170,7 @@ export function AdminSystemSettingsPage() {
             name: provider.name,
             display_name: provider.display_name,
             client_id: provider.client_id,
-            client_secret: provider.client_secret,
+            client_secret: '',
             authorization_url: provider.authorization_url,
             token_url: provider.token_url,
             userinfo_url: provider.userinfo_url,
@@ -205,11 +205,15 @@ export function AdminSystemSettingsPage() {
     function submitOAuthForm(event: FormEvent<HTMLFormElement>) {
         event.preventDefault()
         setOauthFormError(null)
+        const payload = { ...oauthForm }
+        if (oauthEditTarget && !payload.client_secret) {
+            delete payload.client_secret
+        }
         if (oauthEditTarget) {
-            updateOAuthMutation.mutate({ id: oauthEditTarget.id, payload: oauthForm })
+            updateOAuthMutation.mutate({ id: oauthEditTarget.id, payload })
             return
         }
-        createOAuthMutation.mutate(oauthForm)
+        createOAuthMutation.mutate(payload)
     }
 
     function confirmDeleteOAuthProvider(provider: OAuthProviderConfig) {
@@ -510,7 +514,10 @@ export function AdminSystemSettingsPage() {
 
                     <label>
                         <span>{t('adminOAuth.fieldClientSecret')}</span>
-                        <input type="password" name="client_secret" value={oauthForm.client_secret} onChange={handleOAuthChange} required autoComplete="new-password" />
+                        <input type="password" name="client_secret" value={oauthForm.client_secret} onChange={handleOAuthChange} required={!oauthEditTarget} autoComplete="new-password" />
+                        {oauthEditTarget && oauthEditTarget.has_client_secret && (
+                            <small className="muted">{t('adminOAuth.fieldClientSecretHint')}</small>
+                        )}
                     </label>
 
                     <label>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -151,7 +151,7 @@ export interface OAuthProvider {
 
 export interface OAuthProviderConfig extends OAuthProvider {
     client_id: string
-    client_secret: string
+    has_client_secret: boolean
     authorization_url: string
     token_url: string
     userinfo_url: string
@@ -165,7 +165,7 @@ export interface OAuthProviderConfigInput {
     name: string
     display_name: string
     client_id: string
-    client_secret: string
+    client_secret?: string
     authorization_url: string
     token_url: string
     userinfo_url: string


### PR DESCRIPTION
## Summary
The admin provider CRUD serializer returned client_secret in every response,
and the system-settings OAuth tab loaded it into React state for editing —
exposing the secret to XSS, browser extensions, screen sharing, and response
logging. The secret is now write-only: responses report has_client_secret,
create without a secret is refused (400), and a blank secret on update keeps
the stored value. The edit form shows the field blank with a hint and omits
the key from the PATCH payload.

## Linked spec
- Spec: docs/specs/2026-03-community-and-access.md (§16.1 test plan),
  docs/specs/2026-03-admin-governance-and-settings.md (§9.4 OAuth tab),
  docs/user-guide/14-admin-console.md (§OAuth)
- ADR: none — serializer contract change, no architecture decision

## Validation
- Backend tests run: python -m pytest -q (backend) — passed, incl. 5 new
  OAuthProviderSecretWriteOnlyTests in accounts/tests.py
- Frontend build run: npm run build — passed
- Frontend tests run: npm run test:unit (124 passed), npm run lint — clean
- Manual checks: none
- Screenshots: none

## Checklist
- [x] Spec updated/linked for larger or risky changes
- N/A: ADR — serializer contract change only
- [x] Backend and frontend updated together where API contracts changed