### PR TITLE
feat(accounts): rate-limit public auth endpoints

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,6 +42,15 @@ API_KEY_DEFAULT_EXPIRY_DAYS=365
 # Requests per key. Only key-authenticated traffic is throttled; browser
 # sessions are not.
 API_KEY_THROTTLE_RATE=600/hour
+# Per-IP rate limits for the public auth endpoints (login, refresh,
+# registration, email verification, OAuth login/token exchange). Cookie
+# sessions on the UI are not throttled by these.
+AUTH_LOGIN_THROTTLE_RATE=40/hour
+AUTH_REFRESH_THROTTLE_RATE=60/hour
+AUTH_REGISTER_THROTTLE_RATE=10/hour
+AUTH_VERIFY_THROTTLE_RATE=30/hour
+AUTH_OAUTH_INITIATE_THROTTLE_RATE=60/hour
+AUTH_OAUTH_EXCHANGE_THROTTLE_RATE=40/hour
 # How stale last_used_at may be before it is rewritten — bounds the write
 # amplification of key authentication.
 API_KEY_LAST_USED_RESOLUTION_MINUTES=5

--- a/backend/accounts/test_throttling.py
+++ b/backend/accounts/test_throttling.py
@@ -1,0 +1,113 @@
+"""Rate limits on the public auth endpoints.
+
+Each public auth write endpoint carries a per-IP budget. The rest of the
+suite runs with these rates disabled (``settings_test``); these tests
+patch the rates onto the throttle classes, because DRF snapshots
+``DEFAULT_THROTTLE_RATES`` onto ``SimpleRateThrottle`` at import time and
+``override_settings`` cannot reach it.
+"""
+
+from unittest import mock
+
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from .throttling import (
+    AuthLoginThrottle,
+    AuthOAuthExchangeThrottle,
+    AuthOAuthInitiateThrottle,
+    AuthRefreshThrottle,
+    AuthRegisterThrottle,
+    AuthVerifyThrottle,
+)
+
+LOGIN = "/api/v1/auth/token/"
+REFRESH = "/api/v1/auth/token/refresh/"
+REGISTER = "/api/v1/auth/register/"
+VERIFY = "/api/v1/auth/verify-email/"
+OAUTH_INITIATE = "/api/v1/auth/oauth/login/bogus-provider/"
+OAUTH_EXCHANGE = "/api/v1/auth/oauth/token-exchange/"
+
+
+@mock.patch.object(AuthLoginThrottle, "THROTTLE_RATES", {"auth_login": "3/hour"})
+@mock.patch.object(AuthRefreshThrottle, "THROTTLE_RATES", {"auth_refresh": "3/hour"})
+@mock.patch.object(AuthRegisterThrottle, "THROTTLE_RATES", {"auth_register": "3/hour"})
+@mock.patch.object(AuthVerifyThrottle, "THROTTLE_RATES", {"auth_verify": "3/hour"})
+@mock.patch.object(AuthOAuthInitiateThrottle, "THROTTLE_RATES", {"auth_oauth_initiate": "3/hour"})
+@mock.patch.object(AuthOAuthExchangeThrottle, "THROTTLE_RATES", {"auth_oauth_exchange": "3/hour"})
+class AuthEndpointThrottleTests(TestCase):
+    """Each public auth endpoint is capped per client IP."""
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_login_past_its_budget_gets_429(self):
+        for _ in range(3):
+            response = self.client.post(
+                LOGIN, {"username": "nobody", "password": "wrong"}, format="json"
+            )
+            self.assertNotEqual(response.status_code, 429)
+        response = self.client.post(
+            LOGIN, {"username": "nobody", "password": "wrong"}, format="json"
+        )
+        self.assertEqual(response.status_code, 429)
+
+    def test_refresh_past_its_budget_gets_429(self):
+        for _ in range(3):
+            response = self.client.post(REFRESH, format="json")
+            self.assertNotEqual(response.status_code, 429)
+        self.assertEqual(self.client.post(REFRESH, format="json").status_code, 429)
+
+    def test_register_past_its_budget_gets_429(self):
+        for i in range(3):
+            response = self.client.post(
+                REGISTER, {"email": f"spam{i}@example.com"}, format="json"
+            )
+            self.assertNotEqual(response.status_code, 429)
+        self.assertEqual(
+            self.client.post(REGISTER, {"email": "spam3@example.com"}, format="json").status_code,
+            429,
+        )
+
+    def test_verify_email_past_its_budget_gets_429(self):
+        for _ in range(3):
+            response = self.client.post(VERIFY, {"token": "bogus"}, format="json")
+            self.assertNotEqual(response.status_code, 429)
+        self.assertEqual(
+            self.client.post(VERIFY, {"token": "bogus"}, format="json").status_code,
+            429,
+        )
+
+    def test_oauth_login_initiate_past_its_budget_gets_429(self):
+        for _ in range(3):
+            response = self.client.post(OAUTH_INITIATE, format="json")
+            self.assertNotEqual(response.status_code, 429)
+        self.assertEqual(self.client.post(OAUTH_INITIATE, format="json").status_code, 429)
+
+    def test_oauth_token_exchange_past_its_budget_gets_429(self):
+        for _ in range(3):
+            response = self.client.post(OAUTH_EXCHANGE, {"code": "bogus"}, format="json")
+            self.assertNotEqual(response.status_code, 429)
+        self.assertEqual(
+            self.client.post(OAUTH_EXCHANGE, {"code": "bogus"}, format="json").status_code,
+            429,
+        )
+
+    def test_each_endpoint_has_its_own_budget(self):
+        for _ in range(4):
+            self.client.post(LOGIN, {"username": "nobody", "password": "wrong"}, format="json")
+        self.assertEqual(
+            self.client.post(LOGIN, {"username": "nobody", "password": "wrong"}, format="json").status_code,
+            429,
+        )
+        # Exhausting login must not cost refresh or registration their budgets.
+        self.assertNotEqual(self.client.post(REFRESH, format="json").status_code, 429)
+        self.assertNotEqual(
+            self.client.post(REGISTER, {"email": "fresh@example.com"}, format="json").status_code,
+            429,
+        )

--- a/backend/accounts/throttling.py
+++ b/backend/accounts/throttling.py
@@ -22,3 +22,40 @@ class ApiKeyRateThrottle(SimpleRateThrottle):
         if not isinstance(api_key, ApiKey):
             return None
         return self.cache_format % {"scope": self.scope, "ident": str(api_key.pk)}
+
+
+class AuthRateThrottle(SimpleRateThrottle):
+    """Per-IP rate limit for public auth endpoints.
+
+    Login, refresh, registration and email verification are the only endpoints
+    a stranger can hit without any credential, so each gets its own budget
+    keyed by client IP. Each endpoint uses a dedicated subclass so budgets
+    never share a counter.
+    """
+
+    def get_cache_key(self, request, view):
+        return self.cache_format % {"scope": self.scope, "ident": self.get_ident(request)}
+
+
+class AuthLoginThrottle(AuthRateThrottle):
+    scope = "auth_login"
+
+
+class AuthRefreshThrottle(AuthRateThrottle):
+    scope = "auth_refresh"
+
+
+class AuthRegisterThrottle(AuthRateThrottle):
+    scope = "auth_register"
+
+
+class AuthVerifyThrottle(AuthRateThrottle):
+    scope = "auth_verify"
+
+
+class AuthOAuthInitiateThrottle(AuthRateThrottle):
+    scope = "auth_oauth_initiate"
+
+
+class AuthOAuthExchangeThrottle(AuthRateThrottle):
+    scope = "auth_oauth_exchange"

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,5 +1,5 @@
 from rest_framework import generics, status
-from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.decorators import api_view, authentication_classes, permission_classes, throttle_classes
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework.exceptions import PermissionDenied, ValidationError
@@ -35,6 +35,7 @@ from .cookies import (
     set_auth_cookies,
 )
 from .permissions import IsAdmin
+from .throttling import AuthLoginThrottle, AuthRefreshThrottle, AuthRegisterThrottle, AuthVerifyThrottle
 from audit.models import AuditActionCategory, AuditEventStatus
 from audit.mixins import AuditedUpdateMixin
 from audit.services import build_diff, record_audit_event
@@ -44,6 +45,7 @@ logger = logging.getLogger(__name__)
 class CustomTokenObtainPairView(TokenObtainPairView):
     """JWT login — sets httpOnly cookies and returns a minimal JSON body."""
     serializer_class = CustomTokenObtainPairSerializer
+    throttle_classes = [AuthLoginThrottle]
 
     def post(self, request, *args, **kwargs):
         response = super().post(request, *args, **kwargs)
@@ -57,6 +59,7 @@ class CookieTokenRefreshView(APIView):
     """Token refresh that reads the refresh token from the httpOnly cookie
     and writes the new access (and rotated refresh) token back as cookies."""
     permission_classes = [AllowAny]
+    throttle_classes = [AuthRefreshThrottle]
 
     def post(self, request, *args, **kwargs):
         refresh_token = request.COOKIES.get(REFRESH_COOKIE)
@@ -432,6 +435,7 @@ def feature_flag_update(request, pk: int):
 
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([AuthRegisterThrottle])
 def register(request):
     """Self-registration: create a pending zev_owner account and send a verification email."""
     if not FeatureFlag.is_enabled(FeatureFlag.ZEV_SELF_REGISTRATION_ENABLED):
@@ -505,6 +509,7 @@ def register(request):
 
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([AuthVerifyThrottle])
 def verify_email(request):
     """Consume a one-time verification token and return JWT tokens to auto-login the user."""
     token_value = request.data.get("token", "").strip()

--- a/backend/accounts/views_oauth.py
+++ b/backend/accounts/views_oauth.py
@@ -21,7 +21,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.text import slugify
 from rest_framework import generics, status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -30,6 +30,7 @@ from audit.models import AuditActionCategory, AuditEventStatus
 from audit.services import build_diff, record_audit_event
 
 from .cookies import set_auth_cookies
+from .throttling import AuthOAuthExchangeThrottle, AuthOAuthInitiateThrottle
 from .models import (
     OAuthExchangeCode,
     OAuthProvider,
@@ -255,6 +256,7 @@ def oauth_providers_public(request):
 
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([AuthOAuthInitiateThrottle])
 def oauth_login_initiate(request, provider_slug: str):
     """Return the provider authorization URL for a login flow."""
     provider = get_object_or_404(OAuthProvider, name=provider_slug, enabled=True)
@@ -484,6 +486,7 @@ def oauth_callback(request, provider_slug: str):
 
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([AuthOAuthExchangeThrottle])
 def oauth_token_exchange(request):
     """
     Exchange a short-lived OAuth exchange code for JWT tokens.

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -139,6 +139,13 @@ REST_FRAMEWORK = {
         # Only applies to key-authenticated requests; cookie sessions return a
         # null cache key and are not throttled.
         "api_key": env("API_KEY_THROTTLE_RATE", default="600/hour"),
+        # Per-IP budgets for the public auth endpoints (accounts.throttling).
+        "auth_login": env("AUTH_LOGIN_THROTTLE_RATE", default="40/hour"),
+        "auth_refresh": env("AUTH_REFRESH_THROTTLE_RATE", default="60/hour"),
+        "auth_register": env("AUTH_REGISTER_THROTTLE_RATE", default="10/hour"),
+        "auth_verify": env("AUTH_VERIFY_THROTTLE_RATE", default="30/hour"),
+        "auth_oauth_initiate": env("AUTH_OAUTH_INITIATE_THROTTLE_RATE", default="60/hour"),
+        "auth_oauth_exchange": env("AUTH_OAUTH_EXCHANGE_THROTTLE_RATE", default="40/hour"),
     },
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",

--- a/backend/config/settings_test.py
+++ b/backend/config/settings_test.py
@@ -24,4 +24,15 @@ CACHES = {
 # that reuses one API key would start failing once it crossed the hourly limit —
 # in whichever test happened to be the 601st. Tests that exercise throttling
 # override the rate themselves.
-REST_FRAMEWORK = {**REST_FRAMEWORK, "DEFAULT_THROTTLE_RATES": {"api_key": None}}  # noqa: F405
+REST_FRAMEWORK = {
+    **REST_FRAMEWORK,  # noqa: F405
+    "DEFAULT_THROTTLE_RATES": {
+        "api_key": None,
+        "auth_login": None,
+        "auth_refresh": None,
+        "auth_register": None,
+        "auth_verify": None,
+        "auth_oauth_initiate": None,
+        "auth_oauth_exchange": None,
+    },
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -283,6 +283,6 @@ PVshare Cockpit is a closed, subscription-based SaaS (CHF ~30/participant/year) 
 | Observability — structured application logging and metrics endpoint | `idea` | `medium` | No Prometheus metrics or structured log format today |
 | End-to-end test suite (Playwright or similar) | `idea` | `medium` | Playwright is used for automated user-guide screenshots; no interactive end-to-end coverage of user flows yet |
 | Frontend component-level unit tests | `shipped` | — | `npm run test:unit` (Vitest) covers API helpers, reducers and page-level logic |
-| Rate limiting on sensitive API endpoints | `idea` | `medium` | Auth and import endpoints have no rate limiting today |
+| Rate limiting on sensitive API endpoints | `partial` | `medium` | Auth endpoints (login, refresh, register, verify-email, OAuth login/exchange) are throttled per IP; import endpoints are not |
 | Automated security dependency scanning (Dependabot / Snyk) | `idea` | `low` | Renovate is configured for updates; no security-focused CVE scanning |
 | Multi-region or multi-instance deployment guidance | `deferred` | — | Single-instance model assumed; stateful session and Celery design would need review |

--- a/docs/specs/2026-03-community-and-access.md
+++ b/docs/specs/2026-03-community-and-access.md
@@ -368,6 +368,31 @@ re-fetch `/auth/me/`.
 not impersonating and the current path is not `/account`, redirect to
 `/account` with `state.forcePasswordChange = true`.
 
+### 5.9 Auth endpoint throttling
+
+Every public auth *write* endpoint carries a per-IP rate limit
+(`AuthRateThrottle` subclasses in `accounts/throttling.py`), so a stranger who
+can hit them without any credential is bounded even when the interactive UI's
+cookie sessions stay unthrottled:
+
+| Endpoint | Throttle class | Scope | Default rate (env override) |
+|---|---|---|---|
+| `POST /api/v1/auth/token/` | `AuthLoginThrottle` | `auth_login` | `40/hour` (`AUTH_LOGIN_THROTTLE_RATE`) |
+| `POST /api/v1/auth/token/refresh/` | `AuthRefreshThrottle` | `auth_refresh` | `60/hour` (`AUTH_REFRESH_THROTTLE_RATE`) |
+| `POST /api/v1/auth/register/` | `AuthRegisterThrottle` | `auth_register` | `10/hour` (`AUTH_REGISTER_THROTTLE_RATE`) |
+| `POST /api/v1/auth/verify-email/` | `AuthVerifyThrottle` | `auth_verify` | `30/hour` (`AUTH_VERIFY_THROTTLE_RATE`) |
+| `POST /api/v1/auth/oauth/login/<provider_slug>/` | `AuthOAuthInitiateThrottle` | `auth_oauth_initiate` | `60/hour` (`AUTH_OAUTH_INITIATE_THROTTLE_RATE`) |
+| `POST /api/v1/auth/oauth/token-exchange/` | `AuthOAuthExchangeThrottle` | `auth_oauth_exchange` | `40/hour` (`AUTH_OAUTH_EXCHANGE_THROTTLE_RATE`) |
+
+Rates live in `REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]`. A request over the
+budget is refused with `429 Too Many Requests` before the view body runs. The
+test settings (`config/settings_test.py`) disable all scopes so the rest of the
+suite is not throttled.
+
+Limits are keyed by `REMOTE_ADDR`. Behind a reverse proxy, `NUM_PROXIES` must
+be set and the ingress must overwrite `X-Forwarded-For`, otherwise every client
+shares one IP bucket (a whole-office lockout at 10 registrations/hour).
+
 ---
 
 ## 6. User management (admin)
@@ -823,6 +848,9 @@ interface ParticipantAccountCreateResult { participant: Participant; account: Us
 
 ### 16.1 Backend test classes
 
+Line counts are not tracked here — they drift with every change. The inventory
+lists the test classes per module (test counts are the `test_*` methods).
+
 **`accounts/tests.py`** (13 test classes):
 
 | Class | Tests | Description |
@@ -841,16 +869,44 @@ interface ParticipantAccountCreateResult { participant: Participant; account: Us
 | `RbacEndpointMatrixTests` | 6 | Full list/create/update/action-delete/unauthenticated matrix across all endpoints |
 | `OAuthTokenCleanupTaskTests` | 1 | Token cleanup task keeps active and removes expired entries |
 
-**`zev/tests.py`** (554 lines, 6 test classes):
+**Other `accounts/` test modules:**
+
+| Module | Classes | Tests | Coverage |
+|---|---|---|---|
+| `test_api_keys.py` | 10 | 81 | Generation, hashing, auth, read-only keys, scope deny-list, audit, throttling, CRUD, admin management |
+| `test_oauth.py` | 9 | 50 | Provider listing, initiate, callback guards/redirects, link flow, social accounts, audit |
+| `test_cookie_oauth.py` | — (6 module-level test functions) | 6 | Refresh/logout cookie handling; token exchange sets cookies and consumes codes |
+| `test_impersonation.py` | 5 | 21 | Permissions, audit, cookie round-trip, stop-impersonation |
+| `test_throttling.py` | 1 | 7 | Per-IP 429 boundaries for all six public auth write endpoints; budgets are independent |
+
+**`zev/tests.py`** (14 test classes):
 
 | Class | Tests | Description |
 |---|---|---|
+| `ZevPaymentTermTests` | 4 | Payment term default (30 days), range validation, API accept/reject |
 | `ParticipantEndpointRestrictionTests` | 7 | Participant cannot access ZEV/participant lists; can list own metering points; cannot create/update/delete metering points; cannot access assignments |
 | `ZevCreationWizardTests` | 2 | Non-admin cannot create ZEV; admin wizard creates ZEV + owner + participant + assignments |
 | `ParticipantAccountLifecycleTests` | 3 | Create participant auto-creates account with initial password; update saves contact details; invitation resets password and sends email |
+| `AdminCanEditOwnerParticipantTests` | 2 | Admin can edit the owner participant; owner cannot edit own record |
 | `ParticipantAccountLinkingTests` | 5 | Admin can link/unlink accounts; rejects double-linking; admin can create-and-link; non-admin cannot link/create |
 | `ZevOwnerRoleSyncTests` | 1 | Owner transfer promotes new owner, demotes previous |
 | `MeteringPointAssignmentValidationTests` | 9 | Unique assignment, no overlaps, historical OK, open-end blocks future, dates within participant window, self-update OK |
+| `AssignmentSaveOverlapGuardTests` | 5 | Overlap guard on save path |
+| `SeedDemoAssignmentReseedTests` | 1 | Demo seed re-creates assignments |
+| `MeteringPointReadingsDeletionTests` | 4 | Delete-readings action variants |
+| `NextInvoiceNumberTests` | 3 | Invoice number allocation |
+| `SeedDemoPeriodHelpersTests` | 6 | Demo seed period helpers |
+| `SeedDemoTariffVersionTests` | 10 | Demo seed tariff versioning |
+
+**Other `zev/` test modules:**
+
+| Module | Classes | Tests | Coverage |
+|---|---|---|---|
+| `test_scoping.py` | 1 | 4 | `ZevScopedQuerySetMixin` read scoping by role |
+| `test_write_scoping.py` | 4 | 17 | Write scoping: foreign create refused, move-via-PATCH refused, legit writes and admin bypass still work, audit retained |
+| `test_zev_id_filter.py` | 5 | 15 | `?zev_id=` narrowing on list endpoints |
+| `test_transfer.py` | 6 | 66 | Whole-ZEV archive shape, round-trip, rejected archives, schema parity, transfer endpoints |
+| `test_geocoding.py` | 4 | 19 | Building footprint cache, warm tasks, trigger-on-save |
 
 ### 16.2 Frontend
 

--- a/docs/user-guide/12-troubleshooting.md
+++ b/docs/user-guide/12-troubleshooting.md
@@ -50,6 +50,7 @@ docker compose logs
 | "Invalid credentials" | Wrong username/password | Check [demo accounts](01-getting-started.md#demo-accounts) |
 | "Account not activated" | User never received invitation | Reset password via login page |
 | "Permission denied" | User role is too restrictive | Ask admin to update your role |
+| "429 Too many requests" | Login/registration attempts exceeded the per-IP rate limit | Wait a while (check the `Retry-After` header) before trying again |
 
 ### Forgot Password
 

--- a/docs/user-guide/16-api-keys.md
+++ b/docs/user-guide/16-api-keys.md
@@ -117,7 +117,9 @@ Key-authenticated requests are limited to **600 requests per hour per key**
 returns `429 Request was throttled.`
 
 The limit is per key, not per account, so one busy script cannot starve another.
-Browser sessions are not throttled.
+Browser sessions are not throttled by this limit; the login, registration,
+refresh, verification and OAuth login/exchange endpoints carry their own
+per-IP limits (see `AUTH_*_THROTTLE_RATE` settings).
 
 Rejected responses normally carry a `Retry-After` header with the seconds to
 wait — but **not always**: once you are well past the limit the header is


### PR DESCRIPTION
## Summary

Rate-limit the six public auth write endpoints that a stranger can hit
without any credential, each with its own per-IP budget:

| Endpoint | Throttle scope | Default rate |
|---|---|---|
| POST /api/v1/auth/token/ | auth_login | 40/hour |
| POST /api/v1/auth/token/refresh/ | auth_refresh | 60/hour |
| POST /api/v1/auth/register/ | auth_register | 10/hour |
| POST /api/v1/auth/verify-email/ | auth_verify | 30/hour |
| POST /api/v1/auth/oauth/login/<provider_slug>/ | auth_oauth_initiate | 60/hour |
| POST /api/v1/auth/oauth/token-exchange/ | auth_oauth_exchange | 40/hour |

Requests over the budget are refused with 429 before the view body runs.
Rates are configurable per scope via AUTH_*_THROTTLE_RATE env vars and are
disabled in the test settings, so the rest of the suite is not throttled.
Cookie sessions on the interactive UI stay unthrottled, and API-key traffic
keeps its existing key-scoped limit. The spec notes that deployments behind a
reverse proxy must set NUM_PROXIES so all clients do not share one IP bucket.

Adds per-IP 429 boundary tests for all six endpoints in test_throttling.py,
including that each endpoint's budget is independent.

## Linked spec
- Spec: docs/specs/2026-03-community-and-access.md — §5.9 (endpoint table + proxy
  caveat) and §16.1 (test inventory) updated
- ADR: none

## Validation
- Backend tests run: python -m pytest -q -> 1042 passed, 202 subtests passed
- Frontend build run: not run (no frontend changes)
- Frontend tests run: not run (no frontend changes)
- Manual checks: none
- Screenshots: N/A (no frontend changes)

## Checklist
- [x] Spec updated: 2026-03-community-and-access.md §5.9 + §16.1
- N/A: ADR (no architecture decision changed)
- N/A: frontend (no API response shape change; backend-only)