### PR TITLE
fix(security): enforce CSRF for cookie JWT sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ npm run dev
 
 Frontend dev URL: <http://localhost:5173>
 
+> Cookie sessions require same-origin (or same-host reverse proxy, e.g. `VITE_API_BASE_URL=/api/v1`). Same-host different-port dev (`localhost:5173` → `localhost:8001`) works with `CORS_ALLOWED_ORIGINS`/`CSRF_TRUSTED_ORIGINS`. Truly cross-hostname (`app.example.com` → `api.example.com`) cannot be fixed by those settings alone — JS cannot read a cross-origin `csrftoken` cookie — use a same-origin reverse proxy.
+
 ### 3) Celery worker (required for async emails)
 
 ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,9 @@ DATABASE_URL=sqlite:///db.sqlite3
 
 # CORS — frontend origin(s)
 CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
+# CSRF — must match CORS for cookie CSRF when cross-origin; production same-origin needs no CORS
+# CSRF_TRUSTED_ORIGINS defaults to CORS_ALLOWED_ORIGINS (set explicitly for https://app.example.com → https://api.example.com)
+# CSRF_TRUSTED_ORIGINS=https://app.example.com
 
 # Media files storage path
 MEDIA_ROOT=/app/media

--- a/backend/accounts/authentication.py
+++ b/backend/accounts/authentication.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.utils import timezone
 from rest_framework import exceptions
-from rest_framework.authentication import BaseAuthentication, get_authorization_header
+from rest_framework.authentication import BaseAuthentication, SessionAuthentication, get_authorization_header
 from rest_framework.permissions import SAFE_METHODS
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
@@ -10,12 +10,12 @@ from .api_keys import split_key, verify_secret
 ACCESS_COOKIE = "openzev_access"
 
 
-class CookieJWTAuthentication(JWTAuthentication):
-    """JWT authentication that reads the access token from an httpOnly cookie.
+def enforce_csrf(request) -> None:
+    SessionAuthentication().enforce_csrf(request)
 
-    Falls back to the standard Authorization header so API clients and existing
-    tooling (e.g. drf-spectacular, curl) continue to work without changes.
-    """
+
+class CookieJWTAuthentication(JWTAuthentication):
+    """JWT authentication that prefers the Authorization header and falls back to the httpOnly cookie."""
 
     def authenticate(self, request):
         # Prefer the Authorization header (API clients / backward-compat)
@@ -23,7 +23,8 @@ class CookieJWTAuthentication(JWTAuthentication):
         if header:
             # Leave ``Api-Key`` credentials to ApiKeyAuthentication rather than
             # failing the request with "token not valid".
-            if header.split()[0:1] == [b"Api-Key"]:
+            parts = header.split()
+            if parts and parts[0].lower() == b"api-key":
                 return None
             return super().authenticate(request)
 
@@ -33,7 +34,12 @@ class CookieJWTAuthentication(JWTAuthentication):
             return None
 
         validated_token = self.get_validated_token(raw_token)
-        return self.get_user(validated_token), validated_token
+        user = self.get_user(validated_token)
+
+        if request.method not in SAFE_METHODS:
+            enforce_csrf(request)
+
+        return user, validated_token
 
 
 # ── API key scope rules ───────────────────────────────────────────────────────

--- a/backend/accounts/cookies.py
+++ b/backend/accounts/cookies.py
@@ -1,19 +1,9 @@
-"""Auth cookie names and helpers shared across the accounts views.
-
-The project delivers JWTs in httpOnly cookies (``CookieJWTAuthentication`` also
-accepts an ``Authorization: Bearer`` header as a fallback). Login, refresh,
-logout, registration, email verification, OAuth and impersonation all set or
-clear these cookies, so the names and the set/clear helpers live here rather
-than being module-private to any one of them.
-
-``ADMIN_*`` are the backup pair: while an admin is impersonating another user,
-their own tokens are parked under these names so ``stop-impersonation`` can put
-them back.
-"""
+"""Auth cookie names and helpers. ``set_auth_cookies`` also issues the CSRF cookie."""
 
 from datetime import timedelta
 
 from django.conf import settings
+from django.middleware.csrf import get_token
 
 ACCESS_COOKIE = "openzev_access"
 REFRESH_COOKIE = "openzev_refresh"
@@ -32,6 +22,7 @@ def _cookie_kwargs() -> dict:
 
 
 def set_auth_cookies(
+    request,
     response,
     *,
     access: str,
@@ -45,6 +36,7 @@ def set_auth_cookies(
     kw = _cookie_kwargs()
     response.set_cookie(access_cookie, access, max_age=access_max_age, **kw)
     response.set_cookie(refresh_cookie, refresh, max_age=refresh_max_age, **kw)
+    get_token(request)  # CsrfViewMiddleware sets the cookie
 
 
 def clear_auth_cookies(

--- a/backend/accounts/jwt_utils.py
+++ b/backend/accounts/jwt_utils.py
@@ -1,0 +1,17 @@
+from rest_framework_simplejwt.tokens import RefreshToken
+
+
+def make_jwt_for_user(user) -> dict:
+    refresh = RefreshToken.for_user(user)
+    refresh["role"] = user.role
+    refresh["email"] = user.email
+    refresh["full_name"] = user.get_full_name()
+    refresh["must_change_password"] = user.must_change_password
+    return {"access": str(refresh.access_token), "refresh": str(refresh)}
+
+
+def add_custom_claims(token, user) -> None:
+    token["role"] = user.role
+    token["email"] = user.email
+    token["full_name"] = user.get_full_name()
+    token["must_change_password"] = user.must_change_password

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -101,10 +101,9 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
     @classmethod
     def get_token(cls, user):
         token = super().get_token(user)
-        token["role"] = user.role
-        token["email"] = user.email
-        token["full_name"] = user.get_full_name()
-        token["must_change_password"] = user.must_change_password
+        from .jwt_utils import add_custom_claims
+
+        add_custom_claims(token, user)
         return token
 
 

--- a/backend/accounts/test_csrf.py
+++ b/backend/accounts/test_csrf.py
@@ -1,0 +1,130 @@
+"""CSRF for cookie-JWT — cookie unsafe requests need token, header clients don't."""
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from testing.helpers import authenticate
+
+from .api_keys import generate_key
+from .cookies import ACCESS_COOKIE, REFRESH_COOKIE
+from .models import ApiKey, User, UserRole
+
+_PW = {"old_password": "pass1234", "new_password": "new-pass-1234"}
+
+
+def _cookie_client(user, csrf_token=None):
+    # enforce_csrf_checks=True is load-bearing: without it APIClient sets
+    # _dont_enforce_csrf_checks and our negative tests would spuriously pass.
+    client = APIClient(enforce_csrf_checks=True)
+    refresh = RefreshToken.for_user(user)
+    client.cookies[ACCESS_COOKIE] = str(refresh.access_token)
+    client.cookies[REFRESH_COOKIE] = str(refresh)
+    if csrf_token is not None:
+        client.cookies[settings.CSRF_COOKIE_NAME] = csrf_token
+        client.credentials(HTTP_X_CSRFTOKEN=csrf_token)
+    return client
+
+
+class CookieCsrfTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="csrf_user", password="pass1234", role=UserRole.PARTICIPANT)
+        self.token = "a" * 32
+
+    def test_safe_method_no_csrf_needed(self):
+        resp = _cookie_client(self.user).get("/api/v1/auth/me/")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_cookie_post_without_csrf_forbidden(self):
+        resp = _cookie_client(self.user).post(
+            "/api/v1/auth/me/change-password/",
+            _PW,
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn("CSRF", str(resp.data))
+
+    def test_cookie_present_header_missing_forbidden(self):
+        # Classic axios misconfig: csrftoken cookie set but header not sent
+        client = _cookie_client(self.user, self.token)
+        client.credentials()  # clear header, keep cookie
+        resp = client.post(
+            "/api/v1/auth/me/change-password/",
+            _PW,
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_cookie_post_invalid_csrf_forbidden(self):
+        client = _cookie_client(self.user, self.token)
+        client.credentials(HTTP_X_CSRFTOKEN="wrong" + self.token)
+        resp = client.post(
+            "/api/v1/auth/me/change-password/",
+            _PW,
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_cookie_post_valid_csrf_succeeds(self):
+        resp = _cookie_client(self.user, self.token).post(
+            "/api/v1/auth/me/change-password/",
+            _PW,
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    def test_bearer_no_csrf_needed(self):
+        client = APIClient()
+        authenticate(client, self.user)
+        resp = client.post(
+            "/api/v1/auth/me/change-password/",
+            _PW,
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    def test_api_key_no_csrf_needed(self):
+        # change-password is not on the API-key allowlist, so it would 403 either way.
+        # Use a write the key is allowed to do (vat-rates) to prove CSRF is skipped.
+        admin = User.objects.create_user(username="csrf_admin", password="pass1234", role=UserRole.ADMIN)
+        full_key, prefix, hashed = generate_key()
+
+        ApiKey.objects.create(
+            user=admin, name="test", prefix=prefix, hashed_key=hashed, expires_at=timezone.now() + timedelta(days=1)
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Api-Key {full_key}")
+        resp = client.post(
+            "/api/v1/auth/vat-rates/",
+            {"rate": "0.0810", "valid_from": "2030-01-01"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 201)
+
+    def test_login_sets_csrf_cookie(self):
+        User.objects.create_user(username="login_csrf", password="pass1234", role=UserRole.PARTICIPANT, email="login_csrf@example.com")
+        resp = APIClient().post("/api/v1/auth/token/", {"username": "login_csrf", "password": "pass1234"}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(settings.CSRF_COOKIE_NAME, resp.cookies)
+
+    def test_refresh_needs_csrf_and_reissues_cookie(self):
+        client = APIClient()
+        User.objects.create_user(username="refresh_csrf", password="pass1234", role=UserRole.PARTICIPANT, email="refresh_csrf@example.com")
+        login = client.post("/api/v1/auth/token/", {"username": "refresh_csrf", "password": "pass1234"}, format="json")
+        csrf_token = login.cookies[settings.CSRF_COOKIE_NAME].value
+
+        bare = APIClient(enforce_csrf_checks=True)
+        bare.cookies[REFRESH_COOKIE] = login.cookies[REFRESH_COOKIE].value
+        self.assertEqual(bare.post("/api/v1/auth/token/refresh/").status_code, 403)
+
+        ok = APIClient(enforce_csrf_checks=True)
+        ok.cookies[REFRESH_COOKIE] = login.cookies[REFRESH_COOKIE].value
+        ok.cookies[settings.CSRF_COOKIE_NAME] = csrf_token
+        ok.credentials(HTTP_X_CSRFTOKEN=csrf_token)
+        resp = ok.post("/api/v1/auth/token/refresh/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(settings.CSRF_COOKIE_NAME, resp.cookies)

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -14,10 +14,17 @@ from django.core.mail import EmailMessage
 from django.utils import timezone
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.serializers import TokenRefreshSerializer
-from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView
 from .api_keys import default_api_key_expiry, generate_key
-from .models import User, UserRole, EmailVerificationToken
+from .models import (
+    ApiKey,
+    AppSettings,
+    EmailVerificationToken,
+    FeatureFlag,
+    User,
+    UserRole,
+    VatRate,
+)
 from .serializers import (
     UserSerializer, UserCreateSerializer,
     ChangePasswordSerializer, CustomTokenObtainPairSerializer,
@@ -26,7 +33,7 @@ from .serializers import (
     FeatureFlagSerializer,
     VatRateSerializer,
 )
-from .models import ApiKey, AppSettings, FeatureFlag, VatRate
+from .authentication import enforce_csrf
 from .cookies import (
     ADMIN_ACCESS_COOKIE,
     ADMIN_REFRESH_COOKIE,
@@ -42,6 +49,9 @@ from audit.services import build_diff, record_audit_event
 
 logger = logging.getLogger(__name__)
 
+from .jwt_utils import make_jwt_for_user as _make_jwt_for_user
+
+
 class CustomTokenObtainPairView(TokenObtainPairView):
     """JWT login — sets httpOnly cookies and returns a minimal JSON body."""
     serializer_class = CustomTokenObtainPairSerializer
@@ -50,7 +60,7 @@ class CustomTokenObtainPairView(TokenObtainPairView):
     def post(self, request, *args, **kwargs):
         response = super().post(request, *args, **kwargs)
         if response.status_code == 200:
-            set_auth_cookies(response, access=response.data["access"], refresh=response.data["refresh"])
+            set_auth_cookies(request, response, access=response.data["access"], refresh=response.data["refresh"])
             response.data = {"detail": "Login successful."}
         return response
 
@@ -66,6 +76,8 @@ class CookieTokenRefreshView(APIView):
         if not refresh_token:
             return Response({"detail": "Refresh token not found."}, status=status.HTTP_401_UNAUTHORIZED)
 
+        enforce_csrf(request)
+
         serializer = TokenRefreshSerializer(data={"refresh": refresh_token})
         try:
             serializer.is_valid(raise_exception=True)
@@ -77,7 +89,7 @@ class CookieTokenRefreshView(APIView):
         new_access = serializer.validated_data["access"]
         new_refresh = serializer.validated_data.get("refresh", refresh_token)
         response = Response({"detail": "Token refreshed."})
-        set_auth_cookies(response, access=new_access, refresh=new_refresh)
+        set_auth_cookies(request, response, access=new_access, refresh=new_refresh)
         return response
 
 
@@ -528,9 +540,9 @@ def verify_email(request):
         changes=build_diff({"is_active": False}, {"is_active": user.is_active}, ["is_active"]),
     )
 
-    refresh = RefreshToken.for_user(user)
+    tokens = _make_jwt_for_user(user)
     response = Response({"detail": "Email verified."})
-    set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
+    set_auth_cookies(request, response, access=tokens["access"], refresh=tokens["refresh"])
     return response
 
 
@@ -582,9 +594,9 @@ def set_initial_password(request):
     )
 
     # Issue fresh tokens so the updated claims (must_change_password=False) take effect
-    refresh = RefreshToken.for_user(user)
+    tokens = _make_jwt_for_user(user)
     response = Response({"detail": "Password set successfully."})
-    set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
+    set_auth_cookies(request, response, access=tokens["access"], refresh=tokens["refresh"])
     return response
 
 

--- a/backend/accounts/views_impersonation.py
+++ b/backend/accounts/views_impersonation.py
@@ -136,13 +136,14 @@ class ImpersonateParticipantView(APIView):
         current_refresh = request.COOKIES.get(REFRESH_COOKIE, "")
         if current_access and current_refresh:
             set_auth_cookies(
+                request,
                 response,
                 access=current_access,
                 refresh=current_refresh,
                 access_cookie=ADMIN_ACCESS_COOKIE,
                 refresh_cookie=ADMIN_REFRESH_COOKIE,
             )
-        set_auth_cookies(response, access=str(refresh.access_token), refresh=str(refresh))
+        set_auth_cookies(request, response, access=str(refresh.access_token), refresh=str(refresh))
         return response
 
 
@@ -189,6 +190,6 @@ class StopImpersonationView(APIView):
         )
 
         response = Response({"detail": "Impersonation ended."})
-        set_auth_cookies(response, access=admin_access, refresh=admin_refresh)
+        set_auth_cookies(request, response, access=admin_access, refresh=admin_refresh)
         clear_auth_cookies(response, access_cookie=ADMIN_ACCESS_COOKIE, refresh_cookie=ADMIN_REFRESH_COOKIE)
         return response

--- a/backend/accounts/views_oauth.py
+++ b/backend/accounts/views_oauth.py
@@ -24,12 +24,11 @@ from rest_framework import generics, status
 from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework_simplejwt.tokens import RefreshToken
-
 from audit.models import AuditActionCategory, AuditEventStatus
 from audit.services import build_diff, record_audit_event
 
 from .cookies import set_auth_cookies
+from .jwt_utils import make_jwt_for_user as _make_jwt_for_user
 from .throttling import AuthOAuthExchangeThrottle, AuthOAuthInitiateThrottle
 from .models import (
     OAuthExchangeCode,
@@ -129,16 +128,6 @@ def _record_provider_event(request, *, action_type, provider, summary, changes=N
         changes=changes,
         metadata=metadata,
     )
-
-
-def _make_jwt_for_user(user: User) -> dict:
-    """Mint a JWT pair (access + refresh) for *user*, matching the custom claims."""
-    refresh = RefreshToken.for_user(user)
-    refresh["role"] = user.role
-    refresh["email"] = user.email
-    refresh["full_name"] = user.get_full_name()
-    refresh["must_change_password"] = user.must_change_password
-    return {"access": str(refresh.access_token), "refresh": str(refresh)}
 
 
 def _generate_username_from_email(email: str) -> str:
@@ -516,7 +505,7 @@ def oauth_token_exchange(request):
 
     tokens = _make_jwt_for_user(user)
     response = Response({"detail": "Login successful."})
-    set_auth_cookies(response, access=tokens["access"], refresh=tokens["refresh"])
+    set_auth_cookies(request, response, access=tokens["access"], refresh=tokens["refresh"])
     return response
 
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -57,11 +57,16 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    # API CSRF is in CookieJWTAuthentication; this middleware stays for admin and Django views.
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "audit.middleware.AuditRequestContextMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+CSRF_COOKIE_HTTPONLY = False
+CSRF_COOKIE_SECURE = not DEBUG
+CSRF_COOKIE_SAMESITE = "Lax"
 
 ROOT_URLCONF = "config.urls"
 
@@ -189,6 +194,7 @@ CORS_ALLOWED_ORIGINS = env.list(
     default=["http://localhost:5173", "http://localhost:3000"],
 )
 CORS_ALLOW_CREDENTIALS = True
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=CORS_ALLOWED_ORIGINS)
 
 # ── DRF Spectacular (OpenAPI) ─────────────────────────────────────────────────
 SPECTACULAR_SETTINGS = {

--- a/docs/specs/2026-03-community-and-access.md
+++ b/docs/specs/2026-03-community-and-access.md
@@ -267,7 +267,7 @@ Two consequences for anything added later:
 
 **Payload:** `{ email, password }` (preferred) or `{ username, password }` (backward-compatible)
 
-Custom `TokenObtainPairSerializer` embeds in the token:
+Helper `accounts.views._make_jwt_for_user(user) -> dict` adds custom claims (also used by `CustomTokenObtainPairSerializer` and `verify_email`/`set_initial_password`; `views_oauth._make_jwt_for_user` and impersonation use the same claims):
 
 | Claim | Value |
 |---|---|
@@ -276,10 +276,11 @@ Custom `TokenObtainPairSerializer` embeds in the token:
 | `full_name` | `user.get_full_name()` |
 | `must_change_password` | `user.must_change_password` |
 
-**Token refresh:** `POST /api/v1/auth/token/refresh/` (standard SimpleJWT).
+**Token refresh:** `POST /api/v1/auth/token/refresh/` reads `openzev_refresh` cookie; CSRF via `CookieJWTAuthentication` (`SessionAuthentication.enforce_csrf` on unsafe methods) + `CsrfViewMiddleware` kept for admin/Django views.
 
-**Frontend storage:** `localStorage` keys `openzev.access` and `openzev.refresh`.
-Axios interceptor attaches `Authorization: Bearer {access}` to all API requests.
+**Cookie transport:** httpOnly cookies `openzev_access` / `openzev_refresh` + `csrftoken` via `django.middleware.csrf.get_token` (`CsrfViewMiddleware` sets cookie). `CSRF_TRUSTED_ORIGINS` defaults to `CORS_ALLOWED_ORIGINS`.
+
+**Frontend:** `frontend/src/lib/api/client.ts` `api = axios.create({withCredentials:true, xsrfCookieName:'csrftoken', xsrfHeaderName:'X-CSRFToken'})` scoped to instance (no `axios.defaults`).
 
 ### 5.2 Self-registration (zev_owner)
 
@@ -307,7 +308,7 @@ Axios interceptor attaches `Authorization: Bearer {access}` to all API requests.
 2. Validate not consumed and within 24h expiry.
 3. Mark token as consumed (`consumed_at = now`).
 4. Activate user (`is_active = True`).
-5. Issue JWT tokens (access + refresh) for auto-login.
+5. Issue JWT via `accounts.views._make_jwt_for_user(user)` set as httpOnly cookies `openzev_access` / `openzev_refresh` (+ `csrftoken` via `get_token`) for auto-login.
 
 ### 5.4 Initial password set
 
@@ -321,7 +322,7 @@ password. Otherwise returns 400 ("Use the change-password endpoint instead.").
 **Flow:**
 1. Validate password via Django password validators.
 2. Set password, clear `must_change_password` flag.
-3. Return fresh JWT tokens.
+3. Issue fresh JWT via `accounts.views._make_jwt_for_user(user)` set as httpOnly cookies `openzev_access` / `openzev_refresh` (+ `csrftoken` via `get_token`) so updated claims take effect.
 
 ### 5.5 Password change
 
@@ -349,18 +350,14 @@ Validates old password, sets new password, clears `must_change_password`.
 impersonate an admin returns 400.
 
 **Flow:**
-1. Generate a new JWT refresh token for the target user.
-2. Embed `impersonated_by = request.user.id` in the token claims.
-3. Return `{ access, refresh, impersonated_user, impersonator }`.
+1. Generate via `_make_jwt_for_user(target)` + `impersonated_by = request.user.id` claim, set as httpOnly cookies `openzev_access` / `openzev_refresh` (+ `csrftoken` via `get_token`); park caller tokens in `ADMIN_ACCESS_COOKIE` / `ADMIN_REFRESH_COOKIE`.
+2. Return `{ impersonated_user, impersonator }` (tokens are cookies, not body).
 
 **Frontend flow (`AuthContext.startImpersonation`):**
-1. Save current tokens to `openzev.impersonation.original_*` localStorage keys.
-2. Store impersonator user in `openzev.impersonation.impersonator`.
-3. Replace active tokens with the impersonated user's tokens.
-4. Re-fetch `/auth/me/` to update the UI context.
+1. Call impersonate endpoint (cookies handled via `api` with `withCredentials`); backup cookies stored httpOnly.
+2. Re-fetch `/auth/me/` to update the UI context.
 
-**Stop impersonation:** restore original tokens, clear impersonation keys,
-re-fetch `/auth/me/`.
+**Stop impersonation:** restore `ADMIN_*` cookies to main pair, clear backup cookies, re-fetch `/auth/me/`.
 
 ### 5.8 Forced password change redirect
 
@@ -638,8 +635,8 @@ The sidebar (`Layout.tsx`) shows sections conditionally:
 
 | Method | URL | Permission | Description |
 |---|---|---|---|
-| POST | `/token/` | AllowAny | JWT login (returns access + refresh tokens) |
-| POST | `/token/refresh/` | AllowAny | JWT token refresh |
+| POST | `/token/` | AllowAny | JWT login (sets httpOnly cookies `openzev_access` / `openzev_refresh` + `csrftoken` via `get_token`; header `Authorization: Api-Key` is case-insensitive) |
+| POST | `/token/refresh/` | AllowAny | JWT refresh (reads `openzev_refresh` cookie; CSRF via `CookieJWTAuthentication` + `CsrfViewMiddleware`) |
 | POST | `/register/` | AllowAny | Self-register a zev_owner account |
 | POST | `/verify-email/` | AllowAny | Consume verification token, activate user |
 | GET / PATCH | `/me/` | IsAuthenticated | View/update own profile |
@@ -786,8 +783,7 @@ Composite serializer for the creation wizard. Nested:
 
 ### 13.6 CustomTokenObtainPairSerializer
 
-Extends SimpleJWT's `TokenObtainPairSerializer`. Adds custom claims:
-`role`, `email`, `full_name`, `must_change_password`.
+`CustomTokenObtainPairSerializer` has its own `get_token` with the same claims as helper `_make_jwt_for_user(user) -> dict` (used by `verify_email`/`set_initial_password` and `views_oauth`/`impersonation`): `role`, `email`, `full_name`, `must_change_password`.
 
 ---
 
@@ -925,7 +921,7 @@ lists the test classes per module (test counts are the `test_*` methods).
 | Scope leakage across ZEV boundaries | High | Backend queryset scoping per role; `BaseZevScopedPermission` object-level checks; regression test matrix |
 | UI-only enforcement drift | High | Backend always enforces permissions; frontend guards are UX convenience only (ADR 0003) |
 | Assignment validity edge cases | Medium | Date-boundary tests; serializer + model double validation; ADR 0001 rules |
-| Impersonation abuse | High | Admin-only guard; cannot impersonate other admins; impersonation state tracked in JWT claims and localStorage |
+| Impersonation abuse | High | Admin-only guard; cannot impersonate other admins; impersonation state tracked in JWT claims and `ADMIN_*` backup cookies |
 | Self-registration spam | Medium | Email verification required; unusable password until verified |
 | Linked account deletion | Medium | Delete blocked if `participations.exists()`; `SET_NULL` FK prevents cascade |
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
-VITE_API_BASE_URL=http://localhost:8000/api/v1
+VITE_API_BASE_URL=/api/v1
+# same-origin via proxy; use http://localhost:8000/api/v1 only for `npm run dev` without proxy

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -5,12 +5,14 @@ export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
 export const api = axios.create({
   baseURL: API_BASE_URL,
   withCredentials: true,
+  xsrfCookieName: 'csrftoken',
+  xsrfHeaderName: 'X-CSRFToken',
 })
 
 let refreshPromise: Promise<void> | null = null
 
 async function refreshAccessToken(): Promise<void> {
-  await axios.post(`${API_BASE_URL}/auth/token/refresh/`, null, { withCredentials: true })
+  await api.post('/auth/token/refresh/', null)
 }
 
 api.interceptors.response.use(

--- a/frontend/tests/api-client-refresh.test.ts
+++ b/frontend/tests/api-client-refresh.test.ts
@@ -1,22 +1,16 @@
-import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { api, API_BASE_URL } from '../src/lib/api/client'
-
-const REFRESH_URL = `${API_BASE_URL}/auth/token/refresh/`
+import { api } from '../src/lib/api/client'
 
 describe('api refresh interceptor', () => {
   let apiMock: MockAdapter
-  let axiosMock: MockAdapter
 
   beforeEach(() => {
     apiMock = new MockAdapter(api)
-    axiosMock = new MockAdapter(axios)
   })
 
   afterEach(() => {
     apiMock.restore()
-    axiosMock.restore()
   })
 
   it('refreshes the session on 401 and retries the original request', async () => {
@@ -26,19 +20,19 @@ describe('api refresh interceptor', () => {
       .onGet('/protected')
       .reply(200, { ok: true })
 
-    axiosMock.onPost(REFRESH_URL).reply(200)
+    apiMock.onPost('/auth/token/refresh/').reply(200)
 
     const response = await api.get('/protected')
 
     expect(response.data.ok).toBe(true)
     // The refresh endpoint is called exactly once, with no body (the httpOnly cookie carries the token).
-    expect(axiosMock.history.post).toHaveLength(1)
-    expect(axiosMock.history.post[0].url).toBe(REFRESH_URL)
+    expect(apiMock.history.post).toHaveLength(1)
+    expect(apiMock.history.post[0].url).toBe('/auth/token/refresh/')
   })
 
   it('propagates the error when the refresh request fails', async () => {
     apiMock.onGet('/protected').replyOnce(401)
-    axiosMock.onPost(REFRESH_URL).reply(401)
+    apiMock.onPost('/auth/token/refresh/').reply(401)
 
     await expect(api.get('/protected')).rejects.toBeDefined()
   })
@@ -47,20 +41,20 @@ describe('api refresh interceptor', () => {
     apiMock.onPost('/auth/token/refresh/').reply(401)
 
     await expect(api.post('/auth/token/refresh/', null)).rejects.toBeDefined()
-    // No recursive refresh call should be made.
-    expect(axiosMock.history.post).toHaveLength(0)
+    // No recursive refresh call should be made — only the initial request.
+    expect(apiMock.history.post).toHaveLength(1)
   })
 
   it('reuses one refresh request for concurrent 401 responses', async () => {
     apiMock.onGet('/protected-a').replyOnce(401).onGet('/protected-a').reply(200, { ok: 'a' })
     apiMock.onGet('/protected-b').replyOnce(401).onGet('/protected-b').reply(200, { ok: 'b' })
-    axiosMock.onPost(REFRESH_URL).reply(200)
+    apiMock.onPost('/auth/token/refresh/').reply(200)
 
     const [responseA, responseB] = await Promise.all([api.get('/protected-a'), api.get('/protected-b')])
 
     expect(responseA.data.ok).toBe('a')
     expect(responseB.data.ok).toBe('b')
     // A single shared refresh request should serve both concurrent failures.
-    expect(axiosMock.history.post).toHaveLength(1)
+    expect(apiMock.history.post).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## Summary

**Problem:** `CookieJWTAuthentication` accepted requests carrying the `openzev_access`
httpOnly cookie without any CSRF protection. Cookies are sent automatically by the
browser, so any state-changing request (change password, impersonate, update
settings, mark invoice paid, …) could be forged cross-site — a page the victim
visits could POST to the API under their session. Bearer and API-key auth were
already immune; cookie sessions were the one remaining bypass.

**Fix:** enforce CSRF exactly where it matters — cookie-authenticated, unsafe methods:

- `CookieJWTAuthentication` runs `SessionAuthentication().enforce_csrf(request)`
  (Django's origin + token check → 403) on non-safe methods when auth came from the
  cookie. `Authorization: Bearer` and `Authorization: Api-Key` (now matched
  case-insensitively) bypass, as they're not cookie sessions.
- All cookie-issuing endpoints (login, refresh, verify-email, initial-password,
  OAuth exchange, impersonation) additionally issue the `csrftoken` cookie via
  `get_token(request)` in `set_auth_cookies`. The token cookie stays readable to JS
  (not httpOnly) so the frontend can echo it in `X-CSRFToken`.
- `CsrfViewMiddleware` remains for Django admin/forms; the API path handles CSRF in
  the auth layer.
- Frontend: `xsrfCookieName`/`xsrfHeaderName` are scoped to the `api` axios instance
  (no `axios.defaults` globals), and the silent-refresh call now uses the same
  `api` instance so it carries the token.
- `CSRF_TRUSTED_ORIGINS` defaults to `CORS_ALLOWED_ORIGINS` (overridable) to cover
  local dev setups.

**Deployment note (included):** cookie sessions now require frontend and API to
share a host (same-origin, or same-host reverse proxy). Cross-hostname API
deployments need a same-origin reverse proxy; `README.md:260` and `frontend/.env.example`
updated accordingly. Same-host different-port dev (`localhost:5173` → `localhost:8001`) works with `CORS/CSRF_TRUSTED_ORIGINS`; truly cross-hostname cannot be fixed by CORS alone.

## Linked spec
- Spec: `docs/specs/2026-03-community-and-access.md` — updated auth-flow sections
  (cookie transport + CSRF, `_make_jwt_for_user` claims via `jwt_utils`, case-insensitive `Api-Key`,
  impersonation cookies).
- ADR: not needed — the enforcement point moved within the existing auth layer; no
  cross-system decision.
- No spec needed because: n/a (spec updated, see above).

## Validation
- Backend tests: `python -m pytest -q` — full suite passes, incl. new
  `accounts/test_csrf.py` (9 tests: missing/invalid/valid token, header bypass,
  safe-method exemption, login/refresh cookie issuance, API-key bypass).
- Frontend build: `npm run build` — passes.
- Frontend tests: `npm run test:unit` — **updated `tests/api-client-refresh.test.ts`**
  (refresh now routes through the `api` instance; the old bare-`axios` mocks would
  fail on the new call path). All 21 files / 124 tests pass.
- Manual checks: `POST /auth/token/` sets `openzev_access`/`openzev_refresh` +
  `csrftoken`; `POST /auth/token/refresh/` → 403 without `X-CSRFToken`, 200 with;
  `Authorization: Api-Key` and `api-key` both reach `ApiKeyAuthentication`.
- Screenshots: N/A — no user-facing UI change.

## Checklist
- [x] Spec updated/linked for larger or risky changes
- N/A: ADR — no architecture decision
- [x] Backend and frontend updated together where API contracts changed
      (incl. frontend unit tests for the new refresh path)
