### PR TITLE
fix(security): harden upload parsing against zip bombs and parse loops

### DIFF
--- a/backend/accounts/test_throttling.py
+++ b/backend/accounts/test_throttling.py
@@ -14,13 +14,19 @@ from django.test import TestCase
 from rest_framework.test import APIClient
 
 from .throttling import (
+    ApiKeyRateThrottle,
     AuthLoginThrottle,
     AuthOAuthExchangeThrottle,
     AuthOAuthInitiateThrottle,
     AuthRefreshThrottle,
     AuthRegisterThrottle,
     AuthVerifyThrottle,
+    ImportThrottle,
+    TransferArchiveThrottle,
 )
+from .test_api_keys import create_api_key
+from accounts.models import UserRole
+from testing.helpers import authenticate as auth, make_user
 
 LOGIN = "/api/v1/auth/token/"
 REFRESH = "/api/v1/auth/token/refresh/"
@@ -28,6 +34,8 @@ REGISTER = "/api/v1/auth/register/"
 VERIFY = "/api/v1/auth/verify-email/"
 OAUTH_INITIATE = "/api/v1/auth/oauth/login/bogus-provider/"
 OAUTH_EXCHANGE = "/api/v1/auth/oauth/token-exchange/"
+IMPORT_CSV = "/api/v1/metering/import/csv/"
+INSPECT_ARCHIVE = "/api/v1/zev/zevs/inspect-archive/"
 
 
 @mock.patch.object(AuthLoginThrottle, "THROTTLE_RATES", {"auth_login": "3/hour"})
@@ -111,3 +119,54 @@ class AuthEndpointThrottleTests(TestCase):
             self.client.post(REGISTER, {"email": "fresh@example.com"}, format="json").status_code,
             429,
         )
+
+
+@mock.patch.object(ImportThrottle, "THROTTLE_RATES", {"import": "3/hour"})
+@mock.patch.object(TransferArchiveThrottle, "THROTTLE_RATES", {"transfer_import": "3/hour"})
+class UploadEndpointThrottleTests(TestCase):
+    """Metering imports and transfer archives are capped per user.
+
+    Unlike the auth endpoints these need an authenticated request — DRF checks
+    permissions before throttles, so an anonymous 401/403 would never reach
+    the counter. The bodies are invalid on purpose: a 400 still consumes the
+    budget, which is what is being asserted.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+        self.admin = make_user("throttle_upload_admin", UserRole.ADMIN)
+        auth(self.client, self.admin)
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_import_past_its_budget_gets_429(self):
+        for _ in range(3):
+            self.assertNotEqual(self.client.post(IMPORT_CSV, format="multipart").status_code, 429)
+        self.assertEqual(self.client.post(IMPORT_CSV, format="multipart").status_code, 429)
+
+    def test_transfer_archive_past_its_budget_gets_429(self):
+        for _ in range(3):
+            self.assertNotEqual(self.client.post(INSPECT_ARCHIVE, format="multipart").status_code, 429)
+        self.assertEqual(self.client.post(INSPECT_ARCHIVE, format="multipart").status_code, 429)
+
+    def test_import_and_transfer_have_separate_budgets(self):
+        for _ in range(4):
+            self.client.post(IMPORT_CSV, format="multipart")
+        self.assertEqual(self.client.post(IMPORT_CSV, format="multipart").status_code, 429)
+        # Exhausting the import budget leaves the archive budget untouched.
+        self.assertNotEqual(self.client.post(INSPECT_ARCHIVE, format="multipart").status_code, 429)
+
+    @mock.patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "3/hour"})
+    @mock.patch.object(ImportThrottle, "THROTTLE_RATES", {"import": "50/hour"})
+    def test_import_requests_still_count_against_the_api_key_budget(self):
+        # View-level ``throttle_classes`` replace DEFAULT_THROTTLE_CLASSES, so
+        # the import view has to list ApiKeyRateThrottle itself or
+        # key-authenticated requests stop counting against the key budget.
+        client = APIClient()
+        full_key = create_api_key(self.admin)[1]
+        client.credentials(HTTP_AUTHORIZATION=f"Api-Key {full_key}")
+        for _ in range(3):
+            self.assertNotEqual(client.post(IMPORT_CSV, format="multipart").status_code, 429)
+        self.assertEqual(client.post(IMPORT_CSV, format="multipart").status_code, 429)

--- a/backend/accounts/throttling.py
+++ b/backend/accounts/throttling.py
@@ -1,4 +1,4 @@
-from rest_framework.throttling import SimpleRateThrottle
+from rest_framework.throttling import SimpleRateThrottle, UserRateThrottle
 
 
 class ApiKeyRateThrottle(SimpleRateThrottle):
@@ -59,3 +59,15 @@ class AuthOAuthInitiateThrottle(AuthRateThrottle):
 
 class AuthOAuthExchangeThrottle(AuthRateThrottle):
     scope = "auth_oauth_exchange"
+
+
+class ImportThrottle(UserRateThrottle):
+    """Per-user budget for metering imports."""
+
+    scope = "import"
+
+
+class TransferArchiveThrottle(UserRateThrottle):
+    """Per-user budget for whole-ZEV transfer archive import/inspect."""
+
+    scope = "transfer_import"

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -159,11 +159,19 @@ REST_FRAMEWORK = {
         "auth_verify": env("AUTH_VERIFY_THROTTLE_RATE", default="30/hour"),
         "auth_oauth_initiate": env("AUTH_OAUTH_INITIATE_THROTTLE_RATE", default="60/hour"),
         "auth_oauth_exchange": env("AUTH_OAUTH_EXCHANGE_THROTTLE_RATE", default="40/hour"),
+        # Per-user budgets bounding bulk uploads (worker-exhaustion guard).
+        "import": env("IMPORT_THROTTLE_RATE", default="60/hour"),
+        "transfer_import": env("TRANSFER_IMPORT_THROTTLE_RATE", default="20/hour"),
     },
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 50,
 }
+
+# ── Upload hardening volume caps ──────────────────────────────────────────────
+# Rationale: docs/specs/2026-03-metering-import-and-quality.md §4.4.
+IMPORT_MAX_ROWS = env.int("IMPORT_MAX_ROWS", default=200_000)
+TRANSFER_MAX_DECOMPRESSED_MB = env.int("TRANSFER_MAX_DECOMPRESSED_MB", default=500)
 
 from datetime import timedelta
 

--- a/backend/config/settings_test.py
+++ b/backend/config/settings_test.py
@@ -34,5 +34,13 @@ REST_FRAMEWORK = {
         "auth_verify": None,
         "auth_oauth_initiate": None,
         "auth_oauth_exchange": None,
+        "import": None,
+        "transfer_import": None,
     },
 }
+
+# Pin the env-tunable upload caps to their defaults so a developer's local
+# .env cannot change what the suite observes; limit tests patch the module
+# constants directly.
+IMPORT_MAX_ROWS = 200_000
+TRANSFER_MAX_DECOMPRESSED_MB = 500

--- a/backend/metering/importers/csv_importer.py
+++ b/backend/metering/importers/csv_importer.py
@@ -11,15 +11,33 @@ Both formats support header-based mapping and index-based mapping for headerless
 import csv
 import io
 import uuid
+import zipfile
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 
 import openpyxl
 from dateutil import parser as dateutil_parser
+from django.conf import settings
 
+from metering.importers.limits import (
+    MAX_REPORTED_ERRORS,
+    MAX_UPLOAD_BYTES,
+    add_error,
+    mb,
+    validate_zip,
+)
 from metering.models import ImportLog, ImportSource, MeterReading
 from zev.models import MeteringPoint, Zev
+
+# Upload hardening limits — rationale: docs/specs/2026-03-metering-import-and-quality.md §4.4.
+MAX_CSV_BYTES = MAX_UPLOAD_BYTES
+MAX_CSV_ROWS = getattr(settings, "IMPORT_MAX_ROWS", 200_000)
+MAX_CSV_COLUMNS = 1_500
+MAX_VALUES_COUNT = 1440  # one value per minute per day
+MAX_XLSX_DECOMPRESSED_BYTES = 50 * 1024 * 1024  # decompressed budget, deliberately not aliased to MAX_UPLOAD_BYTES
+MAX_XLSX_MEMBERS = 200
+MAX_XLSX_RATIO = 500
 
 DEFAULT_COLUMN_MAP = {
     "meter_id": "meter_id",
@@ -88,19 +106,72 @@ def _build_table(raw_rows, *, has_header):
 
 
 def _read_csv_table(file, *, has_header, delimiter):
+    # The file is decoded incrementally (no up-front read().decode() pass);
+    # blank rows are skipped the way pandas does.
+    size_hint = getattr(file, "size", None)
+    if size_hint is not None and size_hint > MAX_CSV_BYTES:
+        raise ImportFileError(f"File too large ({mb(size_hint)}). Maximum is {mb(MAX_CSV_BYTES)}.")
+
+    file.seek(0)
+    # Unwrap Django UploadedFile to the underlying stream for TextIOWrapper.
+    binary = getattr(file, "file", file)
+
+    rows = []
+    # The header is not a data row, so a headered file may carry one extra row.
+    row_cap = MAX_CSV_ROWS + (1 if has_header else 0)
+    text_wrapper = None
     try:
-        text = file.read().decode("utf-8-sig")
+        text_wrapper = io.TextIOWrapper(binary, encoding="utf-8-sig", newline="")
+        reader = csv.reader(text_wrapper, delimiter=delimiter)
+        for row in reader:
+            if not row:
+                continue
+            if len(row) > MAX_CSV_COLUMNS:
+                raise ImportFileError(
+                    f"Row {len(rows) + 1} has too many columns ({len(row)} > {MAX_CSV_COLUMNS})."
+                )
+            if len(rows) >= row_cap:
+                raise ImportFileError(f"File has too many rows (exceeds {MAX_CSV_ROWS}).")
+            rows.append(row)
     except UnicodeDecodeError as exc:
         raise ImportFileError(
             "File is not valid UTF-8. Re-export it as UTF-8 (in Excel: 'CSV UTF-8') and try again."
         ) from exc
-    reader = csv.reader(io.StringIO(text, newline=""), delimiter=delimiter)
-    # pandas skips blank lines *and* renumbers, so a blank line does not consume
-    # a row number. Rows of empty strings are data and are kept.
-    return _build_table([row for row in reader if row], has_header=has_header)
+    except ImportFileError:
+        raise
+    except csv.Error as exc:
+        raise ImportFileError(f"CSV parse error: {exc}") from exc
+    finally:
+        # Detach (not close): the finalizer of a TextIOWrapper closes the
+        # underlying stream, and the caller may still want to read the file.
+        if text_wrapper is not None:
+            text_wrapper.detach()
+
+    return _build_table(rows, has_header=has_header)
 
 
 def _read_xlsx_table(file, *, has_header):
+    # XLSX is a ZIP: validate members / decompressed size / ratio before
+    # openpyxl inflates anything (sharedStrings.xml alone can be a bomb).
+    file.seek(0)
+    try:
+        with zipfile.ZipFile(file) as zf:
+            validate_zip(
+                zf,
+                label="Excel file",
+                max_members=MAX_XLSX_MEMBERS,
+                max_total_bytes=MAX_XLSX_DECOMPRESSED_BYTES,
+                max_ratio=MAX_XLSX_RATIO,
+                error_cls=ImportFileError,
+            )
+    except ImportFileError:
+        raise
+    except zipfile.BadZipFile as exc:
+        raise ImportFileError(f"Could not read the Excel file: {exc}") from exc
+    except Exception as exc:
+        raise ImportFileError(f"Could not validate Excel archive: {exc}") from exc
+
+    file.seek(0)
     try:
         workbook = openpyxl.load_workbook(file, read_only=True, data_only=True, keep_links=False)
     except Exception as exc:  # openpyxl raises a variety of types for bad files
@@ -108,7 +179,20 @@ def _read_xlsx_table(file, *, has_header):
     try:
         # pandas reads sheet index 0, which is not necessarily the sheet that was
         # selected when the workbook was saved (openpyxl's ``active``).
-        raw_rows = [list(row) for row in workbook.worksheets[0].iter_rows(values_only=True)]
+        sheet = workbook.worksheets[0]
+        # The header is not a data row, so a headered sheet may carry one extra row.
+        row_cap = MAX_CSV_ROWS + (1 if has_header else 0)
+        raw_rows = []
+        for row in sheet.iter_rows(values_only=True):
+            if len(raw_rows) >= row_cap:
+                raise ImportFileError(
+                    f"Excel sheet has too many rows (exceeds {MAX_CSV_ROWS})."
+                )
+            if len(row) > MAX_CSV_COLUMNS:
+                raise ImportFileError(
+                    f"Excel sheet has too many columns ({len(row)} > {MAX_CSV_COLUMNS})."
+                )
+            raw_rows.append(list(row))
     finally:
         workbook.close()
 
@@ -269,6 +353,30 @@ def _infer_log_zev(explicit_zev, touched_metering_points):
     return None
 
 
+def _coerce_values_count(values_count):
+    """Bounds the per-row slot loop."""
+    try:
+        values_count = int(values_count)
+    except (TypeError, ValueError):
+        raise ImportFileError(f"values_count must be an integer (got {values_count!r}).")
+    if values_count < 1 or values_count > MAX_VALUES_COUNT:
+        raise ImportFileError(
+            f"values_count must be between 1 and {MAX_VALUES_COUNT} (got {values_count})."
+        )
+    return values_count
+
+
+def _coerce_interval_minutes(interval_minutes):
+    """Timestamps are spaced by this many minutes."""
+    try:
+        interval_minutes = int(interval_minutes)
+    except (TypeError, ValueError):
+        raise ImportFileError(f"interval_minutes must be an integer (got {interval_minutes!r}).")
+    if interval_minutes < 1:
+        raise ImportFileError("interval_minutes must be at least 1.")
+    return interval_minutes
+
+
 def preview_csv(
     file,
     user,
@@ -285,6 +393,8 @@ def preview_csv(
 ):
     col = {**DEFAULT_COLUMN_MAP, **(column_map or {})}
     has_header = _to_bool(has_header, default=True)
+    interval_minutes = _coerce_interval_minutes(interval_minutes)
+    values_count = _coerce_values_count(values_count)
     table = _read_table(file, has_header=has_header, delimiter=delimiter)
 
     required_keys = ["meter_id", "timestamp", "energy_kwh"] if format_profile == "standard" else ["meter_id", "timestamp", "energy_start"]
@@ -389,6 +499,8 @@ def import_csv(
 
     has_header = _to_bool(has_header, default=True)
     overwrite_existing = _to_bool(overwrite_existing, default=False)
+    interval_minutes = _coerce_interval_minutes(interval_minutes)
+    values_count = _coerce_values_count(values_count)
     table = _read_table(file, has_header=has_header, delimiter=delimiter)
 
     log = ImportLog.objects.create(
@@ -422,23 +534,24 @@ def import_csv(
         try:
             if _is_missing(row[resolved_cols["meter_id"]]):
                 skipped += 1
-                errors.append({"row": row_number, "error": "Missing meter_id value."})
+                add_error(errors, {"row": row_number, "error": "Missing meter_id value."})
                 continue
 
             meter_id = str(row[resolved_cols["meter_id"]]).strip()
             if not meter_id:
                 skipped += 1
-                errors.append({"row": row_number, "error": "Empty meter_id value."})
+                add_error(errors, {"row": row_number, "error": "Empty meter_id value."})
                 continue
 
             mp = meter_lookup.get(meter_id)
             if mp is None:
                 skipped += 1
-                errors.append(
+                add_error(
+                    errors,
                     {
                         "row": row_number,
                         "error": f"Metering point '{meter_id}' not found or not accessible.",
-                    }
+                    },
                 )
                 continue
 
@@ -448,7 +561,7 @@ def import_csv(
                 raw_day = row[resolved_cols["timestamp"]]
                 if _is_missing(raw_day):
                     skipped += 1
-                    errors.append({"row": row_number, "error": "Missing date value for daily profile."})
+                    add_error(errors, {"row": row_number, "error": "Missing date value for daily profile."})
                     continue
 
                 day_start = _build_day_start(raw_day, timestamp_format)
@@ -458,14 +571,15 @@ def import_csv(
                     col_pos = start_pos + slot
                     if col_pos >= table.width:
                         skipped += 1
-                        errors.append(
+                        add_error(
+                            errors,
                             {
                                 "row": row_number,
                                 "error": (
                                     f"Missing interval column at position {col_pos} "
                                     f"(slot {slot + 1}/{values_count})."
                                 ),
-                            }
+                            },
                         )
                         continue
 
@@ -507,21 +621,22 @@ def import_csv(
                             imported += 1
                         else:
                             skipped += 1
-                            errors.append(
+                            add_error(
+                                errors,
                                 {
                                     "row": row_number,
                                     "error": (
                                         "Duplicate reading for metering_point + timestamp + direction "
                                         f"(slot {slot + 1}/{values_count})."
                                     ),
-                                }
+                                },
                             )
                 continue
 
             raw_ts = row[resolved_cols["timestamp"]]
             if _is_missing(raw_ts):
                 skipped += 1
-                errors.append({"row": row_number, "error": "Missing timestamp value."})
+                add_error(errors, {"row": row_number, "error": "Missing timestamp value."})
                 continue
 
             if timestamp_format:
@@ -541,11 +656,12 @@ def import_csv(
                     explicit_direction = str(raw_direction).strip().lower()
                     if explicit_direction and explicit_direction not in {"in", "out"}:
                         skipped += 1
-                        errors.append(
+                        add_error(
+                            errors,
                             {
                                 "row": row_number,
                                 "error": f"Invalid direction '{explicit_direction}'. Expected 'in' or 'out'.",
-                            }
+                            },
                         )
                         continue
 
@@ -581,21 +697,27 @@ def import_csv(
                     imported += 1
                 else:
                     skipped += 1
-                    errors.append(
+                    add_error(
+                        errors,
                         {
                             "row": row_number,
                             "error": "Duplicate reading for metering_point + timestamp + direction.",
-                        }
+                        },
                     )
         except (KeyError, InvalidOperation, TypeError, ValueError) as exc:
-            errors.append({"row": row_number, "error": str(exc)})
+            add_error(errors, {"row": row_number, "error": str(exc)})
             skipped += 1
 
     log.zev = _infer_log_zev(zev, touched_metering_points)
     log.rows_imported = imported + overwritten
     log.rows_skipped = skipped
     if overwritten > 0:
+        # Prepended after the loop, when the cap may already be reached: trim
+        # the oldest payload so the note cannot push the list past the cap or
+        # displace the truncation note (which stays last).
         errors.insert(0, {"row": None, "error": f"Overwrote {overwritten} existing readings."})
+        if len(errors) > MAX_REPORTED_ERRORS + 1:
+            del errors[1]
     log.errors = errors
     log.save()
     return log

--- a/backend/metering/importers/limits.py
+++ b/backend/metering/importers/limits.py
@@ -1,0 +1,76 @@
+"""Shared upload-hardening limits and ZIP validation.
+
+Importers that accept uploads (CSV/Excel, SDAT-CH, transfer archives) enforce
+the same shape of caps before doing expensive work. Rationale and tuning
+guidance live in docs/specs/2026-03-metering-import-and-quality.md §4.4.
+"""
+
+import re
+
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+MAX_REPORTED_ERRORS = 50
+
+# The ratio check ignores members under 1 MB decompressed: legitimate small
+# members (sparse sheets, repeated CSV headers) compress far beyond the cap.
+ZIP_RATIO_FLOOR_BYTES = 1_000_000
+
+_WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:")
+
+
+def mb(num_bytes):
+    return f"{num_bytes / (1024 * 1024):.0f} MB"
+
+
+def add_error(errors: list, payload: dict):
+    """Append to errors, capping at MAX_REPORTED_ERRORS with a truncation note."""
+    if len(errors) < MAX_REPORTED_ERRORS:
+        errors.append(payload)
+    elif len(errors) == MAX_REPORTED_ERRORS:
+        errors.append(
+            {
+                "row": None,
+                "error": f"Too many errors — showing first {MAX_REPORTED_ERRORS}; further errors truncated.",
+            }
+        )
+
+
+def validate_zip(zf, *, label, max_members, max_total_bytes, max_ratio, error_cls):
+    """Reject a ZIP structured to exhaust memory or CPU when inflated.
+
+    Checks member count, the declared decompressed total, and per-member
+    compression ratio. Sizes come from the central directory, so these are
+    trust bounds paired with the proxy body-size cap rather than a meter of
+    actual inflation; row caps bound what is really read. Returns
+    ``zf.infolist()`` for callers that need the members.
+    """
+    infos = zf.infolist()
+    if len(infos) > max_members:
+        raise error_cls(f"{label} has too many members ({len(infos)} > {max_members}).")
+    total = sum(info.file_size for info in infos)
+    if total > max_total_bytes:
+        raise error_cls(
+            f"{label} too large when decompressed ({mb(total)} > {mb(max_total_bytes)})."
+        )
+    for info in infos:
+        if info.file_size and info.compress_size:
+            ratio = info.file_size / info.compress_size
+            if ratio > max_ratio and info.file_size > ZIP_RATIO_FLOOR_BYTES:
+                raise error_cls(
+                    f"{label} member {info.filename!r} has suspicious compression ratio ({ratio:.1f}:1)."
+                )
+    return infos
+
+
+def reject_unsafe_member_path(name, *, error_cls, label="Archive"):
+    """Reject member names that could escape a directory if ever extracted.
+
+    Members are only ever streamed today, never written to disk; this guards
+    the day that changes. Windows drive letters are included — a path check
+    that lets ``C:\\evil`` through is half a guard.
+    """
+    if (
+        name.startswith(("/", "\\"))
+        or ".." in name.replace("\\", "/").split("/")
+        or _WINDOWS_DRIVE.match(name)
+    ):
+        raise error_cls(f"{label} member has unsafe path: {name!r}.")

--- a/backend/metering/importers/sdatch_importer.py
+++ b/backend/metering/importers/sdatch_importer.py
@@ -14,6 +14,9 @@ from lxml import etree
 
 from zev.models import MeteringPoint
 from metering.models import MeterReading, ImportLog, ImportSource
+from metering.importers.limits import MAX_UPLOAD_BYTES, add_error, mb
+
+MAX_SDAT_BYTES = MAX_UPLOAD_BYTES
 
 # Namespaces used in SDAT-CH MeteringData documents
 NSMAP = {
@@ -45,8 +48,24 @@ def import_sdatch(file, zev, user):
         filename=filename,
     )
 
+    # App-level size cap (nginx enforces 413 earlier).
+    size_hint = getattr(file, "size", None)
+    if size_hint is not None and size_hint > MAX_SDAT_BYTES:
+        log.rows_total = 0
+        log.rows_imported = 0
+        log.rows_skipped = 0
+        log.errors = [{"error": f"File too large ({mb(size_hint)}). Maximum is {mb(MAX_SDAT_BYTES)}."}]
+        log.save()
+        return log
+
     try:
-        tree = etree.parse(file)
+        parser = etree.XMLParser(
+            resolve_entities=False,
+            load_dtd=False,
+            no_network=True,
+            huge_tree=False,
+        )
+        tree = etree.parse(file, parser)
         root = tree.getroot()
     except Exception as exc:
         log.rows_total = 0
@@ -76,7 +95,7 @@ def import_sdatch(file, zev, user):
         meter_id = (meter_id_elem.text or "").strip()
         mp = meter_lookup.get(meter_id)
         if mp is None:
-            errors.append({"meter_id": meter_id, "error": "Metering point not found in ZEV."})
+            add_error(errors, {"meter_id": meter_id, "error": "Metering point not found in ZEV."})
             continue
 
         for interval in mp_elem.iter("{*}Interval"):
@@ -93,7 +112,7 @@ def import_sdatch(file, zev, user):
             try:
                 start_ts = _parse_ts(start_elem.text.strip())
             except Exception as exc:
-                errors.append({"error": f"Invalid timestamp {start_elem.text}: {exc}"})
+                add_error(errors, {"error": f"Invalid timestamp {start_elem.text}: {exc}"})
                 continue
 
             # Resolution in minutes (default 15)
@@ -138,8 +157,7 @@ def import_sdatch(file, zev, user):
                         skipped += 1
                 except Exception as exc:
                     skipped += 1
-                    errors.append({"error": str(exc)})
-
+                    add_error(errors, {"error": str(exc)})
     log.rows_total = rows_total
     log.rows_imported = imported
     log.rows_skipped = skipped

--- a/backend/metering/test_import_limits.py
+++ b/backend/metering/test_import_limits.py
@@ -1,0 +1,228 @@
+"""Upload hardening limits for the CSV/Excel import path.
+
+Each cap is enforced before any expensive work: size via the upload's
+``size`` attribute, rows/columns during streaming, ZIP members/ratio before
+openpyxl inflates anything. The tests patch the module constants down to
+small values rather than building multi-megabyte fixtures.
+"""
+
+import io
+from datetime import date
+from unittest import mock
+
+import openpyxl
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from accounts.models import UserRole
+from metering.importers import csv_importer
+from metering.models import MeterReading
+from metering.testing import preview_csv, upload_csv
+from testing.helpers import authenticate as auth, make_user
+from testing.zips import ZIP_BOMB_BYTES, zip_upload
+from zev.models import MeteringPoint, MeteringPointType, Participant, Zev
+
+
+class CsvLimitTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.owner = make_user("csv_limit_owner", UserRole.ZEV_OWNER)
+        auth(self.client, self.owner)
+        self.zev = Zev.objects.create(name="CSV Limit ZEV", owner=self.owner, zev_type="vzev", invoice_prefix="X")
+
+    def test_file_over_size_cap_is_rejected(self):
+        with mock.patch.object(csv_importer, "MAX_CSV_BYTES", 10):
+            resp = upload_csv(self.client, "big.csv", b"meter_id,timestamp,energy_kwh\n" + b"x" * 100)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("too large", resp.data["error"])
+
+    def test_file_over_row_cap_is_rejected(self):
+        rows = b"".join(b"CH-X,2026-01-01T00:00:00Z,1.0\n" for _ in range(4))
+        with mock.patch.object(csv_importer, "MAX_CSV_ROWS", 3):
+            resp = upload_csv(self.client, "rows.csv", b"meter_id,timestamp,energy_kwh\n" + rows)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("too many rows", resp.data["error"])
+
+    def test_row_cap_counts_data_rows_not_the_header(self):
+        # Header + exactly MAX_CSV_ROWS data rows must fit — the header is not
+        # a data row and must not consume the cap.
+        rows = b"".join(b"CH-X,2026-01-01T00:00:00Z,1.0\n" for _ in range(3))
+        with mock.patch.object(csv_importer, "MAX_CSV_ROWS", 3):
+            resp = upload_csv(self.client, "rows.csv", b"meter_id,timestamp,energy_kwh\n" + rows)
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.data["rows_total"], 3)
+
+    def test_row_cap_headerless_file_gets_the_full_budget(self):
+        # Without a header the file may carry exactly MAX_CSV_ROWS rows — the
+        # +1 headroom applies only when a header row exists.
+        rows = b"".join(b"CH-X,2026-01-01T00:00:00Z,1.0\n" for _ in range(3))
+        with mock.patch.object(csv_importer, "MAX_CSV_ROWS", 3):
+            resp = upload_csv(
+                self.client, "rows.csv", rows,
+                has_header="false", col_meter_id="0", col_timestamp="1", col_energy_kwh="2",
+            )
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.data["rows_total"], 3)
+
+    def test_row_cap_headerless_file_over_the_cap_is_rejected(self):
+        rows = b"".join(b"CH-X,2026-01-01T00:00:00Z,1.0\n" for _ in range(4))
+        with mock.patch.object(csv_importer, "MAX_CSV_ROWS", 3):
+            resp = upload_csv(
+                self.client, "rows.csv", rows,
+                has_header="false", col_meter_id="0", col_timestamp="1", col_energy_kwh="2",
+            )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("too many rows", resp.data["error"])
+
+    def test_file_over_column_cap_is_rejected(self):
+        with mock.patch.object(csv_importer, "MAX_CSV_COLUMNS", 3):
+            resp = upload_csv(self.client, "cols.csv", b"a,b,c,d\n1,2,3,4\n")
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("too many columns", resp.data["error"])
+
+    def test_values_count_above_maximum_is_rejected(self):
+        resp = upload_csv(
+            self.client, "vc.csv", b"meter_id,date,1,2\nCH-X,2026-01-01,1,2\n",
+            format_profile="daily_15min", values_count="2000",
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("values_count must be between 1 and 1440", resp.data["error"])
+
+    def test_values_count_below_one_is_rejected_on_import_and_preview(self):
+        csv_bytes = b"meter_id,date,1,2\nCH-X,2026-01-01,1,2\n"
+        resp = upload_csv(
+            self.client, "vc0.csv", csv_bytes, format_profile="daily_15min", values_count="0"
+        )
+        self.assertEqual(resp.status_code, 400)
+        resp = preview_csv(
+            self.client, "vc0.csv", csv_bytes, format_profile="daily_15min", values_count="0"
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_values_count_at_maximum_is_accepted(self):
+        self.mp = MeteringPoint.objects.create(
+            zev=self.zev, meter_id="CH-LIMIT-1", meter_type=MeteringPointType.CONSUMPTION
+        )
+        Participant.objects.create(
+            zev=self.zev, first_name="L", last_name="P", email="limit@example.com",
+            valid_from=date(2026, 1, 1),
+        )
+
+        resp = upload_csv(
+            self.client, "vc.csv", b"meter_id,timestamp,energy_kwh\nCH-LIMIT-1,2026-01-01T00:00:00Z,1.0\n",
+            values_count="1440",
+        )
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(MeterReading.objects.count(), 1)
+
+    def test_non_integer_interval_or_values_count_is_rejected(self):
+        resp = upload_csv(
+            self.client, "vc.csv", b"meter_id,timestamp,energy_kwh\nCH-X,2026-01-01T00:00:00Z,1.0\n",
+            values_count="abc",
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("values_count must be an integer", resp.data["error"])
+
+    def test_row_error_list_is_capped_with_a_truncation_note(self):
+        rows = b"".join(
+            f"NOPE-{i},2026-01-01T00:00:00Z,1.0\n".encode() for i in range(60)
+        )
+
+        resp = upload_csv(self.client, "errs.csv", b"meter_id,timestamp,energy_kwh\n" + rows)
+
+        self.assertEqual(resp.status_code, 201)
+        errors = resp.data["errors"]
+        self.assertEqual(len(errors), csv_importer.MAX_REPORTED_ERRORS + 1)
+        self.assertIn("Too many errors", errors[-1]["error"])
+
+    def test_overwrite_note_cannot_push_the_error_list_past_its_cap(self):
+        MeteringPoint.objects.create(
+            zev=self.zev, meter_id="CH-LIMIT-1", meter_type=MeteringPointType.CONSUMPTION
+        )
+        header = b"meter_id,timestamp,energy_kwh\n"
+        rows = b"CH-LIMIT-1,2026-01-01T00:00:00Z,1.0\n" + b"".join(
+            f"NOPE-{i},2026-01-01T00:00:00Z,1.0\n".encode() for i in range(60)
+        )
+        upload_csv(self.client, "ov.csv", header + rows)
+        resp = upload_csv(self.client, "ov.csv", header + rows, overwrite_existing="true")
+
+        self.assertEqual(resp.status_code, 201)
+        errors = resp.data["errors"]
+        self.assertEqual(len(errors), csv_importer.MAX_REPORTED_ERRORS + 1)
+        self.assertEqual(errors[0]["error"], "Overwrote 1 existing readings.")
+        self.assertIn("Too many errors", errors[-1]["error"])
+
+    def test_interval_minutes_below_one_is_rejected(self):
+        csv_bytes = b"meter_id,date,1,2\nCH-X,2026-01-01,1,2\n"
+        resp = upload_csv(
+            self.client, "iv.csv", csv_bytes, format_profile="daily_15min", interval_minutes="0"
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("interval_minutes must be at least 1", resp.data["error"])
+        resp = preview_csv(
+            self.client, "iv.csv", csv_bytes, format_profile="daily_15min", interval_minutes="0"
+        )
+        self.assertEqual(resp.status_code, 400)
+
+
+class XlsxZipLimitTests(TestCase):
+    """The XLSX pre-inflation ZIP checks: member count and compression ratio."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.owner = make_user("xlsx_limit_owner", UserRole.ZEV_OWNER)
+        auth(self.client, self.owner)
+
+    def _upload(self, upload):
+        return self.client.post(
+            "/api/v1/metering/import/csv/", {"file": upload}, format="multipart"
+        )
+
+    def test_zip_with_too_many_members_is_rejected(self):
+        members = {f"part{i}.xml": b"<x/>" for i in range(6)}
+        with mock.patch.object(csv_importer, "MAX_XLSX_MEMBERS", 5):
+            resp = self._upload(zip_upload("bomb.xlsx", members))
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("too many members", resp.data["error"])
+
+    def test_zip_with_a_high_ratio_member_is_rejected(self):
+        resp = self._upload(zip_upload("bomb.xlsx", {"xl/sharedStrings.xml": ZIP_BOMB_BYTES}))
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("suspicious compression ratio", resp.data["error"])
+
+    def test_non_zip_xlsx_is_rejected(self):
+        resp = self._upload(SimpleUploadedFile("fake.xlsx", b"not a zip", content_type="text/csv"))
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Could not read the Excel file", resp.data["error"])
+
+    def test_wide_row_past_the_first_is_rejected(self):
+        # The column cap must hold for every row: a sheet whose width only
+        # shows up after row 1 (openpyxl may or may not pad row 1 to the
+        # sheet's declared width) still has to be refused.
+        workbook = openpyxl.Workbook()
+        sheet = workbook.active
+        sheet.append(["a"])
+        sheet.append(["b", "c", "d", "e"])
+        buffer = io.BytesIO()
+        workbook.save(buffer)
+        upload = SimpleUploadedFile(
+            "wide.xlsx", buffer.getvalue(), content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+
+        with mock.patch.object(csv_importer, "MAX_CSV_COLUMNS", 3):
+            resp = self._upload(upload)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("too many columns", resp.data["error"])

--- a/backend/metering/test_import_sdatch.py
+++ b/backend/metering/test_import_sdatch.py
@@ -2,12 +2,14 @@
 
 from datetime import date, datetime, timezone
 from decimal import Decimal
+from unittest import mock
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from rest_framework.test import APIClient
 
 from accounts.models import UserRole
+from metering.importers import csv_importer, sdatch_importer
 from metering.models import ImportLog, ImportSource, MeterReading, ReadingDirection
 from testing.helpers import authenticate as auth, make_user
 from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Participant, Zev
@@ -206,3 +208,48 @@ class SdatchImportTests(TestCase):
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data["rows_imported"], 1)
         self.assertTrue(MeterReading.objects.filter(metering_point=admin_meter).exists())
+
+
+class SdatchLimitTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.owner = make_user("sdatch_limit_owner", UserRole.ZEV_OWNER)
+        auth(self.client, self.owner)
+        self.zev = Zev.objects.create(name="SDAT Limit ZEV", owner=self.owner, zev_type="vzev", invoice_prefix="Y")
+
+    def test_file_over_size_cap_is_reported_without_parsing(self):
+        xml = (
+            b'<?xml version="1.0" encoding="UTF-8"?><MeteringData>'
+            b'<MeteringPoint><ID>CH-SDAT-1</ID></MeteringPoint></MeteringData>'
+        )
+
+        with mock.patch.object(sdatch_importer, "MAX_SDAT_BYTES", 10):
+            upload = SimpleUploadedFile("big.xml", xml, content_type="application/xml")
+            resp = self.client.post(
+                "/api/v1/metering/import/sdatch/",
+                {"file": upload, "zev_id": str(self.zev.id)},
+                format="multipart",
+            )
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertIn("too large", resp.data["errors"][0]["error"].lower())
+        self.assertEqual(resp.data["rows_imported"], 0)
+        self.assertEqual(MeterReading.objects.count(), 0)
+
+    def test_row_error_list_is_capped_with_a_truncation_note(self):
+        meters = "".join(
+            f"<MeteringPoint><ID>NOPE-{i}</ID></MeteringPoint>" for i in range(60)
+        )
+        xml = f'<?xml version="1.0" encoding="UTF-8"?><MeteringData>{meters}</MeteringData>'.encode()
+
+        upload = SimpleUploadedFile("errs.xml", xml, content_type="application/xml")
+        resp = self.client.post(
+            "/api/v1/metering/import/sdatch/",
+            {"file": upload, "zev_id": str(self.zev.id)},
+            format="multipart",
+        )
+
+        self.assertEqual(resp.status_code, 201)
+        errors = resp.data["errors"]
+        self.assertEqual(len(errors), csv_importer.MAX_REPORTED_ERRORS + 1)
+        self.assertIn("Too many errors", errors[-1]["error"])

--- a/backend/metering/views.py
+++ b/backend/metering/views.py
@@ -10,6 +10,7 @@ from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from accounts.permissions import IsZevOwnerOrAdmin
+from accounts.throttling import ApiKeyRateThrottle, ImportThrottle
 from zev.models import Zev, Participant, MeteringPoint
 from .models import MeterReading, ImportLog
 from zev.scoping import ZevScopedQuerySetMixin
@@ -388,6 +389,10 @@ class ImportView(viewsets.ViewSet):
     """Handles CSV and SDAT-CH file uploads for metering data."""
     permission_classes = [IsAuthenticated, IsZevOwnerOrAdmin]
     parser_classes = [MultiPartParser, FormParser]
+    # ImportThrottle bounds bulk uploads per user; ApiKeyRateThrottle stays so
+    # view-level lists (which replace DEFAULT_THROTTLE_CLASSES) keep counting
+    # key-authenticated requests against the key budget.
+    throttle_classes = [ApiKeyRateThrottle, ImportThrottle]
 
     @action(detail=False, methods=["post"], url_path="csv")
     def upload_csv(self, request):
@@ -418,8 +423,8 @@ class ImportView(viewsets.ViewSet):
         delimiter = request.data.get("delimiter", ",")
         format_profile = request.data.get("format_profile", "standard")
         timestamp_format = request.data.get("timestamp_format") or None
-        interval_minutes = int(request.data.get("interval_minutes", 15))
-        values_count = int(request.data.get("values_count", 96))
+        interval_minutes = request.data.get("interval_minutes", 15)
+        values_count = request.data.get("values_count", 96)
 
         try:
             payload = preview_csv(
@@ -465,8 +470,9 @@ class ImportView(viewsets.ViewSet):
             metadata={
                 "filename": file.name,
                 "format_profile": format_profile,
-                "interval_minutes": interval_minutes,
-                "values_count": values_count,
+                # The preview succeeded, so both values are int-coercible.
+                "interval_minutes": int(interval_minutes),
+                "values_count": int(values_count),
             },
         )
         return Response(payload)
@@ -493,8 +499,8 @@ class ImportView(viewsets.ViewSet):
             delimiter = request.data.get("delimiter", ",")
             format_profile = request.data.get("format_profile", "standard")
             timestamp_format = request.data.get("timestamp_format") or None
-            interval_minutes = int(request.data.get("interval_minutes", 15))
-            values_count = int(request.data.get("values_count", 96))
+            interval_minutes = request.data.get("interval_minutes", 15)
+            values_count = request.data.get("values_count", 96)
             overwrite_existing_raw = request.data.get("overwrite_existing", "false")
             overwrite_existing = str(overwrite_existing_raw).strip().lower() in {"1", "true", "yes", "on"}
 

--- a/backend/testing/zips.py
+++ b/backend/testing/zips.py
@@ -1,0 +1,28 @@
+"""ZIP-building helpers for upload-limit tests.
+
+``test_import_limits`` and ``test_transfer_limits`` each carried a copy of
+this before it was consolidated here.
+"""
+
+import io
+import zipfile
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+
+# 2 MB of zeros deflates to ~2 KB: ~1000:1, far past the 500:1 ratio caps.
+ZIP_BOMB_BYTES = b"\0" * (2 * 1024 * 1024)
+
+
+def zip_bytes(members, *, compress=zipfile.ZIP_DEFLATED):
+    """Raw bytes of a ZIP holding the given ``{name: payload}`` members."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compress) as zf:
+        for name, payload in members.items():
+            zf.writestr(name, payload)
+    return buffer.getvalue()
+
+
+def zip_upload(name, members, **kwargs):
+    """A SimpleUploadedFile ZIP for POSTing as multipart."""
+    return SimpleUploadedFile(name, zip_bytes(members, **kwargs), content_type="application/zip")

--- a/backend/zev/test_transfer_limits.py
+++ b/backend/zev/test_transfer_limits.py
@@ -1,0 +1,72 @@
+"""ZIP-level hardening limits on the transfer archive import path.
+
+``open_archive`` validates limits before returning the ``ZipFile``, so a
+hostile archive is rejected before a single member is read. Member-count
+and size caps are patched down to small values; the path-traversal and
+compression-ratio checks run against their real limits with small
+in-memory archives.
+"""
+
+from unittest import mock
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from testing.zips import ZIP_BOMB_BYTES, zip_upload
+from zev.transfer.importer import open_archive
+from zev.transfer.schema import ArchiveError
+from zev.transfer import importer as transfer_importer
+
+
+class TransferArchiveLimitTests(TestCase):
+    def test_member_with_traversal_path_is_rejected(self):
+        with self.assertRaisesRegex(ArchiveError, "unsafe path"):
+            open_archive(zip_upload("archive.zip", {"../evil.txt": b"x"}))
+
+    def test_member_with_backslash_traversal_path_is_rejected(self):
+        # A Windows-style separator must not smuggle a ".." past the check.
+        with self.assertRaisesRegex(ArchiveError, "unsafe path"):
+            open_archive(zip_upload("archive.zip", {"..\\evil.txt": b"x"}))
+
+    def test_member_with_drive_letter_path_is_rejected(self):
+        # ``C:\evil`` is neither absolute nor a traversal, but is just as able
+        # to escape a directory if a member is ever written to disk.
+        with self.assertRaisesRegex(ArchiveError, "unsafe path"):
+            open_archive(zip_upload("archive.zip", {"C:\\evil.txt": b"x"}))
+
+    def test_member_with_absolute_path_is_rejected(self):
+        with self.assertRaisesRegex(ArchiveError, "unsafe path"):
+            open_archive(zip_upload("archive.zip", {"/etc/passwd": b"x"}))
+
+    def test_archive_with_too_many_members_is_rejected(self):
+        members = {f"readings/{i}.csv": b"meter_id,timestamp,energy_kwh\n" for i in range(6)}
+        with mock.patch.object(transfer_importer, "MAX_TRANSFER_MEMBERS", 5):
+            with self.assertRaisesRegex(ArchiveError, "too many members"):
+                open_archive(zip_upload("archive.zip", members))
+
+    def test_archive_over_decompressed_cap_is_rejected(self):
+        with mock.patch.object(transfer_importer, "MAX_TRANSFER_DECOMPRESSED_BYTES", 100):
+            with self.assertRaisesRegex(ArchiveError, "too large when decompressed"):
+                open_archive(zip_upload("archive.zip", {"readings/0.csv": b"x" * 200}))
+
+    def test_archive_over_compressed_cap_is_rejected(self):
+        with mock.patch.object(transfer_importer, "MAX_TRANSFER_COMPRESSED_BYTES", 10):
+            with self.assertRaisesRegex(ArchiveError, "too large"):
+                open_archive(zip_upload("archive.zip", {"readings/0.csv": b"x" * 200}))
+
+    def test_archive_with_a_high_ratio_member_is_rejected(self):
+        with self.assertRaisesRegex(ArchiveError, "suspicious compression ratio"):
+            open_archive(zip_upload("archive.zip", {"readings/bomb.csv": ZIP_BOMB_BYTES}))
+
+    def test_archive_that_is_not_a_zip_is_rejected(self):
+        with self.assertRaisesRegex(ArchiveError, "not a valid ZIP"):
+            open_archive(SimpleUploadedFile("archive.zip", b"not a zip", content_type="application/zip"))
+
+    def test_decompressed_cap_covers_the_documented_2m_row_scale(self):
+        # One readings row is ~75 bytes of CSV and the transfer spec
+        # contemplates archives at the 2M-row scale; an export that large
+        # must round-trip instead of being refused at import.
+        self.assertGreaterEqual(
+            transfer_importer.MAX_TRANSFER_DECOMPRESSED_BYTES,
+            2_000_000 * 75,
+        )

--- a/backend/zev/transfer/importer.py
+++ b/backend/zev/transfer/importer.py
@@ -26,10 +26,18 @@ import zipfile
 from decimal import Decimal, InvalidOperation
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.conf import settings
 from django.db import DataError, IntegrityError, transaction
 
 from invoices.models import Invoice, InvoiceItem
 from metering.importers.csv_importer import _parse_datetime_utc, _parse_decimal
+from metering.importers.limits import (
+    MAX_REPORTED_ERRORS,
+    MAX_UPLOAD_BYTES,
+    mb,
+    reject_unsafe_member_path,
+    validate_zip,
+)
 from metering.models import ImportLog, ImportSource, MeterReading, ReadingDirection, ReadingResolution
 from tariffs.models import Tariff, TariffPeriod
 from zev.models import MeteringPoint, MeteringPointAssignment, Participant, Zev
@@ -72,7 +80,46 @@ MAX_ENERGY_KWH = Decimal("99999999.9999")
 
 # A malformed readings file can produce one error per row. The response has to
 # stay a response, so the list is capped and the true total reported alongside.
-MAX_REPORTED_ERRORS = 50
+
+# Upload hardening limits — rationale: docs/specs/2026-03-metering-import-and-quality.md §4.4.
+MAX_TRANSFER_DECOMPRESSED_BYTES = getattr(settings, "TRANSFER_MAX_DECOMPRESSED_MB", 500) * 1024 * 1024
+MAX_TRANSFER_MEMBERS = 500
+MAX_TRANSFER_COMPRESSED_BYTES = MAX_UPLOAD_BYTES
+MAX_TRANSFER_RATIO = 500
+
+
+def open_archive(fileobj):
+    """Open a transfer archive, validating limits first.
+
+    Raises ``ArchiveError`` when the file is too large, has too many members,
+    exceeds decompressed-size or compression-ratio limits, or contains unsafe
+    member paths.
+    """
+    fileobj.seek(0)
+    size_hint = getattr(fileobj, "size", None)
+    if size_hint is not None and size_hint > MAX_TRANSFER_COMPRESSED_BYTES:
+        raise ArchiveError(
+            f"Archive too large ({mb(size_hint)}). Maximum compressed size is {mb(MAX_TRANSFER_COMPRESSED_BYTES)}."
+        )
+    try:
+        zf = zipfile.ZipFile(fileobj)
+    except zipfile.BadZipFile as exc:
+        raise ArchiveError("The uploaded file is not a valid ZIP archive.") from exc
+    try:
+        infos = validate_zip(
+            zf,
+            label="Archive",
+            max_members=MAX_TRANSFER_MEMBERS,
+            max_total_bytes=MAX_TRANSFER_DECOMPRESSED_BYTES,
+            max_ratio=MAX_TRANSFER_RATIO,
+            error_cls=ArchiveError,
+        )
+        for info in infos:
+            reject_unsafe_member_path(info.filename, error_cls=ArchiveError)
+    except BaseException:
+        zf.close()
+        raise
+    return zf
 
 
 class ImportFailed(Exception):
@@ -201,13 +248,6 @@ def read_manifest(archive):
         raise ArchiveError(f"{MANIFEST_NAME} 'source_zev' must be a JSON object.")
 
     return manifest
-
-
-def open_archive(fileobj):
-    try:
-        return zipfile.ZipFile(fileobj)
-    except zipfile.BadZipFile as exc:
-        raise ArchiveError("The uploaded file is not a valid ZIP archive.") from exc
 
 
 def inspect_archive(fileobj):

--- a/backend/zev/views.py
+++ b/backend/zev/views.py
@@ -12,6 +12,7 @@ from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from accounts.permissions import IsAdmin
+from accounts.throttling import ApiKeyRateThrottle, TransferArchiveThrottle
 from accounts.models import User, UserRole
 from accounts.serializers import UserSerializer
 from metering.models import MeterReading
@@ -205,6 +206,7 @@ class ZevViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
         methods=["post"],
         url_path="inspect-archive",
         parser_classes=[MultiPartParser, FormParser],
+        throttle_classes=[ApiKeyRateThrottle, TransferArchiveThrottle],
     )
     def inspect_archive_action(self, request):
         """Read an archive's manifest without importing anything."""
@@ -222,6 +224,7 @@ class ZevViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
         methods=["post"],
         url_path="import-archive",
         parser_classes=[MultiPartParser, FormParser],
+        throttle_classes=[ApiKeyRateThrottle, TransferArchiveThrottle],
     )
     def import_archive_action(self, request):
         """Create a new ZEV from an uploaded transfer archive.

--- a/charts/openzev/values.yaml
+++ b/charts/openzev/values.yaml
@@ -111,7 +111,11 @@ email:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # 50m covers the upload endpoints (ingress-nginx defaults to 1m, which
+  # would kill even small imports). Per-location limits for the docker
+  # fullstack setup live in docker/fullstack-nginx.conf.
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
   tls: []
   hosts:
     - host: openzev.local

--- a/docker/fullstack-nginx.conf
+++ b/docker/fullstack-nginx.conf
@@ -5,20 +5,40 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  # Inherited by every proxying location below (none overrides the set).
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+
+  # Modest global default; larger caps per upload endpoint below.
+  client_max_body_size 10m;
+
+  # JSON error for 413 so frontend can parse it (default is HTML).
+  error_page 413 /413.json;
+  location = /413.json {
+    default_type application/json;
+    return 413 '{"detail":"File too large."}';
+  }
+
+  # Import endpoints need larger bodies (SDAT annual dumps ~25-50MB, XLSX ZIPs).
+  # Must appear before the generic /api/ prefix match.
+  location /api/v1/metering/import/ {
+    client_max_body_size 50m;
+    proxy_pass http://127.0.0.1:8000;
+  }
+
+  location ~ ^/api/v1/zev/zevs/(import-archive|inspect-archive) {
+    client_max_body_size 50m;
+    proxy_pass http://127.0.0.1:8000;
+  }
+
   location /api/ {
     proxy_pass http://127.0.0.1:8000;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
   }
 
   location /media/ {
     proxy_pass http://127.0.0.1:8000;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
   }
 
   location / {

--- a/docs/specs/2026-03-metering-import-and-quality.md
+++ b/docs/specs/2026-03-metering-import-and-quality.md
@@ -279,6 +279,45 @@ Preview accepts the same configuration parameters as CSV import (column map,
 header, delimiter, profile, timestamp format, interval, values count) but does
 **not** write any data.
 
+### 4.4 Hardening and limits (C+ — 2026-08)
+
+All import paths enforce app-level and nginx-level limits; the parser is pinned to prevent version drift.
+
+**Nginx body limits:**
+- Global `client_max_body_size 10m` (`docker/fullstack-nginx.conf`, `frontend/nginx.conf`).
+- Per-location `50m` on `/api/v1/metering/import/` (CSV/SDAT) and `/api/v1/zev/zevs/(import|inspect)-archive` (transfer) — the paths include the `/api/v1/` prefix the Django router mounts. The Helm chart sets `nginx.ingress.kubernetes.io/proxy-body-size: "50m"` on the ingress (ingress-nginx defaults to 1m, which would block even small uploads).
+- `error_page 413` returns JSON `{"detail":"File too large."}` rather than HTML.
+
+**SDAT-CH XML parser (pinned):**
+```python
+parser = etree.XMLParser(resolve_entities=False, load_dtd=False, no_network=True, huge_tree=False)
+tree = etree.parse(file, parser)
+```
+On lxml 6.1.1 the default is `resolve_entities='internal'` with a libxml2 amplification ceiling (~100x, `huge_tree=False`), so Billion Laughs does not reach GB-scale — explicit flags pin behaviour against future `huge_tree=True` drift. See `backend/metering/importers/sdatch_importer.py`. An oversized SDAT file is reported as an ImportLog error (HTTP 201) — the SDAT importer always reports through its log — unlike CSV, whose oversize files return HTTP 400.
+
+**CSV / Excel streaming and caps (`backend/metering/importers/csv_importer.py`):**
+- `MAX_CSV_BYTES 50 MB` enforced via the upload's `size` attribute (nginx rejects oversized bodies earlier with 413); `MAX_XLSX_DECOMPRESSED_BYTES 50 MB`, `MAX_CSV_ROWS 200k` (env `IMPORT_MAX_ROWS`, `backend/config/settings.py`), `MAX_CSV_COLUMNS 1500`. The row cap counts data rows — a header row does not consume it. Headroom by profile: `standard` (one reading per row) is the tight case at ~5.7 meter-years of 15-minute data (35,040 rows/meter-year); `daily_15min` (one row per meter-day) has ~548 meter-years of headroom. Raise `IMPORT_MAX_ROWS` for larger standard-profile exports.
+- `MAX_XLSX_MEMBERS 200`, `MAX_XLSX_RATIO 500:1` (XLSX is a ZIP; `openpyxl` with `read_only=True` still materializes shared strings, so the ZIP is validated before inflation). The ratio is a heuristic, deliberately loose: legitimate sparse sheets compress far beyond 100:1, and the decompressed-size sum is the hard bound. Sheet row caps are enforced *during* iteration and the column cap on *every* row, so an oversized sheet is rejected before it is materialized and a wide row cannot hide behind a narrow first row.
+- `MAX_VALUES_COUNT 1440` (values per `daily_15min` row) — prevents CPU bomb via `values_count=100000`; both `preview_csv` and `import_csv` validate `1..1440` through `_coerce_values_count`, and `interval_minutes >= 1` through `_coerce_interval_minutes`. Validation is single-layer: the coercers raise `ImportFileError` on non-integer input (no silent defaults), which the views map to a 400.
+- Streaming via `TextIOWrapper` over the uploaded file (`detach()` in a `finally` keeps the underlying upload readable on error paths); `file.read().decode` whole-file buffering removed.
+- `MAX_REPORTED_ERRORS 50` (shared across importers from `backend/metering/importers/limits.py`) — further per-row errors are truncated with a sentinel error. SDAT-CH reuses the same `add_error` helper, capping during the parse loop. The "Overwrote N existing readings" note is prepended after the loop and trimmed so the list never exceeds cap + 1 nor loses the sentinel.
+
+**Shared limits module (`backend/metering/importers/limits.py`):**
+- `MAX_UPLOAD_BYTES 50 MB` (aliased as `MAX_CSV_BYTES`, `MAX_SDAT_BYTES`, `MAX_TRANSFER_COMPRESSED_BYTES`), `MAX_REPORTED_ERRORS 50`, the `mb()` formatter, `add_error()`, and `validate_zip()` — one ZIP validator (member count, declared decompressed sum, ratio with a 1 MB decompressed floor) used by both `_read_xlsx_table` and `open_archive`, parameterized by limits and error class. `reject_unsafe_member_path()` rejects absolute paths, `..` traversal on `/`- or `\`-separated paths, and Windows drive letters.
+
+**Transfer archive ZIP caps (`backend/zev/transfer/importer.py:open_archive`):**
+- `MAX_TRANSFER_COMPRESSED_BYTES 50 MB`, `MAX_TRANSFER_DECOMPRESSED_BYTES 500 MB` (env `TRANSFER_MAX_DECOMPRESSED_MB`, `backend/config/settings.py`), `MAX_TRANSFER_MEMBERS 500`, `MAX_TRANSFER_RATIO 500:1`.
+- The decompressed cap is derived from the archive scale the feature documents: 2M readings ≈ 150 MB of CSV (`docs/specs/2026-08-zev-transfer-archive.md`). Decompressed members are streamed, never materialised, so the cap is a trust bound rather than a memory bound; a guard test (`zev/test_transfer_limits.py:TransferArchiveLimitTests`) fails if it is lowered below that scale. The compressed cap pairs with nginx's 50m location and is not tunable.
+- Checked inside `open_archive`, which validates the opened `ZipFile` through the shared `validate_zip` before returning it (no second open); unsafe member paths (traversal, absolute, drive letters) are rejected.
+
+**Throttling (worker exhaustion, not just OOM):**
+- `backend/accounts/throttling.py:ImportThrottle` (`UserRateThrottle` subclass, `60/hour` per-user) on `POST /import/csv`, `/import/sdatch`, `/import/preview-csv` (`backend/metering/views.py`); `backend/accounts/throttling.py:TransferArchiveThrottle` (`UserRateThrottle` subclass, `20/hour` per-user) on `POST /zev/zevs/import-archive` and `inspect-archive` (`backend/zev/views.py`).
+- Both views list `ApiKeyRateThrottle` alongside their specific throttle: view-level `throttle_classes` *replace* `DEFAULT_THROTTLE_CLASSES`, so without it key-authenticated requests would stop counting against the API-key budget. These endpoints are authenticated (DRF checks permissions before throttles), so per-user keying always applies.
+- Rates in `backend/config/settings.py` (`REST_FRAMEWORK.DEFAULT_THROTTLE_RATES`) with env overrides `IMPORT_THROTTLE_RATE`, `TRANSFER_IMPORT_THROTTLE_RATE`; disabled in tests (`backend/config/settings_test.py` → `None`). The env-tunable volume caps (`IMPORT_MAX_ROWS`, `TRANSFER_MAX_DECOMPRESSED_MB`) are pinned to their defaults there.
+- Rationale: sync gunicorn workers tie up on parse duration even for legal-sized files; size caps alone do not bound concurrency.
+
+**Frontend error shapes:** the import UI reads `error` (app 400s) with `detail` as a fallback — the proxy's 413 body (`{"detail":"File too large."}`) — and treats a 201 whose log has `rows_imported == 0` with errors as a failure (the SDAT-CH oversize path reports through its log).
+
 ---
 
 ## 5. API endpoints
@@ -771,6 +810,26 @@ type MeteringDashboardSummary =
 | `ImportParserRobustnessTests` | §4.1: malformed CSV reported without crash; malformed SDAT-CH reported without crash; timezone offset normalized to UTC; duplicate rows skipped; idempotent re-import; overwrite mode updates value without creating new row |
 | `MeteringRawDataEndpointTests` | §5.3: owner gets daily-grouped raw rows with correct direction sums; participant can read own metering point's raw data |
 | `DataQualityStatusTests` | §5.5: owner sees gaps and severity; participant sees own meters; default 30-day range; fully assigned readings report no unassigned; holder-less meter flags every reading; assignment-gap readings flagged unassigned; overlapping windows flag only the corrupt meter (others still report) |
+
+### Backend (`metering/test_import_limits.py`, `metering/test_import_sdatch.py`)
+
+| Test class | Validates |
+|---|---|
+| `CsvLimitTests` | §4.4: CSV over the size cap, row cap, or column cap is rejected with a 400 before parsing; the header row does not consume the row cap, and headerless files get the full budget; `values_count` outside `1..1440`, `interval_minutes < 1`, and non-integer `interval_minutes`/`values_count` rejected on import and preview, `values_count` at maximum accepted; per-row error list capped at 50 with a truncation sentinel, and the overwrite note cannot push it past the cap |
+| `XlsxZipLimitTests` | §4.4: XLSX ZIP with too many members or a high-ratio member is rejected before openpyxl inflates it; a non-ZIP `.xlsx` is rejected; a sheet whose width appears only after the first row is rejected (column cap holds per row) |
+| `SdatchLimitTests` | §4.4: SDAT-CH file over the size cap produces an ImportLog error without parsing; the per-row error list is capped at 50 with a truncation sentinel during the parse loop |
+
+### Backend (`accounts/test_throttling.py`)
+
+| Test class | Validates |
+|---|---|
+| `UploadEndpointThrottleTests` | §4.4: import endpoints and transfer-archive endpoints each return 429 past their per-user budget; the two budgets are independent; key-authenticated import requests still count against the API-key budget |
+
+### Backend (`zev/test_transfer_limits.py`)
+
+| Test class | Validates |
+|---|---|
+| `TransferArchiveLimitTests` | §4.4: transfer archives with traversal member paths (`/`- and `\`-separated, plus Windows drive letters), absolute paths, too many members, over the compressed or decompressed caps, or a high-ratio member are rejected; non-ZIP archives are rejected; the decompressed cap cannot drop below the documented 2M-row archive scale |
 
 ### Frontend
 

--- a/docs/specs/2026-08-zev-transfer-archive.md
+++ b/docs/specs/2026-08-zev-transfer-archive.md
@@ -208,7 +208,8 @@ has no readings).
   `check_format_version`, then per-section `_load_json`.
 - The whole import runs in one transaction — nothing is created unless
   everything validates. Failures are collected in a `_Collector` (the first
-  `MAX_REPORTED_ERRORS = 50` stored, the true total counted alongside) and
+  `MAX_REPORTED_ERRORS = 50` — shared with the metering importer via
+  `metering/importers/limits.py` — stored, the true total counted alongside) and
   raised as `ImportFailed(errors, total_errors=...)`; the response lists every
   problem by section, entry and reason.
 - `_preflight_meter_ids` rejects meter ids already on the instance, by name,

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,14 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  client_max_body_size 10m;
+
+  error_page 413 /413.json;
+  location = /413.json {
+    default_type application/json;
+    return 413 '{"detail":"File too large."}';
+  }
+
   location / {
     try_files $uri /index.html;
   }

--- a/frontend/src/pages/ImportsPage.tsx
+++ b/frontend/src/pages/ImportsPage.tsx
@@ -121,7 +121,14 @@ export function ImportsPage() {
     const uploadMutation = useMutation({
         mutationFn: uploadMeteringFile,
         onSuccess: (result) => {
-            pushToast(t('pages.imports.messages.importSuccess', { imported: result.rows_imported, skipped: result.rows_skipped }), 'success')
+            // SDAT-CH reports parse failures inside the ImportLog of a 201
+            // response; an import that produced nothing and logged errors is
+            // a failure, not a success toast.
+            if (result.rows_imported === 0 && (result.errors?.length ?? 0) > 0) {
+                pushToast(result.errors?.[0]?.error || t('pages.imports.messages.importFailed'), 'error')
+            } else {
+                pushToast(t('pages.imports.messages.importSuccess', { imported: result.rows_imported, skipped: result.rows_skipped }), 'success')
+            }
             setWizardOpen(false)
             setWizardStep(1)
             setFile(null)
@@ -129,8 +136,9 @@ export function ImportsPage() {
             void queryClient.invalidateQueries({ queryKey: queryKeys.metering.importLogs() })
         },
         onError: (error) => {
-            const errorMessage = (error as { response?: { data?: { error?: string } } })?.response?.data?.error
-            pushToast(errorMessage || t('pages.imports.messages.importFailed'), 'error')
+            // `detail` is the proxy's error shape (e.g. the nginx 413 body).
+            const data = (error as { response?: { data?: { error?: string; detail?: string } } })?.response?.data
+            pushToast(data?.error || data?.detail || t('pages.imports.messages.importFailed'), 'error')
         },
     })
 


### PR DESCRIPTION
## Summary

Upload endpoints now layer app-level checks under the nginx body limit, covering what a proxy is structurally blind to:

- **ZIP validation before inflation** for XLSX imports and whole-ZEV transfer archives: member count, total decompressed size, and per-member compression ratio (500:1 — deliberately loose, the decompressed sum is the hard bound). Transfer archives additionally reject unsafe member paths (`/`- and `\`-separated traversal, absolute paths, Windows drive letters). A small archive that expands a thousandfold passes any body-size limit and would otherwise OOM the worker in openpyxl or the transfer importer.
- **SDAT-CH XML** parsed with `resolve_entities=False, load_dtd=False, no_network=True, huge_tree=False`, plus a size cap before parsing and errors capped during the parse loop.
- **`values_count` validated to 1..1440** and `interval_minutes >= 1` on both import and preview (the daily-profile slot loop is otherwise an unbounded CPU spend); non-integer input raises instead of defaulting silently.
- **CSV reads stream through `TextIOWrapper`** with row and column caps enforced during iteration; the XLSX column cap holds for every row. The row cap counts data rows — a header does not consume it.
- **Per-user throttles** bound worker exhaustion that size caps alone cannot (import 60/hour, transfer archive 20/hour, both env-tunable).

The checks live once, not per importer: `metering/importers/limits.py` (shared `validate_zip`, `reject_unsafe_member_path`, `add_error`, upload/error constants) and `testing/zips.py` for the ZIP test fixtures; the two importers run one shared validation path, parameterized by per-importer limits. Int validation is single-layer — the coercers raise, the views map to 400. The import and archive views list `ApiKeyRateThrottle` alongside their specific throttle because view-level `throttle_classes` *replace* the DRF defaults; without it, key-authenticated requests silently stop counting against the API-key budget.

The proxy layer matches the app limits: `client_max_body_size 10m` globally with 50m on the import and archive locations (proxy headers hoisted to one server block), JSON 413 responses, and the Helm ingress sets `proxy-body-size: 50m`. The import UI reads the proxy's `detail` 413 shape and treats a 201 whose log has `rows_imported == 0` with errors as a failure, so an oversized SDAT-CH file surfaces as an error toast rather than a success.

Volume caps that trade off against real data stay env-tunable (`IMPORT_MAX_ROWS` 200k — ~5.7 meter-years of standard-profile 15-minute data, ~548 meter-years for daily profiles; `TRANSFER_MAX_DECOMPRESSED_MB` 500 MB, sized for the documented 2M-row archive scale and guarded by a test); compressed-size caps are constants because they pair with the nginx 50m locations.

## Linked spec

- Spec: docs/specs/2026-03-metering-import-and-quality.md — §4.4 (hardening and limits) and the test-plan tables
- Spec: docs/specs/2026-08-zev-transfer-archive.md — importer error-cap provenance
- ADR: N/A — hardening and consolidation within the existing structure, no architecture decision

## Validation

- Backend tests run: `python -m pytest -q` — full suite green (exit 0); new/extended suites in `metering/test_import_limits.py` (caps, header/headerless row boundaries, coercion, error-cap + overwrite trim), `metering/test_import_sdatch.py`, `zev/test_transfer_limits.py` (traversal incl. drive letters, member/size/ratio caps, 2M-row guard), `accounts/test_throttling.py` (per-user budgets, budget independence, API-key budget still counted)
- Frontend build run: `npm run build` ✓
- Frontend tests run: `npm run test:unit` — 124/124 ✓
- Manual checks: `ruff check` clean on all touched modules; DRF semantics verified against installed source (view-level throttle_classes replacement; permissions run before throttles); nginx `proxy_set_header` inheritance reviewed (no location overrides the set, so the server-level hoist is behavior-preserving)
- Screenshots: N/A — no visual change beyond error toasts

## Checklist

- [x] Spec updated/linked for larger or risky changes
- ADR: N/A — no architecture decision
- [x] Backend and frontend updated together where API contracts changed (413 `detail` fallback and 201-with-errors failure handling)
