### PR TITLE
fix(compose): proxy API same-origin to restore cookie CSRF

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,8 @@ services:
       context: .
       dockerfile: frontend/Dockerfile
       args:
-        VITE_API_BASE_URL: http://localhost:8001/api/v1
+        VITE_API_BASE_URL: /api/v1
+        NGINX_CONF: nginx.compose.conf
     ports:
       - "8080:80"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -30,7 +30,9 @@ LABEL org.opencontainers.image.title="$OCI_TITLE" \
     org.opencontainers.image.revision="$OCI_REVISION" \
     org.opencontainers.image.created="$OCI_CREATED"
 
-COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+# compose overrides this with nginx.compose.conf to proxy /api same-origin.
+ARG NGINX_CONF=nginx.conf
+COPY frontend/$NGINX_CONF /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.compose.conf
+++ b/frontend/nginx.compose.conf
@@ -1,0 +1,27 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  client_max_body_size 10m;
+
+  error_page 413 /413.json;
+  location = /413.json {
+    default_type application/json;
+    return 413 '{"detail":"File too large."}';
+  }
+
+  location /api/ {
+    proxy_pass http://backend:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location / {
+    try_files $uri /index.html;
+  }
+}


### PR DESCRIPTION
## Summary

The compose demo frontend broke after #446 (cookie-JWT CSRF enforcement): the UI ran at `localhost:8080` while its image called the backend cross-origin at `http://localhost:8001`, so axios could not read the `csrftoken` cookie and every unsafe request failed with `CSRF Failed: CSRF token missing.`

Build the compose frontend same-origin (`VITE_API_BASE_URL=/api/v1`) and proxy `/api/` to the backend service through nginx. The proxy is a compose-only config (`frontend/nginx.compose.conf`, selected via a new `NGINX_CONF` Docker build arg); released images keep the shared `nginx.conf` and rely on an ingress, so the hardcoded `backend:8000` upstream never ships to Helm/K8s.

## Linked spec

N/A: compose dev-environment fix — no API, workflow, or authentication-logic change.

## Validation

- Backend tests run: not run — no backend change.
- Frontend build run: not run this session.
- Frontend tests run: not run this session.
- Manual checks: not performed this session — requires `docker compose up -d --build frontend` then re-login (`scripts/start-demo-environment.sh`).
- Screenshots: n/a

Checked: `docker compose config` valid; `git diff --check` clean.

## Checklist

- N/A: spec updated/linked for larger or risky changes (compose-only, no API/workflow impact)
- N/A: ADR updated/linked (no architecture decision changed)
- N/A: backend and frontend updated together (no API contract change)