### PR TITLE
feat(invoices): allocation-weight primitive for shared metering points

### DIFF
--- a/backend/invoices/engine.py
+++ b/backend/invoices/engine.py
@@ -423,6 +423,72 @@ def _count_active_participants_by_month(zev: Zev, tariff: Tariff, period_start: 
     return counts
 
 
+def _allocation_weight_sum_by_month(zev: Zev, period_start: date, period_end: date) -> dict[date, Decimal]:
+    """Sum of ``Participant.allocation_weight`` active in each billed month.
+
+    Counted per month, not once over the period — same rationale as
+    ``_count_active_participants_by_month``: a joiner in February must not
+    dilute January's share. Read from ZEV membership, never from sibling
+    invoices, so generating one participant's invoice alone yields the same
+    share as a full run.
+
+    Unlike ``_count_active_participants_by_month`` this takes no ``tariff``:
+    it feeds both weight-keyed SHARED_* fees (which look up their own
+    tariff-clipped months here) and per-metering-point community fees, and
+    is computed once over the whole invoice period rather than once per
+    tariff. A month with no eligible participant is absent, not zero, so a
+    caller cannot divide by it.
+    """
+    windows = list(
+        Participant.objects.filter(zev=zev).values_list("valid_from", "valid_to", "allocation_weight")
+    )
+
+    sums: dict[date, Decimal] = {}
+    cursor = _month_start(period_start)
+    last_month = _month_start(period_end)
+    while cursor <= last_month:
+        next_month = _next_month(cursor)
+        billed_from = max(cursor, period_start)
+        billed_to = min(next_month - timedelta(days=1), period_end)
+        total = sum(
+            (weight for valid_from, valid_to, weight in windows
+             if _overlaps(valid_from, valid_to, billed_from, billed_to)),
+            Decimal("0"),
+        )
+        if total > 0:
+            sums[cursor] = total
+        cursor = next_month
+
+    return sums
+
+
+def _allocation_weight_sum_by_date(zev: Zev, period_start: date, period_end: date) -> dict[date, Decimal]:
+    """Sum of ``Participant.allocation_weight`` active on each calendar date.
+
+    Date-granular, matching ``participant_on``: feeds shared energy, levies
+    and credits, so a mid-period joiner's share starts exactly on their join
+    date rather than at the start of the month. A date with no eligible
+    participant is absent, not zero.
+    """
+    windows = list(
+        Participant.objects.filter(zev=zev).values_list("valid_from", "valid_to", "allocation_weight")
+    )
+
+    sums: dict[date, Decimal] = {}
+    cursor = period_start
+    while cursor <= period_end:
+        total = sum(
+            (weight for valid_from, valid_to, weight in windows
+             if valid_from <= cursor and (valid_to is None or valid_to >= cursor)),
+            Decimal("0"),
+        )
+        if total > 0:
+            sums[cursor] = total
+        cursor += timedelta(days=1)
+
+    return sums
+
+
 _ENERGY_BILLING_MODES = {BillingMode.ENERGY, BillingMode.PERCENTAGE_OF_ENERGY}
 _SHARED_BILLING_MODES = {BillingMode.SHARED_MONTHLY_FEE, BillingMode.SHARED_YEARLY_FEE}
 

--- a/backend/invoices/test_allocation_weight_helpers.py
+++ b/backend/invoices/test_allocation_weight_helpers.py
@@ -1,0 +1,164 @@
+"""Unit tests for the allocation-weight primitive (shared metering points,
+docs/specs/2026-08-shared-metering-points.md §7.1).
+
+Neither helper is called from anywhere yet — they're wired into SHARED_* fee
+pricing and community-meter billing in later phases — so these are direct
+unit tests of the helpers themselves rather than end-to-end engine tests.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from testing.factories import ParticipantFactory, ZevFactory
+
+from .engine import _allocation_weight_sum_by_date, _allocation_weight_sum_by_month
+
+pytestmark = pytest.mark.django_db
+
+PERIOD_START = date(2026, 1, 1)
+PERIOD_END = date(2026, 3, 31)
+
+
+def _zev_with_participants(*weights_and_windows):
+    """A ZEV with one participant per ``(weight, valid_from, valid_to)`` tuple."""
+    zev = ZevFactory()
+    for weight, valid_from, valid_to in weights_and_windows:
+        ParticipantFactory(zev=zev, valid_from=valid_from, valid_to=valid_to, allocation_weight=weight)
+    return zev
+
+
+def test_default_weights_sum_to_the_headcount():
+    """With every weight at its default (1), the sum is just a count — the
+    special case the weight helper collapses to."""
+    zev = _zev_with_participants(
+        (Decimal("1"), date(2026, 1, 1), None),
+        (Decimal("1"), date(2026, 1, 1), None),
+        (Decimal("1"), date(2026, 1, 1), None),
+    )
+
+    sums = _allocation_weight_sum_by_month(zev, PERIOD_START, PERIOD_END)
+
+    assert sums == {
+        date(2026, 1, 1): Decimal("3"),
+        date(2026, 2, 1): Decimal("3"),
+        date(2026, 3, 1): Decimal("3"),
+    }
+
+
+def test_unequal_weights_sum_correctly():
+    zev = _zev_with_participants(
+        (Decimal("1"), date(2026, 1, 1), None),
+        (Decimal("2.5"), date(2026, 1, 1), None),
+        (Decimal("0.5"), date(2026, 1, 1), None),
+    )
+
+    sums = _allocation_weight_sum_by_month(zev, PERIOD_START, PERIOD_END)
+
+    assert sums[date(2026, 1, 1)] == Decimal("4")
+
+
+def test_joiner_shifts_the_month_sum_only_from_their_own_month():
+    """A participant joining mid-period must not retroactively change earlier
+    months' denominators — the per-month counting rationale that
+    _count_active_participants_by_month already documents."""
+    zev = _zev_with_participants(
+        (Decimal("1"), date(2026, 1, 1), None),
+        (Decimal("2"), date(2026, 2, 15), None),
+    )
+
+    sums = _allocation_weight_sum_by_month(zev, PERIOD_START, PERIOD_END)
+
+    assert sums[date(2026, 1, 1)] == Decimal("1")
+    assert sums[date(2026, 2, 1)] == Decimal("3")
+    assert sums[date(2026, 3, 1)] == Decimal("3")
+
+
+def test_leaver_stops_contributing_the_month_after_they_leave():
+    zev = _zev_with_participants(
+        (Decimal("1"), date(2026, 1, 1), None),
+        (Decimal("2"), date(2026, 1, 1), date(2026, 1, 20)),
+    )
+
+    sums = _allocation_weight_sum_by_month(zev, PERIOD_START, PERIOD_END)
+
+    assert sums[date(2026, 1, 1)] == Decimal("3")
+    assert sums[date(2026, 2, 1)] == Decimal("1")
+
+
+def test_month_with_no_eligible_participant_is_absent_not_zero():
+    """A caller must not be able to divide by an absent-but-present-as-zero
+    denominator, so an empty month is missing from the dict entirely."""
+    zev = _zev_with_participants(
+        (Decimal("1"), date(2026, 1, 1), date(2026, 1, 31)),
+    )
+
+    sums = _allocation_weight_sum_by_month(zev, PERIOD_START, PERIOD_END)
+
+    assert date(2026, 1, 1) in sums
+    assert date(2026, 2, 1) not in sums
+    assert date(2026, 3, 1) not in sums
+
+
+def test_regeneration_from_zev_membership_not_sibling_invoices():
+    """The sum is read from Participant validity, never from other invoices
+    that happen to exist — required for single-participant regeneration to
+    match a full run."""
+    zev = _zev_with_participants(
+        (Decimal("1"), date(2026, 1, 1), None),
+        (Decimal("1"), date(2026, 1, 1), None),
+    )
+
+    whole_run = _allocation_weight_sum_by_month(zev, PERIOD_START, PERIOD_END)
+    same_call_again = _allocation_weight_sum_by_month(zev, PERIOD_START, PERIOD_END)
+
+    assert whole_run == same_call_again
+
+
+def test_by_date_matches_membership_on_the_exact_join_day():
+    """Date-granular: a joiner's weight counts from their valid_from day, not
+    from the start of the month — matching participant_on's day-level
+    resolution rather than _allocation_weight_sum_by_month's month buckets."""
+    zev = _zev_with_participants(
+        (Decimal("1"), date(2026, 1, 1), None),
+        (Decimal("2"), date(2026, 1, 15), None),
+    )
+
+    sums = _allocation_weight_sum_by_date(zev, date(2026, 1, 1), date(2026, 1, 20))
+
+    assert sums[date(2026, 1, 14)] == Decimal("1")
+    assert sums[date(2026, 1, 15)] == Decimal("3")
+
+
+def test_by_date_leaver_stops_on_their_exact_leave_day():
+    zev = _zev_with_participants(
+        (Decimal("1"), date(2026, 1, 1), None),
+        (Decimal("2"), date(2026, 1, 1), date(2026, 1, 10)),
+    )
+
+    sums = _allocation_weight_sum_by_date(zev, date(2026, 1, 1), date(2026, 1, 20))
+
+    assert sums[date(2026, 1, 10)] == Decimal("3")
+    assert sums[date(2026, 1, 11)] == Decimal("1")
+
+
+def test_by_date_day_with_no_eligible_participant_is_absent_not_zero():
+    zev = _zev_with_participants(
+        (Decimal("1"), date(2026, 1, 5), date(2026, 1, 10)),
+    )
+
+    sums = _allocation_weight_sum_by_date(zev, date(2026, 1, 1), date(2026, 1, 20))
+
+    assert date(2026, 1, 5) in sums
+    assert date(2026, 1, 1) not in sums
+    assert date(2026, 1, 20) not in sums
+
+
+def test_a_zev_with_no_participants_at_all_returns_empty_dicts():
+    """Degenerate case: no participants means every month/date is absent, not
+    a zero-division waiting to happen in a future caller."""
+    zev = ZevFactory()
+
+    assert _allocation_weight_sum_by_month(zev, PERIOD_START, PERIOD_END) == {}
+    assert _allocation_weight_sum_by_date(zev, PERIOD_START, PERIOD_END) == {}


### PR DESCRIPTION
## Summary

Phase 2 of shared metering points ([spec](https://github.com/splattner/openzev/blob/main/docs/specs/2026-08-shared-metering-points.md), #387), stacked on #459.

`_allocation_weight_sum_by_month` and `_allocation_weight_sum_by_date`, added alongside — **not replacing** — `_count_active_participants_by_month`. Neither is called from anywhere yet: this PR is the primitive and its own tests only.

Same per-month/per-date counting rationale as the existing headcount helper: read from ZEV membership, never from sibling invoices, so a joiner or leaver only shifts the months/dates they were actually present for, and a single-participant regeneration matches a full run. Unlike the headcount helper, neither takes a `tariff` argument — they're computed once over the whole invoice period and looked up by month/date key, since they also have to serve community energy, which has no tariff of its own until pricing time (a later phase).

## Tests

New file `invoices/test_allocation_weight_helpers.py`, 10 tests: default-weight collapse to headcount, unequal weights, joiner/leaver granularity for both the month and date variants, the "absent not zero" denominator-safety property (a caller must never divide by a month/date that had nobody eligible), regeneration-from-membership, and the zero-participant degenerate case.

## Validation

- `python -m pytest -q` — **1170 passed** (1160 baseline from #459 + 10 new)
- `ruff check` clean
- `makemigrations --check --dry-run` — no changes (no model touched)
- Confirmed the two new functions have no caller outside the test file — genuinely inert in this PR

## Mutation-tested

| mutant | result |
|---|---|
| month-sum drops the `valid_to` bound (a leaver never stops contributing) | 2 tests failed |
| date-sum treats `valid_to` as exclusive instead of inclusive | 1 test failed |

Refs #387
