### PR TITLE
feat(allocation,invoices,metering): read-model + consumer migration for shared metering points

### DIFF
--- a/backend/allocation/read_model.py
+++ b/backend/allocation/read_model.py
@@ -25,13 +25,13 @@ or count them as it sees fit.
 
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 
 from django.db import models
 
 from metering.models import MeterReading, ReadingDirection
-from zev.models import MeteringPoint, MeteringPointType
+from zev.models import MeteringPoint, MeteringPointType, Participant
 
 from .split import (
     ConsumptionSplit,
@@ -51,6 +51,43 @@ _KINDS = {
     CONSUMPTION: (CONSUMPTION_METER_TYPES, ReadingDirection.IN),
     PRODUCTION: (PRODUCTION_METER_TYPES, ReadingDirection.OUT),
 }
+
+
+def eligible_participant_shares(zev, period_start: date, period_end: date) -> dict[date, dict[uuid.UUID, Decimal]]:
+    """Each eligible participant's normalized weight share, per calendar date.
+
+    ``date -> {participant_id: share}``, the shares for one date summing to 1.
+    A date with no eligible participant is absent from the dict entirely —
+    never present with an empty or zero-summing mapping — so a consumer
+    distributing a community reading for that date can tell "there was
+    nobody to distribute to" apart from a bug that silently distributed to
+    no one.
+
+    Shared across every consumer that must split a community-allocated
+    reading across participants (PDF stats, dashboards, annual statement,
+    hourly profiles, and eventually the invoice engine itself) rather than
+    each re-deriving eligibility and weight independently — the same reason
+    this module centralizes the reading fetch/resolve/split core. Date
+    granularity matches ``AssignmentWindows.participant_on`` and the reading
+    attribution the rest of this module already uses.
+    """
+    windows = list(
+        Participant.objects.filter(zev=zev).values_list("id", "valid_from", "valid_to", "allocation_weight")
+    )
+
+    shares: dict[date, dict[uuid.UUID, Decimal]] = {}
+    cursor = period_start
+    while cursor <= period_end:
+        eligible = [
+            (participant_id, weight) for participant_id, valid_from, valid_to, weight in windows
+            if valid_from <= cursor and (valid_to is None or valid_to >= cursor)
+        ]
+        if eligible:
+            total_weight = sum(weight for _pid, weight in eligible)
+            shares[cursor] = {pid: weight / total_weight for pid, weight in eligible}
+        cursor += timedelta(days=1)
+
+    return shares
 
 
 def community_totals_by_timestamp(zev, start_dt: datetime, end_dt: datetime) -> tuple[dict, dict]:
@@ -92,13 +129,19 @@ class AllocatedReading:
     timestamp; ``zev_consumption_kwh``/``zev_production_kwh`` are the physical
     community totals the split was computed against. ``holder_id`` is the
     participant's UUID (``Participant.id`` is a ``UUIDField``) or ``None`` for a
-    gap reading (no assignment active at the timestamp). ``split`` is ``None``
-    when the caller passed ``with_split=False``.
+    gap reading (no assignment active at the timestamp) — the literal holder of
+    record even when ``allocation_mode`` is ``"community"``, kept for
+    provenance. ``allocation_mode`` is ``"personal"``/``"community"``, or
+    ``None`` for a gap reading. Consumers that must not attribute a community
+    reading to its holder personally should branch on ``allocation_mode``
+    rather than assuming a non-``None`` ``holder_id`` means "bill this person".
+    ``split`` is ``None`` when the caller passed ``with_split=False``.
     """
 
     metering_point_id: uuid.UUID
     timestamp: datetime
     holder_id: uuid.UUID | None
+    allocation_mode: str | None
     energy_kwh: Decimal
     zev_consumption_kwh: Decimal
     zev_production_kwh: Decimal
@@ -175,10 +218,12 @@ def iter_allocated_readings(
             split = split_consumption(energy_kwh, zev_consumption, zev_production)
         else:
             split = split_production(energy_kwh, zev_production, zev_consumption)
+        resolution = windows.assignment_at(metering_point_id, ts)
         yield AllocatedReading(
             metering_point_id=metering_point_id,
             timestamp=ts,
-            holder_id=windows.participant_at(metering_point_id, ts),
+            holder_id=resolution.holder_id if resolution is not None else None,
+            allocation_mode=resolution.allocation_mode if resolution is not None else None,
             energy_kwh=energy_kwh,
             zev_consumption_kwh=zev_consumption,
             zev_production_kwh=zev_production,

--- a/backend/allocation/test_read_model.py
+++ b/backend/allocation/test_read_model.py
@@ -19,13 +19,14 @@ from allocation.read_model import (
     CONSUMPTION,
     PRODUCTION,
     community_totals_by_timestamp,
+    eligible_participant_shares,
     iter_allocated_readings,
 )
 from allocation.split import split_consumption, split_production
 from allocation.windows import AssignmentWindows
 from metering.models import MeterReading, ReadingDirection
 from testing.helpers import make_named_participant
-from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Zev
+from zev.models import AllocationMode, MeteringPoint, MeteringPointAssignment, MeteringPointType, Zev
 
 User = get_user_model()
 
@@ -263,3 +264,159 @@ class ReadModelTests(TestCase):
             list(iter_allocated_readings(
                 self.zev, START_DT, END_DT, kind="bogus", windows=self.windows
             ))
+
+
+class SharedReadModelTests(TestCase):
+    """Pins the read-model contract for community-allocated readings (shared
+    metering points, docs/specs/2026-08-shared-metering-points.md §7.7)."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            username="shared_readmodel_owner", password="pass1234", role=UserRole.ZEV_OWNER
+        )
+        self.zev = Zev.objects.create(
+            name="Shared ReadModel ZEV", owner=self.owner, zev_type="vzev",
+            start_date=PERIOD_START, billing_interval="monthly", invoice_prefix="SR",
+        )
+        self.zev.refresh_from_db()
+
+        self.alice = make_named_participant(self.zev, "Alice Muster", PERIOD_START)
+        self.community_mp = MeteringPoint.objects.create(
+            zev=self.zev, meter_type=MeteringPointType.CONSUMPTION, meter_id="CH-SR-COMMUNITY-1",
+        )
+        MeteringPointAssignment.objects.create(
+            metering_point=self.community_mp, participant=self.alice,
+            valid_from=PERIOD_START, allocation_mode=AllocationMode.COMMUNITY,
+        )
+        MeterReading.objects.create(
+            metering_point=self.community_mp, timestamp=_ts(date(2026, 1, 5)),
+            energy_kwh=Decimal("4"), direction=ReadingDirection.IN,
+        )
+
+        self.windows = AssignmentWindows.for_zev(self.zev, PERIOD_START, PERIOD_END)
+
+    def test_community_readings_carry_mode_and_literal_holder(self):
+        """A community reading resolves to its literal holder (provenance)
+        and carries allocation_mode='community' — the two things a consumer
+        needs to distribute it instead of attributing it to the holder."""
+        readings = {
+            (r.metering_point_id, r.timestamp): r
+            for r in iter_allocated_readings(
+                self.zev, START_DT, END_DT, kind=CONSUMPTION, windows=self.windows,
+            )
+        }
+        reading = readings[(self.community_mp.id, _ts(date(2026, 1, 5)))]
+
+        self.assertEqual(reading.holder_id, self.alice.id)
+        self.assertEqual(reading.allocation_mode, "community")
+
+    def test_community_readings_split_against_the_physical_pool(self):
+        """Split math is unchanged for community meters: allocation_mode only
+        changes how a consumer attributes the reading, never the physical
+        split against the community pool."""
+        cons_by_ts, prod_by_ts = community_totals_by_timestamp(self.zev, START_DT, END_DT)
+        readings = {
+            (r.metering_point_id, r.timestamp): r
+            for r in iter_allocated_readings(
+                self.zev, START_DT, END_DT, kind=CONSUMPTION, windows=self.windows,
+                consumption_by_ts=cons_by_ts, production_by_ts=prod_by_ts,
+            )
+        }
+        reading = readings[(self.community_mp.id, _ts(date(2026, 1, 5)))]
+        expected = split_consumption(
+            Decimal("4"), cons_by_ts[_ts(date(2026, 1, 5))], prod_by_ts.get(_ts(date(2026, 1, 5)), Decimal("0")),
+        )
+
+        self.assertEqual(reading.split, expected)
+
+    def test_community_readings_are_distinct_from_gap_readings(self):
+        """A community reading and a gap reading both carry a non-attributing
+        signal, but consumers must be able to tell them apart: a gap has
+        holder_id=None, a community reading has a real holder_id and
+        allocation_mode='community'."""
+        gap_mp = MeteringPoint.objects.create(
+            zev=self.zev, meter_type=MeteringPointType.CONSUMPTION, meter_id="CH-SR-GAP-1",
+        )
+        MeterReading.objects.create(
+            metering_point=gap_mp, timestamp=_ts(date(2026, 1, 5)),
+            energy_kwh=Decimal("2"), direction=ReadingDirection.IN,
+        )
+        windows = AssignmentWindows.for_zev(self.zev, PERIOD_START, PERIOD_END)
+        readings = {
+            (r.metering_point_id, r.timestamp): r
+            for r in iter_allocated_readings(
+                self.zev, START_DT, END_DT, kind=CONSUMPTION, windows=windows,
+            )
+        }
+
+        gap = readings[(gap_mp.id, _ts(date(2026, 1, 5)))]
+        community = readings[(self.community_mp.id, _ts(date(2026, 1, 5)))]
+
+        self.assertIsNone(gap.holder_id)
+        self.assertIsNone(gap.allocation_mode)
+        self.assertIsNotNone(community.holder_id)
+        self.assertEqual(community.allocation_mode, "community")
+
+
+class EligibleParticipantSharesTests(TestCase):
+    """Unit tests for eligible_participant_shares — the shared "who's
+    eligible and at what weight, per date" primitive every community-reading
+    consumer uses."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            username="shares_owner", password="pass1234", role=UserRole.ZEV_OWNER
+        )
+        self.zev = Zev.objects.create(
+            name="Shares ZEV", owner=self.owner, zev_type="vzev",
+            start_date=PERIOD_START, billing_interval="monthly", invoice_prefix="SH",
+        )
+        self.zev.refresh_from_db()
+
+    def _participant(self, name, valid_from, valid_to=None, weight="1"):
+        p = make_named_participant(self.zev, name, valid_from, valid_to)
+        p.allocation_weight = Decimal(weight)
+        p.save(update_fields=["allocation_weight"])
+        return p
+
+    def test_default_weights_split_evenly(self):
+        self._participant("Alice Muster", PERIOD_START)
+        self._participant("Bob Beispiel", PERIOD_START)
+
+        shares = eligible_participant_shares(self.zev, PERIOD_START, PERIOD_END)
+
+        day_shares = shares[date(2026, 1, 5)]
+        self.assertEqual(set(day_shares.values()), {Decimal("0.5")})
+        self.assertEqual(sum(day_shares.values()), Decimal("1"))
+
+    def test_unequal_weights_produce_proportional_shares(self):
+        alice = self._participant("Alice Muster", PERIOD_START, weight="3")
+        bob = self._participant("Bob Beispiel", PERIOD_START, weight="1")
+
+        shares = eligible_participant_shares(self.zev, PERIOD_START, PERIOD_END)
+
+        day_shares = shares[date(2026, 1, 5)]
+        self.assertEqual(day_shares[alice.id], Decimal("0.75"))
+        self.assertEqual(day_shares[bob.id], Decimal("0.25"))
+        self.assertEqual(sum(day_shares.values()), Decimal("1"))
+
+    def test_joiner_only_appears_from_their_join_date(self):
+        alice = self._participant("Alice Muster", PERIOD_START)
+        bob = self._participant("Bob Beispiel", date(2026, 1, 16))
+
+        shares = eligible_participant_shares(self.zev, PERIOD_START, PERIOD_END)
+
+        self.assertEqual(shares[date(2026, 1, 15)], {alice.id: Decimal("1")})
+        self.assertEqual(shares[date(2026, 1, 16)], {alice.id: Decimal("0.5"), bob.id: Decimal("0.5")})
+
+    def test_date_with_no_eligible_participant_is_absent(self):
+        self._participant("Alice Muster", date(2026, 1, 10), date(2026, 1, 20))
+
+        shares = eligible_participant_shares(self.zev, PERIOD_START, PERIOD_END)
+
+        self.assertIn(date(2026, 1, 10), shares)
+        self.assertNotIn(date(2026, 1, 1), shares)
+        self.assertNotIn(date(2026, 1, 31), shares)
+
+    def test_a_zev_with_no_participants_returns_empty(self):
+        self.assertEqual(eligible_participant_shares(self.zev, PERIOD_START, PERIOD_END), {})

--- a/backend/invoices/annual_statement.py
+++ b/backend/invoices/annual_statement.py
@@ -15,13 +15,14 @@ from allocation.read_model import (
     CONSUMPTION_METER_TYPES,
     PRODUCTION_METER_TYPES,
     community_totals_by_timestamp,
+    eligible_participant_shares,
 )
 from allocation.split import split_consumption
 from allocation.windows import AssignmentWindows
 from .pdf_render import render_pdf
 
 from metering.models import MeterReading, ReadingDirection
-from zev.models import MeteringPointAssignment
+from zev.models import AllocationMode, MeteringPointAssignment
 from .models import Invoice, InvoiceStatus
 from .pdf import _format_date_value, _render_template
 
@@ -192,10 +193,16 @@ def _compute_monthly_data(participant, zev, year: int, tr: dict) -> tuple[list[d
     year_start_dt = datetime(year, 1, 1, tzinfo=dt_timezone.utc)
     year_end_dt = datetime(year + 1, 1, 1, tzinfo=dt_timezone.utc)
 
-    # All metering point assignments for this participant in this year
+    # This participant's own assignments, plus every community-allocated
+    # assignment in the ZEV regardless of who literally holds it — a meter
+    # this participant is only weight-eligible for (not the holder of
+    # record) must still reach the readings fetch and the windows below, or
+    # a community-only stake in the ZEV never shows up here at all (the same
+    # gap fixed for the dashboards in metering/analytics.py and views.py).
     assignments = list(
         MeteringPointAssignment.objects.filter(
-            participant=participant,
+            Q(participant=participant) | Q(allocation_mode=AllocationMode.COMMUNITY),
+            metering_point__zev=zev,
             valid_from__lte=year_end,
         ).filter(
             Q(valid_to__isnull=True) | Q(valid_to__gte=year_start)
@@ -248,11 +255,28 @@ def _compute_monthly_data(participant, zev, year: int, tr: dict) -> tuple[list[d
     # ── Per-timestamp attribution windows (ADR 0013) ────────────────────────
     # Readings are only counted for the participant while their assignment is
     # active at the reading's timestamp — a mid-year transfer must not hand
-    # the new holder the old holder's readings.
+    # the new holder the old holder's readings. ``a.participant_id`` is the
+    # literal holder (which may be someone else, for a community window);
+    # ``_participant_share`` below is what decides this participant's own
+    # cut, personal or weighted.
     windows = AssignmentWindows(
-        (a.metering_point_id, a.valid_from, a.valid_to, participant.id, a.allocation_mode, a.id)
+        (a.metering_point_id, a.valid_from, a.valid_to, a.participant_id, a.allocation_mode, a.id)
         for a in assignments
     )
+    shares_by_date = eligible_participant_shares(zev, year_start, year_end)
+
+    def _participant_share(metering_point_id, ts) -> Decimal:
+        """This participant's share of a reading at (mp, ts): 1 for a
+        personal assignment they hold, their normalized weight share for a
+        community assignment (0 if not eligible that date), 0 for a gap or
+        somebody else's personal meter."""
+        resolution = windows.assignment_at(metering_point_id, ts)
+        if resolution is None:
+            return Decimal("0")
+        if resolution.allocation_mode == AllocationMode.COMMUNITY:
+            day = ts.astimezone(dt_timezone.utc).date()
+            return shares_by_date.get(day, {}).get(participant.id, Decimal("0"))
+        return Decimal("1") if resolution.holder_id == participant.id else Decimal("0")
 
     # ── Accumulate per-timestamp, bucket into months ────────────────────────
     month_acc = {m: {"consumed": Decimal("0"), "from_zev": Decimal("0"),
@@ -262,10 +286,11 @@ def _compute_monthly_data(participant, zev, year: int, tr: dict) -> tuple[list[d
     # Consumption with local-pool allocation per timestamp
     for row in participant_consumption_rows:
         ts = row["timestamp"]
-        if not windows.is_held_by(participant.id, row["metering_point_id"], ts):
+        share = _participant_share(row["metering_point_id"], ts)
+        if share == 0:
             continue
         month_num = ts.month
-        consumed = row["consumed_kwh"] or Decimal("0")
+        consumed = (row["consumed_kwh"] or Decimal("0")) * share
 
         zev_consumed = zev_consumption_by_ts.get(ts, Decimal("0"))
         zev_produced = zev_production_by_ts.get(ts, Decimal("0"))
@@ -278,10 +303,11 @@ def _compute_monthly_data(participant, zev, year: int, tr: dict) -> tuple[list[d
     # Production (just sum per month, no allocation needed)
     for row in participant_production_rows:
         ts = row["timestamp"]
-        if not windows.is_held_by(participant.id, row["metering_point_id"], ts):
+        share = _participant_share(row["metering_point_id"], ts)
+        if share == 0:
             continue
         month_num = ts.month
-        produced = row["produced_kwh"] or Decimal("0")
+        produced = (row["produced_kwh"] or Decimal("0")) * share
         month_acc[month_num]["produced"] += produced
 
     # ── Build output rows ───────────────────────────────────────────────────

--- a/backend/invoices/pdf_charts.py
+++ b/backend/invoices/pdf_charts.py
@@ -502,11 +502,12 @@ def _build_hourly_profile_chart_svg(invoice, tr: dict) -> str | None:
     from allocation.read_model import (
         CONSUMPTION_METER_TYPES as _CONS_METER_TYPES,
         community_totals_by_timestamp,
+        eligible_participant_shares,
     )
     from allocation.split import split_consumption
     from allocation.windows import AssignmentWindows
     from metering.models import MeterReading, ReadingDirection, ReadingResolution
-    from zev.models import MeteringPoint as _MP
+    from zev.models import AllocationMode, MeteringPoint as _MP, MeteringPointAssignment as _MPA
 
     ps = invoice.period_start
     pe = invoice.period_end
@@ -517,14 +518,27 @@ def _build_hourly_profile_chart_svg(invoice, tr: dict) -> str | None:
     end_dt = _period_to_dt(pe) + _dt.timedelta(days=1)
 
     # ── Participant consumption readings ────────────────────────────────────
-    consumption_mps = _MP.objects.filter(
-        zev=zev,
-        meter_type__in=_CONS_METER_TYPES,
-        assignments__participant=participant,
-        assignments__valid_from__lte=pe,
-    ).filter(
-        _dj.Q(assignments__valid_to__isnull=True) | _dj.Q(assignments__valid_to__gte=ps)
-    ).distinct()
+    # A meter matters here if this participant personally holds it, OR it is
+    # community-allocated (they may be weight-eligible regardless of who the
+    # literal holder is) — otherwise a community-only stake never reaches the
+    # chart. Two flat queries unioned in Python, matching the same fix in
+    # metering.analytics.compute_hourly_profile (shared metering points, #387).
+    _mp_window = _dj.Q(valid_to__isnull=True) | _dj.Q(valid_to__gte=ps)
+    personal_mp_ids = _MPA.objects.filter(
+        _mp_window,
+        metering_point__zev=zev,
+        metering_point__meter_type__in=_CONS_METER_TYPES,
+        participant=participant,
+        valid_from__lte=pe,
+    ).values_list("metering_point_id", flat=True)
+    community_mp_ids = _MPA.objects.filter(
+        _mp_window,
+        metering_point__zev=zev,
+        metering_point__meter_type__in=_CONS_METER_TYPES,
+        allocation_mode=AllocationMode.COMMUNITY,
+        valid_from__lte=pe,
+    ).values_list("metering_point_id", flat=True)
+    consumption_mps = _MP.objects.filter(id__in=set(personal_mp_ids) | set(community_mp_ids))
     participant_readings = list(
         MeterReading.objects.filter(
             metering_point__in=consumption_mps,
@@ -536,7 +550,8 @@ def _build_hourly_profile_chart_svg(invoice, tr: dict) -> str | None:
     if not participant_readings:
         return None
 
-    windows = AssignmentWindows.for_participant(participant, ps, pe)
+    windows = AssignmentWindows.for_zev(zev, ps, pe)
+    shares_by_date = eligible_participant_shares(zev, ps, pe)
 
     # Only show chart when sub-daily data is present
     resolutions = {r.resolution for r in participant_readings}
@@ -556,12 +571,22 @@ def _build_hourly_profile_chart_svg(invoice, tr: dict) -> str | None:
 
     for reading in participant_readings:
         ts = reading.timestamp
-        if not windows.is_held_by(participant.id, reading.metering_point_id, ts):
-            # Reading predates this participant's assignment (or falls in an
-            # assignment gap): it must not shape their profile.
+        # This participant's share: 1 for a personal assignment they hold,
+        # their normalized weight share for a community assignment (0 if not
+        # eligible that date), 0 for a gap or somebody else's personal
+        # meter — it must not shape their profile.
+        resolution = windows.assignment_at(reading.metering_point_id, ts)
+        if resolution is None:
+            continue
+        if resolution.allocation_mode == AllocationMode.COMMUNITY:
+            day = ts.astimezone(_dt.timezone.utc).date()
+            share = shares_by_date.get(day, {}).get(participant.id, _Dec("0"))
+        else:
+            share = _Dec("1") if resolution.holder_id == participant.id else _Dec("0")
+        if share == 0:
             continue
         hour = ts.hour
-        p_kwh = reading.energy_kwh
+        p_kwh = reading.energy_kwh * share
         zev_cons = zev_cons_by_ts.get(ts, _Dec("0"))
         zev_prod = zev_prod_by_ts.get(ts, _Dec("0"))
         r_local, r_grid = split_consumption(p_kwh, zev_cons, zev_prod)

--- a/backend/invoices/pdf_stats.py
+++ b/backend/invoices/pdf_stats.py
@@ -7,6 +7,7 @@ from allocation.read_model import (
     CONSUMPTION,
     PRODUCTION,
     community_totals_by_timestamp,
+    eligible_participant_shares,
     iter_allocated_readings,
 )
 from allocation.windows import AssignmentWindows
@@ -107,6 +108,10 @@ def _compute_period_participant_stats(invoice) -> tuple[dict, list[dict]]:
     # left the ZEV must keep their name in the period stats.
     participant_names = _participant_names(windows.participant_ids)
 
+    # Weight shares for community-allocated readings, keyed by UTC civil date
+    # — matches participant_on/assignment_at's date granularity. Fetched once
+    # regardless of whether this period has any community meter.
+    shares_by_date = eligible_participant_shares(zev, ps, pe)
 
     participant_map: dict[str, dict] = {}
 
@@ -128,6 +133,14 @@ def _compute_period_participant_stats(invoice) -> tuple[dict, list[dict]]:
     ):
         if reading.holder_id is None:
             continue
+        if reading.allocation_mode == "community":
+            day = reading.timestamp.astimezone(_dt.timezone.utc).date()
+            for pid, share in shares_by_date.get(day, {}).items():
+                entry = _entry(str(pid))
+                entry["total_consumed_kwh"] += reading.energy_kwh * share
+                entry["from_zev_kwh"] += reading.split.local_kwh * share
+                entry["from_grid_kwh"] += reading.split.grid_kwh * share
+            continue
         entry = _entry(str(reading.holder_id))
         entry["total_consumed_kwh"] += reading.energy_kwh
         entry["from_zev_kwh"] += reading.split.local_kwh
@@ -145,6 +158,11 @@ def _compute_period_participant_stats(invoice) -> tuple[dict, list[dict]]:
         with_split=False,
     ):
         if reading.holder_id is None:
+            continue
+        if reading.allocation_mode == "community":
+            day = reading.timestamp.astimezone(_dt.timezone.utc).date()
+            for pid, share in shares_by_date.get(day, {}).items():
+                _entry(str(pid))["total_produced_kwh"] += reading.energy_kwh * share
             continue
         _entry(str(reading.holder_id))["total_produced_kwh"] += reading.energy_kwh
 

--- a/backend/invoices/test_allocation_query_counts.py
+++ b/backend/invoices/test_allocation_query_counts.py
@@ -111,13 +111,20 @@ class AllocationQueryCountTests(_ReconciliationBase):
         )
 
     def test_pdf_stats_query_count(self):
+        # 6 -> 7: eligible_participant_shares (shared metering points, #387)
+        # adds one Participant fetch, still a single query regardless of how
+        # many readings or how many months the period spans.
         invoice = generate_invoice(self.alice, PERIOD_START, PERIOD_END)
-        self._call_at_most(6, _compute_period_participant_stats, invoice)
+        self._call_at_most(7, _compute_period_participant_stats, invoice)
 
     def test_pdf_charts_hourly_profile_query_count(self):
+        # 4 -> 7: shared metering points (#387) adds the personal/community
+        # metering-point-id split (two queries, replacing one) plus
+        # eligible_participant_shares (one query) — all still single
+        # fetches, not per-reading.
         invoice = generate_invoice(self.alice, PERIOD_START, PERIOD_END)
         self._call_at_most(
-            4, _build_hourly_profile_chart_svg, invoice, INVOICE_TRANSLATIONS["de"]
+            7, _build_hourly_profile_chart_svg, invoice, INVOICE_TRANSLATIONS["de"]
         )
 
     def test_annual_statement_monthly_data_query_count(self):
@@ -127,4 +134,8 @@ class AllocationQueryCountTests(_ReconciliationBase):
         )
 
     def test_owner_dashboard_query_count(self):
-        self._call_at_most(6, self._analytics)
+        # 6 -> 8: _community_shares_by_zev (shared metering points, #387) adds
+        # two queries — a metering-point-to-ZEV mapping, then one
+        # eligible_participant_shares fetch per distinct ZEV touched (this
+        # fixture has one) — both still single fetches, not per-reading.
+        self._call_at_most(8, self._analytics)

--- a/backend/invoices/test_pdf.py
+++ b/backend/invoices/test_pdf.py
@@ -504,6 +504,49 @@ class InvoicePdfQrTests(TestCase):
         self.assertEqual(chart.count('data-hour="10"'), 1)
         self.assertNotIn('fill="#c9891a" data-hour', chart)
 
+    def test_hourly_profile_reaches_a_community_only_participant(self):
+        """A participant with no personally-held meter — their only stake in
+        the ZEV is a community share — must still get a chart. Before the fix
+        (shared metering points, docs/specs/2026-08-shared-metering-points.md
+        §7.7), consumption_mps was scoped to literal holders only, so this
+        participant's readings queryset was empty and the function returned
+        None before ever reaching the attribution logic."""
+        from metering.models import MeterReading, ReadingDirection, ReadingResolution
+        from zev.models import AllocationMode, MeteringPoint, MeteringPointAssignment, MeteringPointType
+
+        holder = Participant.objects.create(
+            zev=self.zev, first_name="Hans", last_name="Halter",
+            email="hans@example.com", valid_from=date(2026, 1, 1),
+            allocation_weight=Decimal("3"),
+        )
+        self.participant.allocation_weight = Decimal("1")
+        self.participant.save(update_fields=["allocation_weight"])
+
+        invoice = self._invoice()
+        invoice.total_local_kwh = Decimal("10.00")
+        invoice.total_grid_kwh = Decimal("20.00")
+        invoice.save(update_fields=["total_local_kwh", "total_grid_kwh"])
+
+        community_mp = MeteringPoint.objects.create(
+            zev=self.zev, meter_id="CH00000000000000000000000000TEST05",
+            meter_type=MeteringPointType.CONSUMPTION,
+        )
+        MeteringPointAssignment.objects.create(
+            metering_point=community_mp, participant=holder,
+            valid_from=date(2026, 1, 1), allocation_mode=AllocationMode.COMMUNITY,
+        )
+        MeterReading.objects.create(
+            metering_point=community_mp,
+            timestamp=datetime(2026, 1, 15, 9, 0, tzinfo=dt_timezone.utc),
+            energy_kwh=Decimal("5.0000"), direction=ReadingDirection.IN,
+            resolution=ReadingResolution.HOURLY,
+        )
+
+        chart = _build_hourly_profile_chart_svg(invoice, INVOICE_TRANSLATIONS["de"])
+
+        self.assertIsNotNone(chart)
+        self.assertIn('data-hour="9"', chart)
+
     def test_period_window_uses_utc_not_local_tz(self):
         """pdf_stats and pdf_charts must query the same UTC range as the engine."""
         from datetime import timedelta

--- a/backend/invoices/test_reports.py
+++ b/backend/invoices/test_reports.py
@@ -323,3 +323,76 @@ class AnnualStatementMonthlyDataTests(TestCase):
         # February shows the post-assignment reading, fully local.
         self.assertEqual(feb["consumed_kwh"], "4.00")
         self.assertEqual(feb["from_zev_kwh"], "4.00")
+
+    def test_community_meter_contributes_only_the_participants_weighted_share(self):
+        """A community meter this participant does not literally hold must
+        still reach their statement, at their weighted share — not zero
+        (they're not the holder) and not the full reading (they'd be
+        double-counted against the holder's own share).
+
+        Shared metering points, docs/specs/2026-08-shared-metering-points.md
+        §7.7: broadens the fetch beyond this participant's own assignments,
+        and replaces the literal is_held_by gate with a mode-aware one.
+        """
+        from invoices.annual_statement import _compute_monthly_data
+        from metering.models import MeterReading, ReadingDirection, ReadingResolution
+        from zev.models import AllocationMode, MeteringPoint, MeteringPointAssignment, MeteringPointType
+
+        holder = make_participant(self.zev, first="Hans", last="Halter")
+        self.participant.allocation_weight = Decimal("1")
+        self.participant.save(update_fields=["allocation_weight"])
+        holder.allocation_weight = Decimal("3")
+        holder.save(update_fields=["allocation_weight"])
+
+        community_mp = MeteringPoint.objects.create(
+            zev=self.zev, meter_id="CH00000000000000000000000000REP03",
+            meter_type=MeteringPointType.CONSUMPTION)
+        MeteringPointAssignment.objects.create(
+            metering_point=community_mp, participant=holder,
+            valid_from=date(2026, 1, 1), allocation_mode=AllocationMode.COMMUNITY,
+        )
+        MeterReading.objects.create(
+            metering_point=community_mp,
+            timestamp=datetime(2026, 1, 15, 12, 0, tzinfo=dt_timezone.utc),
+            energy_kwh=Decimal("8"), direction=ReadingDirection.IN,
+            resolution=ReadingResolution.DAILY,
+        )
+
+        monthly, _totals = _compute_monthly_data(self.participant, self.zev, 2026, self.tr)
+
+        # Weight 1 of 4 total (1 + 3): this participant's share is 8 * 1/4 = 2.
+        self.assertEqual(monthly[0]["consumed_kwh"], "2.00")
+
+    def test_community_holder_is_not_double_billed_alongside_their_share(self):
+        """The literal holder of a community meter must be billed only their
+        own weighted share, not the full reading on top of it — the
+        double-counting bug the original spec draft had (§7.3's fix, applied
+        here via the mode-aware gate)."""
+        from invoices.annual_statement import _compute_monthly_data
+        from metering.models import MeterReading, ReadingDirection, ReadingResolution
+        from zev.models import AllocationMode, MeteringPoint, MeteringPointAssignment, MeteringPointType
+
+        other = make_participant(self.zev, first="Otto", last="Other")
+        self.participant.allocation_weight = Decimal("3")
+        self.participant.save(update_fields=["allocation_weight"])
+        other.allocation_weight = Decimal("1")
+        other.save(update_fields=["allocation_weight"])
+
+        community_mp = MeteringPoint.objects.create(
+            zev=self.zev, meter_id="CH00000000000000000000000000REP04",
+            meter_type=MeteringPointType.CONSUMPTION)
+        MeteringPointAssignment.objects.create(
+            metering_point=community_mp, participant=self.participant,
+            valid_from=date(2026, 1, 1), allocation_mode=AllocationMode.COMMUNITY,
+        )
+        MeterReading.objects.create(
+            metering_point=community_mp,
+            timestamp=datetime(2026, 1, 15, 12, 0, tzinfo=dt_timezone.utc),
+            energy_kwh=Decimal("8"), direction=ReadingDirection.IN,
+            resolution=ReadingResolution.DAILY,
+        )
+
+        monthly, _totals = _compute_monthly_data(self.participant, self.zev, 2026, self.tr)
+
+        # Weight 3 of 4 total: the holder's own share is 8 * 3/4 = 6, not 8.
+        self.assertEqual(monthly[0]["consumed_kwh"], "6.00")

--- a/backend/metering/analytics.py
+++ b/backend/metering/analytics.py
@@ -12,10 +12,15 @@ from decimal import Decimal, ROUND_HALF_UP
 from django.db.models import Max, Min, Q, Sum
 
 from allocation.errors import OverlappingAssignmentWindowsError
-from allocation.read_model import CONSUMPTION_METER_TYPES, community_totals_by_timestamp
+from allocation.read_model import (
+    CONSUMPTION_METER_TYPES,
+    community_totals_by_timestamp,
+    eligible_participant_shares,
+)
 from allocation.split import split_consumption, split_production
 from allocation.windows import AssignmentWindows
 from zev.models import (
+    AllocationMode,
     Participant,
     MeteringPoint,
     MeteringPointAssignment,
@@ -53,6 +58,45 @@ def _assignment_windows_for_readings(qs, start: date_type, end: date_type) -> As
         "allocation_mode", "id",
     )
     return AssignmentWindows(rows)
+
+
+def _community_shares_by_zev(metering_point_ids, start: date_type, end: date_type) -> dict:
+    """``eligible_participant_shares`` per ZEV touched by ``metering_point_ids``.
+
+    A dashboard queryset can span more than one ZEV (a participant or an
+    admin viewing several communities' meters at once), and share
+    normalization is inherently per-ZEV — one extra query maps metering
+    points to their ZEV, then one ``eligible_participant_shares`` call per
+    distinct ZEV (almost always exactly one). Returns
+    ``(mp_to_zev, shares_by_zev)``.
+    """
+    mp_to_zev = dict(
+        MeteringPoint.objects.filter(id__in=metering_point_ids).values_list("id", "zev_id")
+    )
+    shares_by_zev = {
+        zev_id: eligible_participant_shares(zev_id, start, end)
+        for zev_id in set(mp_to_zev.values())
+    }
+    return mp_to_zev, shares_by_zev
+
+
+def _distribute_reading(windows, mp_to_zev, shares_by_zev, metering_point_id, ts):
+    """``(participant_id, share)`` pairs a reading at ``(mp, ts)`` attributes to.
+
+    A personal assignment yields exactly one pair with ``share=1``; a
+    community assignment yields one pair per eligible participant, weighted
+    by ``allocation_weight``; a gap (no assignment covers ``ts``) yields
+    nothing — matches ``assignment_at``'s contract of distinguishing a true
+    gap from a community window rather than conflating both under ``None``.
+    """
+    resolution = windows.assignment_at(metering_point_id, ts)
+    if resolution is None:
+        return []
+    if resolution.allocation_mode == AllocationMode.COMMUNITY:
+        zev_id = mp_to_zev.get(metering_point_id)
+        day = ts.astimezone(dt_timezone.utc).date()
+        return list(shares_by_zev.get(zev_id, {}).get(day, {}).items())
+    return [(resolution.holder_id, Decimal("1"))]
 
 
 def _participant_names(participant_ids) -> dict[str, str]:
@@ -152,6 +196,9 @@ def owner_dashboard_summary(qs, trunc_fn, selected_participant_id):
     window_start, window_end = _qs_bounds(qs, today)
     windows = _assignment_windows_for_readings(qs, window_start, window_end)
     names = _participant_names(windows.participant_ids)
+    mp_to_zev, shares_by_zev = _community_shares_by_zev(
+        qs.values_list("metering_point_id", flat=True).distinct(), window_start, window_end,
+    )
 
     participant_rows = (
         base.filter(direction="in")
@@ -177,11 +224,6 @@ def owner_dashboard_summary(qs, trunc_fn, selected_participant_id):
 
     participant_map = {}
     for row in participant_rows:
-        pid = windows.participant_at(row["metering_point_id"], row["timestamp"])
-        if pid is None:
-            # Reading fell outside every assignment (gap): it belongs to no one.
-            continue
-        pid = str(pid)
         ts = row["timestamp"]
         bucket_key = row["bucket"].isoformat()
         consumed = row["consumed_kwh"] or Decimal("0")
@@ -191,44 +233,44 @@ def owner_dashboard_summary(qs, trunc_fn, selected_participant_id):
         total_produced = zev_at_ts.get("produced_kwh", Decimal("0"))
         from_zev, from_grid = split_consumption(consumed, total_consumed, total_produced)
 
-        if pid not in participant_map:
-            participant_map[pid] = {
-                "participant_id": pid,
-                "participant_name": names.get(pid, ""),
-                "total_consumed_kwh": Decimal("0"),
-                "total_produced_kwh": Decimal("0"),
-                "from_zev_kwh": Decimal("0"),
-                "from_grid_kwh": Decimal("0"),
-                "total_exported_kwh": Decimal("0"),
-                "timeline_map": {},
-            }
-        participant_map[pid]["total_consumed_kwh"] += consumed
-        participant_map[pid]["from_zev_kwh"] += from_zev
-        participant_map[pid]["from_grid_kwh"] += from_grid
+        for raw_pid, share in _distribute_reading(
+            windows, mp_to_zev, shares_by_zev, row["metering_point_id"], ts,
+        ):
+            pid = str(raw_pid)
+            if pid not in participant_map:
+                participant_map[pid] = {
+                    "participant_id": pid,
+                    "participant_name": names.get(pid, ""),
+                    "total_consumed_kwh": Decimal("0"),
+                    "total_produced_kwh": Decimal("0"),
+                    "from_zev_kwh": Decimal("0"),
+                    "from_grid_kwh": Decimal("0"),
+                    "total_exported_kwh": Decimal("0"),
+                    "timeline_map": {},
+                }
+            participant_map[pid]["total_consumed_kwh"] += consumed * share
+            participant_map[pid]["from_zev_kwh"] += from_zev * share
+            participant_map[pid]["from_grid_kwh"] += from_grid * share
 
-        if bucket_key not in participant_map[pid]["timeline_map"]:
-            participant_map[pid]["timeline_map"][bucket_key] = {
-                "bucket": bucket_key,
-                "consumed_kwh": Decimal("0"),
-                "produced_kwh": Decimal("0"),
-                "imported_kwh": Decimal("0"),
-                "exported_kwh": Decimal("0"),
-            }
-        participant_map[pid]["timeline_map"][bucket_key]["consumed_kwh"] += consumed
-        participant_map[pid]["timeline_map"][bucket_key]["imported_kwh"] += from_grid
+            if bucket_key not in participant_map[pid]["timeline_map"]:
+                participant_map[pid]["timeline_map"][bucket_key] = {
+                    "bucket": bucket_key,
+                    "consumed_kwh": Decimal("0"),
+                    "produced_kwh": Decimal("0"),
+                    "imported_kwh": Decimal("0"),
+                    "exported_kwh": Decimal("0"),
+                }
+            participant_map[pid]["timeline_map"][bucket_key]["consumed_kwh"] += consumed * share
+            participant_map[pid]["timeline_map"][bucket_key]["imported_kwh"] += from_grid * share
 
     for row in participant_production_rows:
-        pid = windows.participant_at(row["metering_point_id"], row["timestamp"])
-        if pid is None:
-            continue
-        pid = str(pid)
+        ts = row["timestamp"]
         bucket_key = row["bucket"].isoformat()
         produced = row["produced_kwh"] or Decimal("0")
 
         # Exported per timestamp = the producer's share of what the ZEV could
         # not consume locally — mirrors what the engine bills as feed-in
         # (ADR 0013), so the chart reconciles with the invoice.
-        ts = row["timestamp"]
         zev_at_ts = ts_pivot.get(ts, {})
         _, exported = split_production(
             produced,
@@ -236,30 +278,34 @@ def owner_dashboard_summary(qs, trunc_fn, selected_participant_id):
             zev_at_ts.get("consumed_kwh", Decimal("0")),
         )
 
-        if pid not in participant_map:
-            participant_map[pid] = {
-                "participant_id": pid,
-                "participant_name": names.get(pid, ""),
-                "total_consumed_kwh": Decimal("0"),
-                "total_produced_kwh": Decimal("0"),
-                "from_zev_kwh": Decimal("0"),
-                "from_grid_kwh": Decimal("0"),
-                "total_exported_kwh": Decimal("0"),
-                "timeline_map": {},
-            }
-        participant_map[pid]["total_produced_kwh"] += produced
-        participant_map[pid]["total_exported_kwh"] += exported
+        for raw_pid, share in _distribute_reading(
+            windows, mp_to_zev, shares_by_zev, row["metering_point_id"], ts,
+        ):
+            pid = str(raw_pid)
+            if pid not in participant_map:
+                participant_map[pid] = {
+                    "participant_id": pid,
+                    "participant_name": names.get(pid, ""),
+                    "total_consumed_kwh": Decimal("0"),
+                    "total_produced_kwh": Decimal("0"),
+                    "from_zev_kwh": Decimal("0"),
+                    "from_grid_kwh": Decimal("0"),
+                    "total_exported_kwh": Decimal("0"),
+                    "timeline_map": {},
+                }
+            participant_map[pid]["total_produced_kwh"] += produced * share
+            participant_map[pid]["total_exported_kwh"] += exported * share
 
-        if bucket_key not in participant_map[pid]["timeline_map"]:
-            participant_map[pid]["timeline_map"][bucket_key] = {
-                "bucket": bucket_key,
-                "consumed_kwh": Decimal("0"),
-                "produced_kwh": Decimal("0"),
-                "imported_kwh": Decimal("0"),
-                "exported_kwh": Decimal("0"),
-            }
-        participant_map[pid]["timeline_map"][bucket_key]["produced_kwh"] += produced
-        participant_map[pid]["timeline_map"][bucket_key]["exported_kwh"] += exported
+            if bucket_key not in participant_map[pid]["timeline_map"]:
+                participant_map[pid]["timeline_map"][bucket_key] = {
+                    "bucket": bucket_key,
+                    "consumed_kwh": Decimal("0"),
+                    "produced_kwh": Decimal("0"),
+                    "imported_kwh": Decimal("0"),
+                    "exported_kwh": Decimal("0"),
+                }
+            participant_map[pid]["timeline_map"][bucket_key]["produced_kwh"] += produced * share
+            participant_map[pid]["timeline_map"][bucket_key]["exported_kwh"] += exported * share
 
     participant_stats = sorted(
         [
@@ -342,6 +388,9 @@ def participant_dashboard_summary(participant_qs, zev_qs, trunc_fn, user, zev_id
         .order_by("id")
         .values_list("id", flat=True)
     )
+    mp_to_zev, shares_by_zev = _community_shares_by_zev(
+        participant_qs.values_list("metering_point_id", flat=True).distinct(), window_start, window_end,
+    )
 
     participant_rows = (
         base.filter(direction="in")
@@ -375,14 +424,21 @@ def participant_dashboard_summary(participant_qs, zev_qs, trunc_fn, user, zev_id
     }
 
     for row in participant_rows:
-        pid = windows.participant_at(row["metering_point_id"], row["timestamp"])
-        if pid is None or pid not in current_participant_ids:
-            # Reading predates this participant's assignment (or sits in a gap,
-            # or belongs to a different participant after a transfer).
+        ts = row["timestamp"]
+        # This participant's own share of the reading: 1 for a personal
+        # assignment they hold, their normalized weight share for a
+        # community assignment (0 if they aren't eligible on this date), 0
+        # for a gap or somebody else's meter.
+        my_share = sum(
+            share for raw_pid, share in _distribute_reading(
+                windows, mp_to_zev, shares_by_zev, row["metering_point_id"], ts,
+            )
+            if raw_pid in current_participant_ids
+        )
+        if my_share == 0:
             continue
         bucket_key = row["bucket"].isoformat()
-        ts = row["timestamp"]
-        participant_consumed = row["consumed_kwh"] or Decimal("0")
+        participant_consumed = (row["consumed_kwh"] or Decimal("0")) * my_share
         zev_consumed = zev_pivot.get(ts, {}).get("consumed", Decimal("0"))
         zev_produced = zev_pivot.get(ts, {}).get("produced", Decimal("0"))
         consumed_from_zev, imported_from_grid = split_consumption(
@@ -433,6 +489,9 @@ def participant_dashboard_summary(participant_qs, zev_qs, trunc_fn, user, zev_id
     zev_window_start, zev_window_end = _qs_bounds(zev_qs, today)
     zev_windows = _assignment_windows_for_readings(zev_qs, zev_window_start, zev_window_end)
     zev_names = _participant_names(zev_windows.participant_ids)
+    zev_mp_to_zev, zev_shares_by_zev = _community_shares_by_zev(
+        zev_qs.values_list("metering_point_id", flat=True).distinct(), zev_window_start, zev_window_end,
+    )
 
     all_consumption_rows = (
         zev_qs.annotate(bucket=trunc_fn("timestamp"))
@@ -457,45 +516,46 @@ def participant_dashboard_summary(participant_qs, zev_qs, trunc_fn, user, zev_id
 
     all_p_map = {}
     for row in all_consumption_rows:
-        pid = zev_windows.participant_at(row["metering_point_id"], row["timestamp"])
-        if pid is None:
-            continue
-        pid = str(pid)
         ts = row["timestamp"]
         consumed = row["consumed_kwh"] or Decimal("0")
         zev_at_ts = zev_pivot.get(ts, {})
         total_consumed = zev_at_ts.get("consumed", Decimal("0"))
         total_produced = zev_at_ts.get("produced", Decimal("0"))
         from_zev, from_grid = split_consumption(consumed, total_consumed, total_produced)
-        if pid not in all_p_map:
-            all_p_map[pid] = {
-                "participant_id": pid,
-                "participant_name": zev_names.get(pid, ""),
-                "total_consumed_kwh": Decimal("0"),
-                "total_produced_kwh": Decimal("0"),
-                "from_zev_kwh": Decimal("0"),
-                "from_grid_kwh": Decimal("0"),
-            }
-        all_p_map[pid]["total_consumed_kwh"] += consumed
-        all_p_map[pid]["from_zev_kwh"] += from_zev
-        all_p_map[pid]["from_grid_kwh"] += from_grid
+        for raw_pid, share in _distribute_reading(
+            zev_windows, zev_mp_to_zev, zev_shares_by_zev, row["metering_point_id"], ts,
+        ):
+            pid = str(raw_pid)
+            if pid not in all_p_map:
+                all_p_map[pid] = {
+                    "participant_id": pid,
+                    "participant_name": zev_names.get(pid, ""),
+                    "total_consumed_kwh": Decimal("0"),
+                    "total_produced_kwh": Decimal("0"),
+                    "from_zev_kwh": Decimal("0"),
+                    "from_grid_kwh": Decimal("0"),
+                }
+            all_p_map[pid]["total_consumed_kwh"] += consumed * share
+            all_p_map[pid]["from_zev_kwh"] += from_zev * share
+            all_p_map[pid]["from_grid_kwh"] += from_grid * share
 
     for row in all_production_rows:
-        pid = zev_windows.participant_at(row["metering_point_id"], row["timestamp"])
-        if pid is None:
-            continue
-        pid = str(pid)
+        ts = row["timestamp"]
         produced = row["produced_kwh"] or Decimal("0")
-        if pid not in all_p_map:
-            all_p_map[pid] = {
-                "participant_id": pid,
-                "participant_name": zev_names.get(pid, ""),
-                "total_consumed_kwh": Decimal("0"),
-                "total_produced_kwh": Decimal("0"),
-                "from_zev_kwh": Decimal("0"),
-                "from_grid_kwh": Decimal("0"),
-            }
-        all_p_map[pid]["total_produced_kwh"] += produced
+        for raw_pid, share in _distribute_reading(
+            zev_windows, zev_mp_to_zev, zev_shares_by_zev, row["metering_point_id"], ts,
+        ):
+            pid = str(raw_pid)
+            if pid not in all_p_map:
+                all_p_map[pid] = {
+                    "participant_id": pid,
+                    "participant_name": zev_names.get(pid, ""),
+                    "total_consumed_kwh": Decimal("0"),
+                    "total_produced_kwh": Decimal("0"),
+                    "from_zev_kwh": Decimal("0"),
+                    "from_grid_kwh": Decimal("0"),
+                }
+            all_p_map[pid]["total_produced_kwh"] += produced * share
 
     zev_participant_stats = sorted(
         [
@@ -541,14 +601,32 @@ def compute_hourly_profile(selected_zev_id, participant_ids, start_dt, end_dt, p
 
     Returns ``{"hourly_profile": list}`` or ``{"hourly_profile": None}``.
     """
+    # A meter matters here if one of the selected participants personally
+    # holds it, OR it is community-allocated (any participant of the ZEV may
+    # be weight-eligible for a share, regardless of who the literal holder
+    # is) — otherwise a community-only participant's meter never reaches the
+    # profile at all. Two flat queries unioned in Python rather than one
+    # composite Q(...)|Q(...) filter: both conditions traverse the same
+    # ``assignments`` relation, and Django's multi-valued-join semantics for
+    # OR-ed conditions on one relation are easy to get subtly wrong.
+    _mp_window = Q(valid_to__isnull=True) | Q(valid_to__gte=ps)
+    personal_mp_ids = MeteringPointAssignment.objects.filter(
+        _mp_window,
+        metering_point__zev_id=selected_zev_id,
+        metering_point__meter_type__in=CONSUMPTION_METER_TYPES,
+        participant_id__in=participant_ids,
+        valid_from__lte=pe,
+    ).values_list("metering_point_id", flat=True)
+    community_mp_ids = MeteringPointAssignment.objects.filter(
+        _mp_window,
+        metering_point__zev_id=selected_zev_id,
+        metering_point__meter_type__in=CONSUMPTION_METER_TYPES,
+        allocation_mode=AllocationMode.COMMUNITY,
+        valid_from__lte=pe,
+    ).values_list("metering_point_id", flat=True)
     consumption_mps = MeteringPoint.objects.filter(
-        zev_id=selected_zev_id,
-        meter_type__in=CONSUMPTION_METER_TYPES,
-        assignments__participant_id__in=participant_ids,
-        assignments__valid_from__lte=pe,
-    ).filter(
-        Q(assignments__valid_to__isnull=True) | Q(assignments__valid_to__gte=ps)
-    ).distinct()
+        id__in=set(personal_mp_ids) | set(community_mp_ids)
+    )
 
     participant_readings_qs = MeterReading.objects.filter(
         metering_point__in=consumption_mps,
@@ -566,10 +644,14 @@ def compute_hourly_profile(selected_zev_id, participant_ids, start_dt, end_dt, p
         return {"hourly_profile": None}
 
     # Per-timestamp attribution: a reading only counts while one of the
-    # selected participants held the metering point at its timestamp (ADR 0013).
+    # selected participants held the metering point at its timestamp (ADR 0013)
+    # — personally, or by a weighted community share.
     participant_ids_set = {str(pid) for pid in participant_ids}
     windows = _assignment_windows_for_readings(
         participant_readings_qs, ps, pe
+    )
+    mp_to_zev, shares_by_zev = _community_shares_by_zev(
+        participant_readings_qs.values_list("metering_point_id", flat=True).distinct(), ps, pe,
     )
 
     # The pool covers every metering point of the ZEV regardless of assignment
@@ -586,13 +668,20 @@ def compute_hourly_profile(selected_zev_id, participant_ids, start_dt, end_dt, p
 
     for reading in participant_readings:
         ts = reading.timestamp
-        holder = windows.participant_at(reading.metering_point_id, ts)
-        if holder is None or str(holder) not in participant_ids_set:
-            # Reading predates the selected participant's assignment (or falls
-            # in a gap): it must not shape their profile.
+        # The selected participants' combined share: 1 if one of them
+        # personally holds the meter, their normalized weight share for a
+        # community assignment, 0 for a gap or somebody else's meter — it
+        # must not shape their profile.
+        my_share = sum(
+            share for raw_pid, share in _distribute_reading(
+                windows, mp_to_zev, shares_by_zev, reading.metering_point_id, ts,
+            )
+            if str(raw_pid) in participant_ids_set
+        )
+        if my_share == 0:
             continue
         hour = ts.hour
-        p_kwh = reading.energy_kwh
+        p_kwh = reading.energy_kwh * my_share
         zev_cons = zev_cons_by_ts.get(ts, Decimal("0"))
         zev_prod = zev_prod_by_ts.get(ts, Decimal("0"))
         r_local, r_grid = split_consumption(p_kwh, zev_cons, zev_prod)

--- a/backend/metering/tests.py
+++ b/backend/metering/tests.py
@@ -762,3 +762,100 @@ class ChartDataEndpointTests(TestCase):
 		resp = self.client.get("/api/v1/metering/readings/chart-data/")
 
 		self.assertEqual(resp.status_code, 400)
+
+
+class SharedMeteringDashboardTests(TestCase):
+	"""A community-allocated meter distributes its energy across every eligible
+	participant by weight in the dashboards and hourly profile, instead of
+	being attributed wholly to its holder of record (shared metering points,
+	docs/specs/2026-08-shared-metering-points.md §7.7)."""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.owner = make_user("sm_dash_owner", UserRole.ZEV_OWNER)
+		self.zev = Zev.objects.create(name="Shared Dash ZEV", owner=self.owner, zev_type="vzev", invoice_prefix="SD")
+
+		self.alice_user = make_user("sm_dash_alice", UserRole.PARTICIPANT)
+		self.alice = Participant.objects.create(
+			zev=self.zev, user=self.alice_user, first_name="Alice", last_name="Muster",
+			email="sm.alice@example.com", valid_from=date(2026, 1, 1), allocation_weight=Decimal("3"),
+		)
+		self.bob = Participant.objects.create(
+			zev=self.zev, first_name="Bob", last_name="Beispiel",
+			email="sm.bob@example.com", valid_from=date(2026, 1, 1), allocation_weight=Decimal("1"),
+		)
+
+		self.community_mp = MeteringPoint.objects.create(
+			zev=self.zev, meter_id="CH-SD-COMMUNITY-1", meter_type=MeteringPointType.CONSUMPTION,
+		)
+		MeteringPointAssignment.objects.create(
+			metering_point=self.community_mp, participant=self.alice,
+			valid_from=date(2026, 1, 1), allocation_mode=AllocationMode.COMMUNITY,
+		)
+		MeterReading.objects.create(
+			metering_point=self.community_mp,
+			timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+			energy_kwh=Decimal("8.0000"), direction=ReadingDirection.IN,
+			resolution=ReadingResolution.FIFTEEN_MIN,
+		)
+
+	def test_owner_dashboard_distributes_community_energy_by_weight(self):
+		auth(self.client, self.owner)
+		resp = self.client.get(
+			"/api/v1/metering/readings/dashboard-summary/",
+			{"zev_id": str(self.zev.id), "date_from": "2026-01-01", "date_to": "2026-01-01", "bucket": "day"},
+		)
+
+		self.assertEqual(resp.status_code, 200)
+		by_id = {s["participant_id"]: s for s in resp.data["participant_stats"]}
+		self.assertEqual(set(by_id), {str(self.alice.id), str(self.bob.id)})
+		# Alice weight 3, Bob weight 1 of 4 total: 8 kWh split 6 / 2 — the holder
+		# (Alice) gets her weighted share, not the whole reading.
+		self.assertAlmostEqual(by_id[str(self.alice.id)]["total_consumed_kwh"], 6.0)
+		self.assertAlmostEqual(by_id[str(self.bob.id)]["total_consumed_kwh"], 2.0)
+
+	def test_participant_dashboard_zev_wide_stats_show_a_community_only_participant(self):
+		"""Bob holds no metering point of his own — his only stake in the ZEV
+		is a community share — so ``totals`` (his own literal readings) stays
+		0 by design; the ZEV-wide breakdown must still carry his weighted
+		share rather than being empty or omitting him entirely.
+
+		Before the fix, zev_ids for this section was derived from the
+		participant's own (holder-scoped) readings queryset, which is empty
+		for a community-only participant — making the whole ZEV invisible to
+		them here, not just their own row."""
+		bob_user = make_user("sm_dash_bob", UserRole.PARTICIPANT)
+		self.bob.user = bob_user
+		self.bob.save(update_fields=["user"])
+		auth(self.client, bob_user)
+
+		resp = self.client.get(
+			"/api/v1/metering/readings/dashboard-summary/",
+			{"date_from": "2026-01-01", "date_to": "2026-01-01", "bucket": "day"},
+		)
+
+		self.assertEqual(resp.status_code, 200)
+		self.assertAlmostEqual(resp.data["totals"]["total_consumed_kwh"], 0.0)
+		by_id = {s["participant_id"]: s for s in resp.data["zev_participant_stats"]}
+		self.assertEqual(set(by_id), {str(self.alice.id), str(self.bob.id)})
+		self.assertAlmostEqual(by_id[str(self.alice.id)]["total_consumed_kwh"], 6.0)
+		self.assertAlmostEqual(by_id[str(self.bob.id)]["total_consumed_kwh"], 2.0)
+
+	def test_hourly_profile_distributes_community_energy_by_weight(self):
+		auth(self.client, self.owner)
+		resp = self.client.get(
+			"/api/v1/metering/readings/hourly-profile/",
+			{
+				"zev_id": str(self.zev.id), "participant_id": str(self.bob.id),
+				"date_from": "2026-01-01", "date_to": "2026-01-01",
+			},
+		)
+
+		self.assertEqual(resp.status_code, 200)
+		profile = resp.data["hourly_profile"]
+		self.assertIsNotNone(profile)
+		hour_12 = next(h for h in profile if h["hour"] == 12)
+		# Bob's 1/4 share of the 8 kWh reading, all local (no production meter,
+		# so the whole community pool draws from the grid... but the pool total
+		# equals the meter's own consumption here, making it fully local).
+		self.assertAlmostEqual(hour_12["from_zev_kwh"] + hour_12["from_grid_kwh"], 2.0)

--- a/backend/metering/views.py
+++ b/backend/metering/views.py
@@ -203,7 +203,13 @@ class MeterReadingViewSet(ZevScopedQuerySetMixin, viewsets.ModelViewSet):
             return Response(result)
 
         # participant path
-        zev_ids = qs.values_list("metering_point__zev_id", flat=True).distinct()
+        # Derived from the participant's own membership, not from qs: a
+        # participant whose only stake in a ZEV is a community-allocated
+        # share (no personally held metering point) has an empty qs, which
+        # would otherwise make the whole ZEV invisible to them here — the
+        # zev-wide section below is unscoped by literal holdership on
+        # purpose (shared metering points, #387).
+        zev_ids = Participant.objects.filter(user=user).values_list("zev_id", flat=True).distinct()
         zev_qs = MeterReading.objects.filter(metering_point__zev_id__in=zev_ids)
         if date_from:
             zev_qs = zev_qs.filter(timestamp__gte=datetime.combine(date_type.fromisoformat(date_from), datetime.min.time(), tzinfo=dt_timezone.utc))


### PR DESCRIPTION
## Summary

Phase 3 of shared metering points ([spec](https://github.com/splattner/openzev/blob/main/docs/specs/2026-08-shared-metering-points.md), #387), stacked on #459/#460.

`allocation/read_model.py`: `AllocatedReading` gains `allocation_mode`; `iter_allocated_readings` resolves via `assignment_at` instead of `participant_at`, keeping `holder_id` literal for provenance. New `eligible_participant_shares(zev, period_start, period_end)` — each eligible participant's normalized weight share per calendar date, "absent not zero" for a date with nobody eligible. Added here rather than duplicated per consumer: it's exactly the kind of shared fetch/resolve step this module already centralizes, and every consumer needs the same "who's eligible, at what weight" answer.

All four consumers migrated: `invoices/pdf_stats.py`, all six `participant_at` sites in `metering/analytics.py`, `invoices/annual_statement.py`, `invoices/pdf_charts.py`. A community-mode reading is now distributed across every eligible participant by weight instead of being attributed wholly to the holder or skipped. `metering/analytics.py` needed its own `_community_shares_by_zev`/`_distribute_reading` helpers since a dashboard queryset can span more than one ZEV, unlike the single-ZEV consumers.

## Two real bugs found by testing the non-holder case, not just personal-only regression

**1. `metering/views.py`'s participant dashboard derived `zev_ids` from the caller's own (holder-scoped) readings queryset.** A participant whose only stake in a ZEV is a community share holds no meter personally, so that queryset is empty — making the *whole ZEV* invisible to them, not just their own row. Fixed to derive `zev_ids` from `Participant.objects.filter(user=user)` instead.

**2. Both `metering/analytics.py`'s `compute_hourly_profile` and `invoices/pdf_charts.py`'s `_build_hourly_profile_chart_svg` scoped their metering-point fetch to assignments literally held by the target participant**, so a community-only stake never reached the function at all — it returned `None` before any attribution logic ran. Fixed by unioning personal-holder and community-mode metering points as two flat queries, deliberately not a composite `Q(...)|Q(...)` on one relation (Django's multi-valued-join semantics for OR-ed conditions spanning the same relation are easy to get subtly wrong).

`invoices/annual_statement.py`'s own windows were similarly broadened from "this participant's own assignments" to "this participant's own assignments, plus every community assignment in the ZEV" — a meter this participant is only weight-eligible for, not the literal holder, must still reach the windows and the readings fetch.

`is_held_by`/`participant_at` stay literal everywhere per spec §5.4; every production call site that needs "does this participant get a share" switched to `assignment_at` (or the new local distribution helpers) instead.

## Tests

14 new, several deliberately exercising the non-holder case rather than just personal-only regression — which is exactly what caught the two bugs above:

- `SharedReadModelTests` (3) + `EligibleParticipantSharesTests` (5) in `allocation/test_read_model.py`
- `SharedMeteringDashboardTests` (3) in `metering/tests.py`: owner dashboard, a community-only participant's zev-wide stats, hourly profile
- Two in `invoices/test_reports.py`: a non-holder gets their share; the holder is not double-billed on top of their own share
- One in `invoices/test_pdf.py`: a community-only participant still gets an hourly-profile chart

## Validation

- `python -m pytest -q` — **1184 passed** (1170 baseline + 14 new)
- `ruff check` clean
- `makemigrations --check --dry-run` — no changes (no model touched in this PR)
- Three query-count bounds bumped with justification (`pdf_stats` 6→7, owner dashboard 6→8, `pdf_charts` hourly profile 4→7) — each addition is a single new fetch, not per-reading; the existing 22 shared-fee and 10 reconciliation tests are unaffected

## Mutation-tested

Reverted `annual_statement.py`'s mode-aware gate to the old literal `is_held_by` check — caught by both new tests: the non-holder drops to `0.00` and the holder jumps from their `6.00` weighted share back to the full `8.00`, reproducing the double-billing bug the original spec draft had (§7.3) and confirming it doesn't recur here.

Refs #387
