### PR TITLE
feat(invoices): community billing for shared metering points

### DIFF
--- a/backend/invoices/engine.py
+++ b/backend/invoices/engine.py
@@ -26,7 +26,7 @@ from allocation.read_model import (
 )
 from allocation.split import split_consumption, split_production
 from allocation.windows import AssignmentWindows
-from zev.models import Zev, Participant, MeteringPoint, MeteringPointAssignment
+from zev.models import AllocationMode, Zev, Participant, MeteringPoint, MeteringPointAssignment
 from tariffs.models import BillingMode, EnergyType, PeriodType, SplitKey, Tariff, TariffCategory
 from metering.models import MeterReading, ReadingDirection
 from .models import Invoice, InvoiceItem, InvoiceStatus
@@ -47,26 +47,40 @@ logger = logging.getLogger(__name__)
 class PeriodReadings(NamedTuple):
     """Everything the pricing loops need to read, fetched once per invoice.
 
-    The two ``*_by_ts`` maps are community-wide totals per timestamp; the two
-    querysets are the individual participant's own readings. ``assignment_windows``
-    resolves which of those readings the participant actually held at their
-    timestamp (readings before an assignment started — or inside a gap — are
-    skipped by the pricing loops).
+    The two ``*_by_ts`` maps are community-wide totals per timestamp; the four
+    querysets are the individual participant's own readings and the ZEV's
+    community-allocated readings. ``assignment_windows`` is ZEV-wide (not
+    participant-scoped) so it can resolve *any* window at a given timestamp —
+    the participant's own, another participant's, or a community one — which
+    is what lets the pricing loops tell a true gap apart from energy that
+    simply belongs to somebody, or something, else (§7.3).
+
+    ``weight_sum_by_date``/``weight_sum_by_month`` are the community's
+    allocation-weight denominators for the invoice period, used to turn a
+    community reading's price into this participant's share.
     """
 
     participant_consumption: models.QuerySet
     participant_production: models.QuerySet
+    community_consumption: models.QuerySet
+    community_production: models.QuerySet
     zev_consumption_by_ts: dict
     zev_production_by_ts: dict
+    weight_sum_by_date: dict
+    weight_sum_by_month: dict
     assignment_windows: AssignmentWindows
 
 
-def _assigned_metering_points(zev, meter_types, period_start, period_end, participant=None):
+def _assigned_metering_points(zev, meter_types, period_start, period_end, participant=None, allocation_mode=None):
     """Metering points of ``meter_types`` assigned during the period.
 
     An assignment counts if it began on or before the period ended and had not
     already finished before it began. Passing ``participant`` narrows this to
-    one member; omitting it covers the whole community.
+    one member; omitting it covers the whole community. Passing
+    ``allocation_mode`` narrows to metering points with at least one matching
+    assignment in the period — the per-reading gate still decides whether a
+    *specific* reading's window actually matches, since one meter's mode can
+    change mid-period (§7.3).
 
     Bidirectional points appear in both the consumption and production sets,
     which is how a single meter can feed the pool and draw from it.
@@ -78,6 +92,8 @@ def _assigned_metering_points(zev, meter_types, period_start, period_end, partic
     }
     if participant is not None:
         filters["assignments__participant"] = participant
+    if allocation_mode is not None:
+        filters["assignments__allocation_mode"] = allocation_mode
     return MeteringPoint.objects.filter(**filters).filter(
         models.Q(assignments__valid_to__isnull=True)
         | models.Q(assignments__valid_to__gte=period_start)
@@ -105,6 +121,12 @@ def _gather_period_readings(participant, period_start, period_end) -> PeriodRead
             participant=participant,
         )
 
+    def community_points(meter_types):
+        return _assigned_metering_points(
+            zev, meter_types, period_start, period_end,
+            allocation_mode=AllocationMode.COMMUNITY,
+        )
+
     # Physical community pool totals per timestamp — every metering point of
     # the ZEV regardless of assignment (ADR 0013): a never-assigned meter still
     # feeds the community pool, even though its readings are billed to nobody.
@@ -117,9 +139,19 @@ def _gather_period_readings(participant, period_start, period_end) -> PeriodRead
             own_points(CONSUMPTION_METER_TYPES), start_dt, end_dt, ReadingDirection.IN),
         participant_production=_readings_in_period(
             own_points(PRODUCTION_METER_TYPES), start_dt, end_dt, ReadingDirection.OUT),
+        community_consumption=_readings_in_period(
+            community_points(CONSUMPTION_METER_TYPES), start_dt, end_dt, ReadingDirection.IN),
+        community_production=_readings_in_period(
+            community_points(PRODUCTION_METER_TYPES), start_dt, end_dt, ReadingDirection.OUT),
         zev_consumption_by_ts=zev_consumption_by_ts,
         zev_production_by_ts=zev_production_by_ts,
-        assignment_windows=AssignmentWindows.for_participant(participant, period_start, period_end),
+        weight_sum_by_date=_allocation_weight_sum_by_date(zev, period_start, period_end),
+        weight_sum_by_month=_allocation_weight_sum_by_month(zev, period_start, period_end),
+        # ZEV-wide, not participant-scoped: the personal loops must be able to
+        # resolve *any* window at a reading's timestamp — another
+        # participant's, or a community one — to tell a true gap apart from
+        # energy that simply belongs to somebody, or something, else (§7.3).
+        assignment_windows=AssignmentWindows.for_zev(zev, period_start, period_end),
     )
 
 
@@ -219,6 +251,7 @@ class ItemAccumulator:
                 "total": Decimal("0"),
                 "unit": unit,
                 "base_total": Decimal("0"),
+                "bucket": bucket,
             }
         entry["quantity"] += quantity
         entry["total"] += total
@@ -315,6 +348,15 @@ def _count_billable_months(tariff: Tariff, period_start: date, period_end: date)
 
 
 def _count_billable_metering_points_by_month(participant: Participant, tariff: Tariff, period_start: date, period_end: date) -> int:
+    """How many of the participant's own metering points each billed month covers.
+
+    Excludes ``COMMUNITY``-mode assignments **for the month in question**, not
+    with a blanket join filter — the same per-window care as the mode-aware
+    gate in ``generate_invoice`` (§7.3/§7.5): a meter personal in one month and
+    community the next must count in the first month and be excluded from the
+    second. A community meter's fee is charged separately, split by weight,
+    in ``_price_fixed_fees``.
+    """
     overlap_start = max(period_start, tariff.valid_from)
     overlap_end = min(period_end, tariff.valid_to or period_end)
     if overlap_start > overlap_end:
@@ -326,7 +368,7 @@ def _count_billable_metering_points_by_month(participant: Participant, tariff: T
         MeteringPointAssignment.objects.filter(
             participant=participant,
             metering_point__is_active=True,
-        ).values_list("metering_point_id", "valid_from", "valid_to")
+        ).values_list("metering_point_id", "valid_from", "valid_to", "allocation_mode")
     )
 
     total_metering_points = 0
@@ -340,19 +382,68 @@ def _count_billable_metering_points_by_month(participant: Participant, tariff: T
         month_start = max(month_first_day, overlap_start)
         month_end = min(month_last_day, overlap_end)
         month_has_active = any(
-            vf <= month_last_day and (vt is None or vt >= month_first_day)
-            for _mp_id, vf, vt in assignments
+            vf <= month_last_day and (vt is None or vt >= month_first_day) and mode == AllocationMode.PERSONAL
+            for _mp_id, vf, vt, mode in assignments
         )
         if month_start <= month_end and month_has_active:
             total_metering_points += len({
                 mp_id
-                for mp_id, vf, vt in assignments
-                if vf <= month_end and (vt is None or vt >= month_start)
+                for mp_id, vf, vt, mode in assignments
+                if vf <= month_end and (vt is None or vt >= month_start) and mode == AllocationMode.PERSONAL
             })
 
         cursor = next_month
 
     return total_metering_points
+
+
+def _count_community_metering_points_by_month(zev: Zev, tariff: Tariff, period_start: date, period_end: date) -> dict[date, int]:
+    """Active, ``COMMUNITY``-mode metering points billable each month.
+
+    Mirrors ``_count_billable_metering_points_by_month`` but is ZEV-wide
+    rather than participant-scoped, and counts only ``COMMUNITY`` windows —
+    the two counts are deliberately disjoint per month, so together they
+    account for every active metering point exactly once. Feeds the
+    per-metering-point community contribution (§7.5): each active community
+    meter's fee is charged once per month, then divided between eligible
+    participants by weight. Keyed by the first day of the month; a month with
+    no active community meter is absent, not zero.
+    """
+    overlap_start = max(period_start, tariff.valid_from)
+    overlap_end = min(period_end, tariff.valid_to or period_end)
+    if overlap_start > overlap_end:
+        return {}
+
+    assignments = list(
+        MeteringPointAssignment.objects.filter(
+            metering_point__zev=zev,
+            metering_point__is_active=True,
+            allocation_mode=AllocationMode.COMMUNITY,
+        ).values_list("metering_point_id", "valid_from", "valid_to")
+    )
+
+    counts: dict[date, int] = {}
+    cursor = _month_start(overlap_start)
+    last_month = _month_start(overlap_end)
+    while cursor <= last_month:
+        next_month = _next_month(cursor)
+        month_first_day = cursor
+        month_last_day = next_month - timedelta(days=1)
+
+        month_start = max(month_first_day, overlap_start)
+        month_end = min(month_last_day, overlap_end)
+        if month_start <= month_end:
+            count = len({
+                mp_id
+                for mp_id, vf, vt in assignments
+                if vf <= month_end and (vt is None or vt >= month_start)
+            })
+            if count:
+                counts[cursor] = count
+
+        cursor = next_month
+
+    return counts
 
 
 def _overlaps(valid_from: date, valid_to: date | None, start: date, end: date) -> bool:
@@ -520,6 +611,7 @@ DESCRIPTION_TRANSLATIONS: dict[str, dict] = {
         "shared_yearly_sg": "monatliche Rate der Jahresgebühr, Gemeinschaftskosten anteilig",
         "shared_yearly_pl": "monatliche Raten der Jahresgebühr, Gemeinschaftskosten anteilig",
         "pct_of": "von CHF",
+        "community_marker": "Gemeinschaftsanteil",
     },
     "fr": {
         "yearly_fee_sg": "mensualité de la redevance annuelle",
@@ -535,6 +627,7 @@ DESCRIPTION_TRANSLATIONS: dict[str, dict] = {
         "shared_yearly_sg": "mensualité de la redevance annuelle, quote-part des frais communs",
         "shared_yearly_pl": "mensualités de la redevance annuelle, quote-part des frais communs",
         "pct_of": "de CHF",
+        "community_marker": "Part communautaire",
     },
     "it": {
         "yearly_fee_sg": "rata mensile della tariffa annuale",
@@ -550,6 +643,7 @@ DESCRIPTION_TRANSLATIONS: dict[str, dict] = {
         "shared_yearly_sg": "rata mensile della tariffa annuale, quota dei costi comuni",
         "shared_yearly_pl": "rate mensili della tariffa annuale, quota dei costi comuni",
         "pct_of": "di CHF",
+        "community_marker": "Quota comunitaria",
     },
     "en": {
         "yearly_fee_sg": "monthly installment of annual fee",
@@ -565,6 +659,7 @@ DESCRIPTION_TRANSLATIONS: dict[str, dict] = {
         "shared_yearly_sg": "monthly installment of annual fee, share of community costs",
         "shared_yearly_pl": "monthly installments of annual fee, share of community costs",
         "pct_of": "of CHF",
+        "community_marker": "Community share",
     },
 }
 
@@ -577,20 +672,29 @@ def _build_description(
     lang: str = "de",
     *,
     base_rate: Decimal | None = None,
+    bucket: str = "default",
 ) -> str:
+    t = DESCRIPTION_TRANSLATIONS.get(lang, DESCRIPTION_TRANSLATIONS["de"])
+    # Every "shared" bucket ("shared", "shared_producer_credit") is a
+    # community-metering-point line (§7.6) — distinct from the pre-existing
+    # SHARED_MONTHLY_FEE/SHARED_YEARLY_FEE wording above, which already names
+    # itself as a community cost and is never tagged with this marker.
+    community = bucket.startswith("shared")
+    marker = t["community_marker"]
+
     if tariff.billing_mode == BillingMode.ENERGY:
-        return tariff.name
+        return f"{tariff.name} ({marker})" if community else tariff.name
     if tariff.billing_mode == BillingMode.PERCENTAGE_OF_ENERGY:
         pct = tariff.percentage or Decimal("0")
         # Format: remove trailing zeros (50.00 → 50, 33.50 → 33.5)
         pct_str = f"{pct:f}".rstrip("0").rstrip(".")
         if base_rate is not None:
-            t = DESCRIPTION_TRANSLATIONS.get(lang, DESCRIPTION_TRANSLATIONS["de"])
             base_str = f"{base_rate:f}".rstrip("0").rstrip(".")
-            return f"{tariff.name} ({pct_str}% {t['pct_of']} {base_str}/kWh)"
-        return f"{tariff.name} ({pct_str}%)"
+            suffix = f", {marker}" if community else ""
+            return f"{tariff.name} ({pct_str}% {t['pct_of']} {base_str}/kWh{suffix})"
+        suffix = f", {marker}" if community else ""
+        return f"{tariff.name} ({pct_str}%{suffix})"
 
-    t = DESCRIPTION_TRANSLATIONS.get(lang, DESCRIPTION_TRANSLATIONS["de"])
     months = int(quantity)
 
     if tariff.billing_mode == BillingMode.YEARLY_FEE:
@@ -599,10 +703,14 @@ def _build_description(
 
     if tariff.billing_mode == BillingMode.PER_METERING_POINT_YEARLY_FEE:
         suffix = t["mp_yearly_sg"] if months == 1 else t["mp_yearly_pl"]
+        if community:
+            suffix = f"{suffix}, {marker}"
         return f"{tariff.name} ({months} {suffix})"
 
     if tariff.billing_mode == BillingMode.PER_METERING_POINT_MONTHLY_FEE:
         suffix = t["mp_monthly_sg"] if months == 1 else t["mp_monthly_pl"]
+        if community:
+            suffix = f"{suffix}, {marker}"
         return f"{tariff.name} ({months} {suffix})"
 
     # The shared modes carry no participant count in the text: the denominator
@@ -644,9 +752,14 @@ def _price_fixed_fees(participant, tariffs, period_start, period_end, accumulato
     multiply that by how many points the participant held in those months.
     Yearly fees are charged as twelfths.
 
-    The shared variants divide one community-wide amount between the members
-    active in each month, so their total is built month by month rather than as
-    ``quantity * unit_price``.
+    The ``SHARED_*`` modes divide one community-wide amount between the
+    members active in each month, so their total is built month by month
+    rather than as ``quantity * unit_price``. The per-metering-point modes
+    bill personal and community metering points separately (§7.5): the
+    personal count excludes ``COMMUNITY``-mode assignments, and each active
+    community meter contributes its own weight-split ``bucket="shared"``
+    line — ``split_key`` plays no part here, since a community meter's cost
+    always allocates by weight.
     """
     for tariff in tariffs:
         if tariff.billing_mode in _ENERGY_BILLING_MODES:
@@ -666,17 +779,46 @@ def _price_fixed_fees(participant, tariffs, period_start, period_end, accumulato
             BillingMode.SHARED_YEARLY_FEE,
         )
 
-        if per_metering_point:
-            quantity = Decimal(_count_billable_metering_points_by_month(
-                participant, tariff, period_start, period_end))
-            if quantity <= 0:
-                continue
-        else:
-            quantity = Decimal(month_count)
-
         unit_price = tariff.fixed_price_chf or Decimal("0")
         if yearly:
             unit_price = unit_price / Decimal("12")
+
+        if per_metering_point:
+            # Personal and community metering points are counted, and billed,
+            # separately (§7.5): the split_key mechanism above is only for
+            # SHARED_* fees, since the cost being divided here belongs to a
+            # community *meter*, which always allocates by weight.
+            quantity = Decimal(_count_billable_metering_points_by_month(
+                participant, tariff, period_start, period_end))
+            if quantity > 0:
+                accumulator.add(
+                    tariff=tariff, quantity=quantity, total=quantity * unit_price, unit="month",
+                )
+
+            community_counts = _count_community_metering_points_by_month(
+                participant.zev, tariff, period_start, period_end)
+            if community_counts:
+                weight_sums = _allocation_weight_sum_by_month(
+                    participant.zev, period_start, period_end)
+                shared_total = Decimal("0")
+                shared_months = 0
+                for month, billed_from, billed_to in _billable_months(tariff, period_start, period_end):
+                    count = community_counts.get(month)
+                    denominator = weight_sums.get(month)
+                    if not count or not denominator or not _overlaps(
+                        participant.valid_from, participant.valid_to, billed_from, billed_to
+                    ):
+                        continue
+                    shared_total += unit_price * Decimal(count) * participant.allocation_weight / denominator
+                    shared_months += 1
+                if shared_months > 0:
+                    accumulator.add(
+                        tariff=tariff, quantity=Decimal(shared_months), total=shared_total,
+                        unit="month", bucket="shared",
+                    )
+            continue
+
+        quantity = Decimal(month_count)
 
         if shared:
             # split_key picks the denominator: WEIGHT normalizes by
@@ -754,6 +896,7 @@ def _build_item_payloads(accumulator) -> tuple[list, Decimal]:
             "unit_price": unit_price,
             "total": quantized_total,
             "base_rate": (raw_base_total / quantity).quantize(Decimal("0.00001"), rounding=ROUND_HALF_UP) if quantity and raw_base_total else None,
+            "bucket": entry["bucket"],
         })
 
     return payloads, subtotal.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
@@ -790,11 +933,17 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
     for reading in readings.participant_consumption.order_by("timestamp").iterator():
         ts = reading.timestamp
-        if not readings.assignment_windows.is_held_by(participant.id, reading.metering_point_id, ts):
-            # Reading predates this participant's assignment (or falls in an
-            # assignment gap): it belongs to nobody in this billing run.
+        resolution = readings.assignment_windows.assignment_at(reading.metering_point_id, ts)
+        if resolution is None:
+            # A true gap: no assignment covers this timestamp. Belongs to
+            # nobody in this billing run.
             skipped_consumption_readings += 1
             skipped_consumption_kwh += reading.energy_kwh
+            continue
+        if resolution.allocation_mode != AllocationMode.PERSONAL or resolution.holder_id != participant.id:
+            # Community energy (billed in the community loop below) or
+            # somebody else's meter (billed on their own invoice) — neither
+            # is a gap, so the skip counters must not count it (§7.3).
             continue
         participant_kwh = reading.energy_kwh
         zev_consumption_at_ts = zev_consumption_by_ts.get(ts, Decimal("0"))
@@ -846,9 +995,12 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
     for reading in readings.participant_production.order_by("timestamp").iterator():
         ts = reading.timestamp
-        if not readings.assignment_windows.is_held_by(participant.id, reading.metering_point_id, ts):
+        resolution = readings.assignment_windows.assignment_at(reading.metering_point_id, ts)
+        if resolution is None:
             skipped_production_readings += 1
             skipped_production_kwh += reading.energy_kwh
+            continue
+        if resolution.allocation_mode != AllocationMode.PERSONAL or resolution.holder_id != participant.id:
             continue
         produced_kwh = reading.energy_kwh
 
@@ -896,6 +1048,126 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
                     quantity=exported_kwh,
                     total=-(exported_kwh * price),
                     unit="kWh",
+                )
+
+    # ─── Community-allocated energy (§7.4) ─────────────────────────────────
+    # Price once, allocate second: each community reading is priced with the
+    # ordinary tariff resolution and split against the same physical ZEV
+    # totals used above (which already include community meters), then the
+    # resulting kWh/CHF are divided by this participant's date-granular
+    # weight share. Fed into the same open accumulators as the personal
+    # loops, so total_local_kwh/total_grid_kwh/total_feed_in_kwh include
+    # shared energy.
+    for reading in readings.community_consumption.order_by("timestamp").iterator():
+        ts = reading.timestamp
+        resolution = readings.assignment_windows.assignment_at(reading.metering_point_id, ts)
+        if resolution is None or resolution.allocation_mode != AllocationMode.COMMUNITY:
+            continue  # gap, or this window is personal — billed elsewhere
+        day = ts.date()
+        if not _overlaps(participant.valid_from, participant.valid_to, day, day):
+            continue  # a mid-period joiner/leaver pays no share outside their own membership
+        weight_sum = readings.weight_sum_by_date.get(day)
+        if not weight_sum:
+            continue
+        share = participant.allocation_weight / weight_sum
+
+        zev_consumption_at_ts = zev_consumption_by_ts.get(ts, Decimal("0"))
+        zev_production_at_ts = zev_production_by_ts.get(ts, Decimal("0"))
+        r_local, r_grid = split_consumption(
+            reading.energy_kwh, zev_consumption_at_ts, zev_production_at_ts
+        )
+        shared_local = r_local * share
+        shared_grid = r_grid * share
+
+        local_kwh_acc += shared_local
+        grid_kwh_acc += shared_grid
+
+        grid_base_price_sum = sum(
+            (_get_tariff_price(t, ts) or Decimal("0"))
+            for t in tariffs.energy(EnergyType.GRID, ts.date())
+        )
+
+        for energy_type, quantity in ((EnergyType.LOCAL, shared_local), (EnergyType.GRID, shared_grid)):
+            if quantity <= 0:
+                continue
+            for tariff in tariffs.energy(energy_type, ts.date()):
+                price = _get_tariff_price(tariff, ts) or Decimal("0")
+                items_accumulator.add(
+                    tariff=tariff,
+                    quantity=quantity,
+                    total=quantity * price,
+                    unit="kWh",
+                    bucket="shared",
+                )
+            for tariff in tariffs.percentage(energy_type, ts.date()):
+                effective_price = grid_base_price_sum * (tariff.percentage / Decimal("100"))
+                items_accumulator.add(
+                    tariff=tariff,
+                    quantity=quantity,
+                    total=quantity * effective_price,
+                    unit="kWh",
+                    base_total=quantity * grid_base_price_sum,
+                    bucket="shared",
+                )
+
+    for reading in readings.community_production.order_by("timestamp").iterator():
+        ts = reading.timestamp
+        resolution = readings.assignment_windows.assignment_at(reading.metering_point_id, ts)
+        if resolution is None or resolution.allocation_mode != AllocationMode.COMMUNITY:
+            continue
+        day = ts.date()
+        if not _overlaps(participant.valid_from, participant.valid_to, day, day):
+            continue
+        weight_sum = readings.weight_sum_by_date.get(day)
+        if not weight_sum:
+            continue
+        share = participant.allocation_weight / weight_sum
+
+        zev_production_at_ts = zev_production_by_ts.get(ts, Decimal("0"))
+        zev_consumption_at_ts = zev_consumption_by_ts.get(ts, Decimal("0"))
+        local_sold_kwh, exported_kwh = split_production(
+            reading.energy_kwh, zev_production_at_ts, zev_consumption_at_ts
+        )
+        shared_local_sold = local_sold_kwh * share
+        shared_exported = exported_kwh * share
+
+        exported_kwh_acc += shared_exported
+
+        grid_base_price_sum = sum(
+            (_get_tariff_price(t, ts) or Decimal("0"))
+            for t in tariffs.energy(EnergyType.GRID, ts.date())
+        )
+
+        if shared_local_sold > 0:
+            for tariff in tariffs.energy(EnergyType.LOCAL, ts.date()):
+                price = _get_tariff_price(tariff, ts) or Decimal("0")
+                items_accumulator.add(
+                    tariff=tariff,
+                    quantity=shared_local_sold,
+                    total=-(shared_local_sold * price),
+                    unit="kWh",
+                    bucket="shared_producer_credit",
+                )
+            for tariff in tariffs.percentage(EnergyType.LOCAL, ts.date()):
+                effective_price = grid_base_price_sum * (tariff.percentage / Decimal("100"))
+                items_accumulator.add(
+                    tariff=tariff,
+                    quantity=shared_local_sold,
+                    total=-(shared_local_sold * effective_price),
+                    unit="kWh",
+                    base_total=(shared_local_sold * grid_base_price_sum),
+                    bucket="shared_producer_credit",
+                )
+
+        if shared_exported > 0:
+            for tariff in tariffs.energy(EnergyType.FEED_IN, ts.date()):
+                price = _get_tariff_price(tariff, ts) or Decimal("0")
+                items_accumulator.add(
+                    tariff=tariff,
+                    quantity=shared_exported,
+                    total=-(shared_exported * price),
+                    unit="kWh",
+                    bucket="shared",
                 )
 
     _price_fixed_fees(participant, tariffs_list, period_start, period_end, items_accumulator)
@@ -953,7 +1225,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
             tariff_category=tariff.category,
             description=_build_description(
                 tariff, period_start, period_end, payload["quantity"], lang,
-                base_rate=payload.get("base_rate"),
+                base_rate=payload.get("base_rate"), bucket=payload["bucket"],
             ),
             quantity_kwh=payload["quantity"],
             unit=payload["unit"],

--- a/backend/invoices/pdf_stats.py
+++ b/backend/invoices/pdf_stats.py
@@ -103,15 +103,20 @@ def _compute_period_participant_stats(invoice) -> tuple[dict, list[dict]]:
     # assignment gap (holder None) belong to no participant.
     windows = AssignmentWindows.for_zev(zev, ps, pe)
 
-    # Names are keyed off the assignment windows, not the current participant
-    # list: the invoice is a historical document, and a holder who has since
-    # left the ZEV must keep their name in the period stats.
-    participant_names = _participant_names(windows.participant_ids)
-
     # Weight shares for community-allocated readings, keyed by UTC civil date
     # — matches participant_on/assignment_at's date granularity. Fetched once
     # regardless of whether this period has any community meter.
     shares_by_date = eligible_participant_shares(zev, ps, pe)
+
+    # Names are keyed off the assignment windows *and* every participant who
+    # ever receives a community share — not just literal holders, since a
+    # community-only participant (never the holder of record for any meter)
+    # would otherwise appear with an empty name. The invoice is a historical
+    # document, so a holder who has since left the ZEV must keep their name.
+    share_participant_ids = {
+        pid for day_shares in shares_by_date.values() for pid in day_shares
+    }
+    participant_names = _participant_names(windows.participant_ids | share_participant_ids)
 
     participant_map: dict[str, dict] = {}
 

--- a/backend/invoices/test_allocation_query_counts.py
+++ b/backend/invoices/test_allocation_query_counts.py
@@ -106,8 +106,14 @@ class AllocationQueryCountTests(_ReconciliationBase):
 
     def test_engine_generate_invoice_query_count(self):
         # Windows fetch + readings fetch + tariff lookup + invoice writes.
+        # 13 -> 17: shared metering points (#387) add four queries — a
+        # community consumption and a community production reading fetch,
+        # plus one Participant fetch each for the date- and month-granular
+        # allocation-weight sums (_allocation_weight_sum_by_date/_by_month) —
+        # still a single query each regardless of how many community
+        # readings or how many months the period spans.
         self._call_at_most(
-            13, generate_invoice, self.alice, PERIOD_START, PERIOD_END
+            17, generate_invoice, self.alice, PERIOD_START, PERIOD_END
         )
 
     def test_pdf_stats_query_count(self):

--- a/backend/invoices/test_allocation_reconciliation.py
+++ b/backend/invoices/test_allocation_reconciliation.py
@@ -27,7 +27,7 @@ from invoices.pdf_stats import _compute_period_participant_stats
 from metering.analytics import owner_dashboard_summary
 from metering.models import MeterReading, ReadingDirection
 from testing.helpers import make_named_participant
-from zev.models import MeteringPoint, MeteringPointAssignment, MeteringPointType, Zev
+from zev.models import AllocationMode, MeteringPoint, MeteringPointAssignment, MeteringPointType, Zev
 
 User = get_user_model()
 
@@ -45,10 +45,10 @@ class _ReconciliationBase(TestCase):
             zev=self.zev, meter_type=meter_type, meter_id=meter_id,
         )
 
-    def _assign(self, metering_point, participant, valid_from, valid_to=None):
+    def _assign(self, metering_point, participant, valid_from, valid_to=None, mode=AllocationMode.PERSONAL):
         return MeteringPointAssignment.objects.create(
             metering_point=metering_point, participant=participant,
-            valid_from=valid_from, valid_to=valid_to,
+            valid_from=valid_from, valid_to=valid_to, allocation_mode=mode,
         )
 
     def _reading(self, metering_point, day, kwh, direction):
@@ -657,3 +657,78 @@ class AnnualStatementDirectionTypePairingTests(_ReconciliationBase):
         consumption pool."""
         self._reading(self.production_mp, date(2026, 1, 5), "6", ReadingDirection.IN)
         self._assert_statement_agrees_with_engine()
+
+
+class CommunityMeterReconciliationTests(_ReconciliationBase):
+    """Every consumer must agree once a metering point is community-allocated
+    (#387): the engine, ``pdf_stats``, and ``analytics`` must attribute the
+    same weighted share to each participant, and no single holder — including
+    the meter's holder of record — may be attributed the full amount.
+    """
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            username="recon_community", password="pass1234", role=UserRole.ZEV_OWNER
+        )
+        self.zev = Zev.objects.create(
+            name="Community Recon ZEV",
+            owner=self.owner,
+            zev_type="vzev",
+            start_date=PERIOD_START,
+            billing_interval="monthly",
+            invoice_prefix="CR",
+        )
+        self.zev.refresh_from_db()
+        # Equal weights (the default): a straightforward 50/50 split makes the
+        # cross-consumer comparison easy to state exactly.
+        self.alice = make_named_participant(self.zev, "Alice Muster", PERIOD_START)
+        self.bob = make_named_participant(self.zev, "Bob Beispiel", PERIOD_START)
+
+        self.community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-CR-COMM-1")
+        # Alice is the holder of record, but that must not make her liable
+        # for more than her weight share (§1.1: no holder special case).
+        self._assign(self.community_mp, self.alice, PERIOD_START, mode=AllocationMode.COMMUNITY)
+
+        self._consumption(self.community_mp, date(2026, 1, 5), "10")
+
+    def test_all_consumers_reconcile_with_a_community_meter(self):
+        alice_invoice, bob_invoice = self._invoices()
+
+        # Engine: split 50/50, no production anywhere so it is all grid.
+        self.assertSameEnergy(alice_invoice.total_grid_kwh, "5")
+        self.assertSameEnergy(bob_invoice.total_grid_kwh, "5")
+
+        alice_pdf = self._pdf_stats(alice_invoice)["Alice Muster"]
+        bob_pdf = self._pdf_stats(bob_invoice)["Bob Beispiel"]
+        self.assertSameEnergy(alice_invoice.total_grid_kwh, alice_pdf["from_grid_kwh"])
+        self.assertSameEnergy(bob_invoice.total_grid_kwh, bob_pdf["from_grid_kwh"])
+        self.assertSameEnergy(self._invoice_consumed(alice_invoice), alice_pdf["total_consumed_kwh"])
+        self.assertSameEnergy(self._invoice_consumed(bob_invoice), bob_pdf["total_consumed_kwh"])
+
+        result = self._analytics()
+        by_id = {s["participant_id"]: s for s in result["participant_stats"]}
+        self.assertSameEnergy(alice_invoice.total_grid_kwh, by_id[str(self.alice.id)]["from_grid_kwh"])
+        self.assertSameEnergy(bob_invoice.total_grid_kwh, by_id[str(self.bob.id)]["from_grid_kwh"])
+
+        # The physical pool total is unsplit: the dashboard's ZEV-wide figure
+        # is still the full 10 kWh (ADR 0013), only the per-participant
+        # attribution is weighted.
+        self.assertSameEnergy(result["totals"]["consumed_kwh"], "10")
+
+    def test_community_meter_energy_is_attributed_to_no_single_holder(self):
+        alice_invoice, bob_invoice = self._invoices()
+
+        # The holder of record (Alice) is billed exactly her weight share,
+        # not the full reading — in every consumer, not just the engine.
+        self.assertSameEnergy(alice_invoice.total_grid_kwh, "5")
+
+        alice_pdf = self._pdf_stats(alice_invoice)["Alice Muster"]
+        self.assertSameEnergy(alice_pdf["from_grid_kwh"], "5")
+
+        result = self._analytics()
+        by_id = {s["participant_id"]: s for s in result["participant_stats"]}
+        self.assertSameEnergy(by_id[str(self.alice.id)]["from_grid_kwh"], "5")
+
+        # Bob, who never holds the meter, is billed the same share.
+        self.assertSameEnergy(bob_invoice.total_grid_kwh, "5")
+        self.assertSameEnergy(by_id[str(self.bob.id)]["from_grid_kwh"], "5")

--- a/backend/invoices/test_pdf.py
+++ b/backend/invoices/test_pdf.py
@@ -984,6 +984,38 @@ class InvoicePdfRenderingTests(TestCase):
             self.assertGreater(len(pdf), 1000, f"PDF for {lang} is too small")
             self.assertEqual(self._page_count(pdf), 2, f"PDF for {lang} should be 2 pages (invoice + insights)")
 
+    def test_shared_lines_render_with_marker(self):
+        """A community-allocated line item's marker text must actually reach
+        the rendered PDF, in every invoice language (§7.6) — not just the
+        description string the engine builds (covered in
+        ``test_shared_metering.py``)."""
+        from pypdf import PdfReader
+
+        markers = {
+            "de": "Gemeinschaftsanteil",
+            "fr": "Part communautaire",
+            "it": "Quota comunitaria",
+            "en": "Community share",
+        }
+        for lang, marker in markers.items():
+            with self.subTest(lang=lang):
+                self.zev.invoice_language = lang
+                self.zev.save(update_fields=["invoice_language"])
+                invoice = self._invoice(invoice_number=f"Q-SHARED-{lang.upper()}")
+                InvoiceItem.objects.create(
+                    invoice=invoice, item_type=InvoiceItem.ItemType.GRID_ENERGY,
+                    tariff_category=TariffCategory.ENERGY,
+                    description=f"Netzenergie ({marker})",
+                    quantity_kwh=Decimal("5.00"), unit="kWh",
+                    unit_price_chf=Decimal("0.20000"), total_chf=Decimal("1.00"),
+                )
+
+                pdf = generate_pdf(invoice)
+                reader = PdfReader(io.BytesIO(pdf))
+                text = "\n".join(page.extract_text() for page in reader.pages)
+
+                self.assertIn(marker, text)
+
     # ── QR-Rechnung placement tests ──────────────────────────────────────
     # The Swiss payment slip must be exactly 106 mm tall and flush with the
     # page bottom.  We verify this by parsing the PDF content stream for the

--- a/backend/invoices/test_shared_metering.py
+++ b/backend/invoices/test_shared_metering.py
@@ -1,0 +1,454 @@
+"""Tests for community-allocated metering points (shared metering, #387).
+
+A ``COMMUNITY``-mode assignment does not change who holds a metering point —
+the holder of record is unchanged, for provenance — but it changes who pays:
+the meter's energy and per-metering-point fees are split across every
+eligible participant by ``Participant.allocation_weight`` instead of being
+billed to the holder alone.
+
+``§7.3`` (personal vs. community is a per-timestamp decision) is the
+load-bearing rule: a queryset filter cannot separate a meter's personal
+readings from its community readings when the mode changes mid-period, so the
+engine gates each *reading* individually via ``assignment_at``.
+"""
+
+from datetime import date, datetime, timezone as dt_timezone
+from decimal import Decimal
+
+import pytest
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from accounts.models import UserRole
+from invoices.models import InvoiceItem
+from metering.models import MeterReading, ReadingDirection
+from tariffs.models import BillingMode, EnergyType, TariffCategory
+from testing import factories
+from zev.models import AllocationMode, MeteringPoint, MeteringPointAssignment, MeteringPointType, Zev
+
+from .engine import generate_invoice
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+JAN = date(2026, 1, 1)
+JAN_END = date(2026, 1, 31)
+
+
+class _SharedMeteringBase:
+    """Shared fixture builders for the community-metering scenarios."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            username=f"shared_owner_{id(self)}", password="pass1234", role=UserRole.ZEV_OWNER
+        )
+        self.zev = Zev.objects.create(
+            name="Shared Metering ZEV",
+            owner=self.owner,
+            zev_type="vzev",
+            start_date=JAN,
+            billing_interval="monthly",
+            invoice_prefix=f"SM{id(self) % 10000}",
+        )
+        self.zev.refresh_from_db()
+
+    def _participant(self, name, valid_from=JAN, valid_to=None, weight="1"):
+        first, last = name.split(" ", 1)
+        return factories.ParticipantFactory(
+            zev=self.zev, first_name=first, last_name=last,
+            email=f"{name.replace(' ', '').lower()}@example.com",
+            valid_from=valid_from, valid_to=valid_to,
+            allocation_weight=Decimal(weight),
+        )
+
+    def _mp(self, meter_type, meter_id):
+        return MeteringPoint.objects.create(zev=self.zev, meter_type=meter_type, meter_id=meter_id)
+
+    def _assign(self, metering_point, participant, valid_from, valid_to=None, mode=AllocationMode.PERSONAL):
+        return MeteringPointAssignment.objects.create(
+            metering_point=metering_point, participant=participant,
+            valid_from=valid_from, valid_to=valid_to, allocation_mode=mode,
+        )
+
+    def _reading(self, metering_point, day, kwh, direction):
+        return MeterReading.objects.create(
+            metering_point=metering_point,
+            timestamp=datetime(day.year, day.month, day.day, 12, 0, tzinfo=dt_timezone.utc),
+            energy_kwh=Decimal(kwh),
+            direction=direction,
+        )
+
+    def _consumption(self, metering_point, day, kwh):
+        self._reading(metering_point, day, kwh, ReadingDirection.IN)
+
+    def _production(self, metering_point, day, kwh):
+        self._reading(metering_point, day, kwh, ReadingDirection.OUT)
+
+    def _grid_tariff(self, price="0.20000"):
+        return factories.flat_tariff(self.zev, energy_type=EnergyType.GRID, price=price)
+
+    def _feed_in_tariff(self, price="0.08000"):
+        return factories.flat_tariff(self.zev, energy_type=EnergyType.FEED_IN, price=price)
+
+    def _mp_fee_tariff(self, price="10.00"):
+        return factories.TariffFactory(
+            zev=self.zev,
+            billing_mode=BillingMode.PER_METERING_POINT_MONTHLY_FEE,
+            category=TariffCategory.METERING,
+            energy_type=None,
+            fixed_price_chf=Decimal(price),
+        )
+
+    def _grid_items(self, invoice):
+        return list(invoice.items.filter(item_type=InvoiceItem.ItemType.GRID_ENERGY))
+
+    def _feed_in_items(self, invoice):
+        return list(invoice.items.filter(item_type=InvoiceItem.ItemType.FEED_IN))
+
+    def _fee_items(self, invoice):
+        return list(invoice.items.filter(tariff_category=TariffCategory.METERING))
+
+
+class SharedConsumptionSplitTests(_SharedMeteringBase, TestCase):
+    def test_shared_consumption_is_billed_to_every_member_by_weight(self):
+        alice = self._participant("Alice Muster", weight="1")
+        bob = self._participant("Bob Beispiel", weight="3")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-COMM-1")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "10")
+
+        self._grid_tariff(price="0.20000")
+        levy = factories.flat_tariff(
+            self.zev, category=TariffCategory.LEVIES, energy_type=EnergyType.GRID, price="0.05000")
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        # Alice: 1/4 of 10 kWh = 2.5; Bob: 3/4 of 10 kWh = 7.5.
+        self.assertEqual(alice_invoice.total_grid_kwh, Decimal("2.5000"))
+        self.assertEqual(bob_invoice.total_grid_kwh, Decimal("7.5000"))
+        self.assertEqual(alice_invoice.total_local_kwh, Decimal("0.0000"))
+
+        self.assertEqual(len(self._grid_items(alice_invoice)), 2)  # energy + levies, incl. levies
+        energy_item = next(i for i in self._grid_items(alice_invoice) if i.tariff_category == TariffCategory.ENERGY)
+        levy_item = next(i for i in self._grid_items(alice_invoice) if i.tariff_category == TariffCategory.LEVIES)
+        self.assertEqual(energy_item.total_chf, Decimal("0.50"))   # 2.5 * 0.20
+        self.assertEqual(levy_item.total_chf, Decimal("0.13"))     # 2.5 * 0.05 = 0.125 -> HALF_UP 0.13
+        self.assertEqual(levy.category, TariffCategory.LEVIES)
+
+        bob_energy = next(i for i in self._grid_items(bob_invoice) if i.tariff_category == TariffCategory.ENERGY)
+        bob_levy = next(i for i in self._grid_items(bob_invoice) if i.tariff_category == TariffCategory.LEVIES)
+        self.assertEqual(bob_energy.total_chf, Decimal("1.50"))   # 7.5 * 0.20
+        self.assertEqual(bob_levy.total_chf, Decimal("0.38"))     # 7.5 * 0.05 = 0.375 -> HALF_UP 0.38
+
+    def test_the_holder_pays_their_share_like_everyone_else(self):
+        """The holder of record gets no special case: they pay only their weight
+        share, exactly like every other eligible participant (§1.1)."""
+        alice = self._participant("Alice Muster", weight="1")
+        bob = self._participant("Bob Beispiel", weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-COMM-2")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "10")
+        self._grid_tariff()
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        self.assertEqual(alice_invoice.total_grid_kwh, Decimal("5.0000"))
+        self.assertEqual(bob_invoice.total_grid_kwh, Decimal("5.0000"))
+
+    def test_sole_participant_carries_the_shared_meter_alone(self):
+        alice = self._participant("Alice Muster", weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-COMM-3")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "10")
+        self._grid_tariff()
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+
+        self.assertEqual(alice_invoice.total_grid_kwh, Decimal("10.0000"))
+
+    def test_shared_energy_conservation_within_rounding(self):
+        """Uneven, non-terminating weight shares (1 and 2, thirds) must still
+        conserve: the sum of both invoices reproduces the un-split amount
+        within one rappen (§10)."""
+        alice = self._participant("Alice Muster", weight="1")
+        bob = self._participant("Bob Beispiel", weight="2")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-COMM-4")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "10")
+        self._grid_tariff(price="0.30000")
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        full_amount = Decimal("10") * Decimal("0.30000")  # 3.00
+        combined = alice_invoice.subtotal_chf + bob_invoice.subtotal_chf
+        self.assertLessEqual(abs(combined - full_amount), Decimal("0.01"))
+
+        combined_kwh = alice_invoice.total_grid_kwh + bob_invoice.total_grid_kwh
+        self.assertLessEqual(abs(combined_kwh - Decimal("10")), Decimal("0.0001"))
+
+
+class SharedProductionSplitTests(_SharedMeteringBase, TestCase):
+    def test_shared_production_credits_every_member_symmetrically(self):
+        alice = self._participant("Alice Muster", weight="1")
+        bob = self._participant("Bob Beispiel", weight="1")
+        community_prod_mp = self._mp(MeteringPointType.PRODUCTION, "CH-SM-PROD-1")
+        self._assign(community_prod_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._production(community_prod_mp, date(2026, 1, 5), "10")
+        self._feed_in_tariff(price="0.08000")
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        # No consumption anywhere: the entire community production is exported.
+        self.assertEqual(alice_invoice.total_feed_in_kwh, Decimal("5.0000"))
+        self.assertEqual(bob_invoice.total_feed_in_kwh, Decimal("5.0000"))
+
+        alice_feed_in = self._feed_in_items(alice_invoice)[0]
+        bob_feed_in = self._feed_in_items(bob_invoice)[0]
+        self.assertEqual(alice_feed_in.total_chf, Decimal("-0.40"))  # -(5 * 0.08)
+        self.assertEqual(bob_feed_in.total_chf, Decimal("-0.40"))
+
+    def test_community_production_uses_same_eligibility_rule(self):
+        """A mid-period joiner gets no credit for community production before
+        their join date — the same date-granular eligibility rule as
+        consumption."""
+        alice = self._participant("Alice Muster", valid_from=JAN, weight="1")
+        bob = self._participant("Bob Beispiel", valid_from=date(2026, 1, 16), weight="1")
+        community_prod_mp = self._mp(MeteringPointType.PRODUCTION, "CH-SM-PROD-2")
+        self._assign(community_prod_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._production(community_prod_mp, date(2026, 1, 5), "10")   # before Bob joins
+        self._production(community_prod_mp, date(2026, 1, 20), "10")  # after Bob joins
+        self._feed_in_tariff()
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        # Jan 5: Alice alone -> all 10 exported to her. Jan 20: split 50/50.
+        self.assertEqual(alice_invoice.total_feed_in_kwh, Decimal("15.0000"))
+        self.assertEqual(bob_invoice.total_feed_in_kwh, Decimal("5.0000"))
+
+
+class MixedWindowAndTimingTests(_SharedMeteringBase, TestCase):
+    def test_shared_meter_part_of_period_only_shares_that_window(self):
+        alice = self._participant("Alice Muster", weight="1")
+        bob = self._participant("Bob Beispiel", weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-COMM-5")
+        # Community only Jan 1-15; unassigned afterwards.
+        self._assign(community_mp, alice, JAN, date(2026, 1, 15), mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "10")   # inside the window
+        self._consumption(community_mp, date(2026, 1, 20), "6")   # outside: a gap, billed to nobody
+        self._grid_tariff()
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        # Only the Jan 5 reading (10 kWh) is shared; the Jan 20 gap reading
+        # (6 kWh) is excluded from both invoices entirely.
+        self.assertEqual(alice_invoice.total_grid_kwh, Decimal("5.0000"))
+        self.assertEqual(bob_invoice.total_grid_kwh, Decimal("5.0000"))
+
+    def test_mixed_window_meter_bills_personally_then_shares(self):
+        """§7.3's load-bearing case: a meter personal in month 1 and community
+        in month 2 bills the holder in full for month 1 and only a weighted
+        share for month 2 — no lost readings, no double billing."""
+        alice = self._participant("Alice Muster", weight="1")
+        bob = self._participant("Bob Beispiel", weight="1")
+        mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-MIXED-1")
+        self._assign(mp, alice, JAN, date(2026, 1, 15), mode=AllocationMode.PERSONAL)
+        self._assign(mp, alice, date(2026, 1, 16), mode=AllocationMode.COMMUNITY)
+        self._consumption(mp, date(2026, 1, 5), "10")   # personal window: Alice alone
+        self._consumption(mp, date(2026, 1, 20), "8")    # community window: split 50/50
+        self._grid_tariff()
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        self.assertEqual(alice_invoice.total_grid_kwh, Decimal("14.0000"))  # 10 + 4
+        self.assertEqual(bob_invoice.total_grid_kwh, Decimal("4.0000"))     # 4 only
+
+    def test_community_readings_are_not_counted_as_skipped(self):
+        """A community reading must never appear in the "no assignment
+        covered this reading" skip log — it belongs to everybody, not
+        nobody (§7.3)."""
+        alice = self._participant("Alice Muster", weight="1")
+        self._participant("Bob Beispiel", weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-COMM-6")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "10")
+        self._grid_tariff()
+
+        with self.assertNoLogs("invoices.engine", level="WARNING"):
+            generate_invoice(alice, JAN, JAN_END)
+
+    def test_joiner_does_not_pay_for_community_energy_before_join_date(self):
+        alice = self._participant("Alice Muster", valid_from=JAN, weight="1")
+        bob = self._participant("Bob Beispiel", valid_from=date(2026, 1, 16), weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-COMM-7")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "10")   # before Bob joins
+        self._consumption(community_mp, date(2026, 1, 20), "10")  # after Bob joins
+        self._grid_tariff()
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        # Jan 5: Alice alone pays the full 10. Jan 20: split 50/50 (5 each).
+        self.assertEqual(alice_invoice.total_grid_kwh, Decimal("15.0000"))
+        self.assertEqual(bob_invoice.total_grid_kwh, Decimal("5.0000"))
+
+    def test_leaver_does_not_pay_for_community_energy_after_leave_date(self):
+        alice = self._participant("Alice Muster", valid_from=JAN, valid_to=date(2026, 1, 15), weight="1")
+        bob = self._participant("Bob Beispiel", valid_from=JAN, weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-COMM-8")
+        self._assign(community_mp, bob, JAN, mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "10")   # both eligible
+        self._consumption(community_mp, date(2026, 1, 20), "10")  # only Bob eligible
+        self._grid_tariff()
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        self.assertEqual(alice_invoice.total_grid_kwh, Decimal("5.0000"))    # Jan 5 half only
+        self.assertEqual(bob_invoice.total_grid_kwh, Decimal("15.0000"))     # Jan 5 half + Jan 20 full
+
+
+class PerMeteringPointCommunityFeeTests(_SharedMeteringBase, TestCase):
+    def test_per_metering_point_fee_splits_shared_meters_and_excludes_holder(self):
+        alice = self._participant("Alice Muster", weight="1")
+        bob = self._participant("Bob Beispiel", weight="1")
+        personal_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-PMP-1")
+        self._assign(personal_mp, alice, JAN, mode=AllocationMode.PERSONAL)
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-PMP-2")
+        # Alice is also the holder of record for the community meter — this
+        # must not count towards her *personal* per-metering-point total.
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._mp_fee_tariff(price="10.00")
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        alice_fees = self._fee_items(alice_invoice)
+        # One personal line (her own meter, excluding the community one she
+        # merely holds) and one shared line (her 1/2 weight share of the
+        # community meter's fee).
+        self.assertEqual(len(alice_fees), 2)
+        personal_line = next(i for i in alice_fees if i.quantity_kwh == Decimal("1.0000") and i.total_chf == Decimal("10.00"))
+        shared_line = next(i for i in alice_fees if i.total_chf == Decimal("5.00"))
+        self.assertIsNotNone(personal_line)
+        self.assertIsNotNone(shared_line)
+
+        bob_fees = self._fee_items(bob_invoice)
+        self.assertEqual(len(bob_fees), 1)  # no personal meters, only the shared line
+        self.assertEqual(bob_fees[0].total_chf, Decimal("5.00"))
+
+    def test_inactive_shared_meter_bills_nobody(self):
+        alice = self._participant("Alice Muster", weight="1")
+        self._participant("Bob Beispiel", weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-PMP-3")
+        community_mp.is_active = False
+        community_mp.save()
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._mp_fee_tariff(price="10.00")
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+
+        self.assertEqual(self._fee_items(alice_invoice), [])
+
+    def test_weighted_energy_and_fee_use_their_respective_time_granularity(self):
+        """Energy shares are date-granular; per-metering-point fee shares are
+        month-granular — a joiner's weight dilutes the whole month's fee
+        denominator immediately, but only the energy readings from their
+        join date onward (§7.1)."""
+        alice = self._participant("Alice Muster", valid_from=JAN, weight="1")
+        self._participant("Bob Beispiel", valid_from=date(2026, 1, 16), weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-PMP-4")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "10")  # before Bob joins
+        self._grid_tariff()
+        self._mp_fee_tariff(price="10.00")
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+
+        # Energy: Bob is not eligible for the Jan 5 reading at all, so Alice
+        # pays the full amount — no dilution.
+        self.assertEqual(alice_invoice.total_grid_kwh, Decimal("10.0000"))
+
+        # Fee: Bob is a member for *some* part of January, so the month's
+        # weight sum already includes him in full — Alice's fee share is
+        # diluted for the whole month despite Bob joining on the 16th.
+        shared_fee = next(i for i in self._fee_items(alice_invoice) if i.total_chf != Decimal("0.00"))
+        self.assertEqual(shared_fee.total_chf, Decimal("5.00"))
+
+
+class InvoiceTotalsAndDescriptionTests(_SharedMeteringBase, TestCase):
+    def test_invoice_kwh_totals_include_shared_energy(self):
+        alice = self._participant("Alice Muster", weight="1")
+        self._participant("Bob Beispiel", weight="1")
+
+        personal_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-TOT-1")
+        self._assign(personal_mp, alice, JAN, mode=AllocationMode.PERSONAL)
+        self._consumption(personal_mp, date(2026, 1, 5), "5")
+
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-TOT-2")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "5")  # Alice's share: 2.5
+
+        self._grid_tariff()
+
+        invoice = generate_invoice(alice, JAN, JAN_END)
+
+        self.assertEqual(invoice.total_grid_kwh, Decimal("7.5000"))
+
+    def test_single_participant_regeneration_equals_full_run(self):
+        """Regenerating one participant's invoice alone must yield the same
+        shared share as it would in a full run: weights are read from ZEV
+        membership, never from sibling invoices (§7.1)."""
+        alice = self._participant("Alice Muster", weight="1")
+        self._participant("Bob Beispiel", weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-TOT-3")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        self._consumption(community_mp, date(2026, 1, 5), "10")
+        self._grid_tariff()
+
+        # Only Alice's invoice is generated — Bob's is never created.
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+
+        self.assertEqual(alice_invoice.total_grid_kwh, Decimal("5.0000"))
+
+    def test_shared_line_description_carries_the_community_marker(self):
+        markers = {
+            "de": "Gemeinschaftsanteil",
+            "fr": "Part communautaire",
+            "it": "Quota comunitaria",
+            "en": "Community share",
+        }
+        for lang, marker in markers.items():
+            with self.subTest(lang=lang):
+                zev = Zev.objects.create(
+                    name=f"Marker ZEV {lang}",
+                    owner=self.owner,
+                    zev_type="vzev",
+                    start_date=JAN,
+                    billing_interval="monthly",
+                    invoice_prefix=f"MK{lang.upper()}",
+                    invoice_language=lang,
+                )
+                zev.refresh_from_db()
+                alice = factories.ParticipantFactory(zev=zev, first_name="Alice", last_name="Muster", valid_from=JAN)
+                community_mp = MeteringPoint.objects.create(
+                    zev=zev, meter_type=MeteringPointType.CONSUMPTION, meter_id=f"CH-SM-MARKER-{lang}")
+                MeteringPointAssignment.objects.create(
+                    metering_point=community_mp, participant=alice, valid_from=JAN,
+                    allocation_mode=AllocationMode.COMMUNITY,
+                )
+                self._reading(community_mp, date(2026, 1, 5), "10", ReadingDirection.IN)
+                factories.flat_tariff(zev, energy_type=EnergyType.GRID, price="0.20000")
+
+                invoice = generate_invoice(alice, JAN, JAN_END)
+                grid_item = self._grid_items(invoice)[0]
+                self.assertIn(marker, grid_item.description)


### PR DESCRIPTION
## Summary
- Bills a `COMMUNITY`-mode metering point's energy and per-metering-point fees across every eligible participant by `allocation_weight`, instead of to its holder alone (spec §7.3-§7.6, part of #387; builds on #459/#460/#461/#462).
- The consumption/production loops' assignment gate becomes mode-aware (`assignment_at` instead of `is_held_by`), distinguishing three cases — gap, community energy, somebody else's meter — so only true gaps count in the skip-reading counters (§7.3). `assignment_windows` is now ZEV-wide, not participant-scoped, since telling those three cases apart requires seeing every window.
- A meter whose mode changes mid-period bills correctly on both sides: `test_mixed_window_meter_bills_personally_then_shares` is the regression test for the exact bug an earlier draft of the spec had.
- Community readings are priced once (same tariff resolution, same physical-pool split) and then allocated by each participant's date-granular weight share; a mid-period joiner/leaver pays no share of readings outside their own membership window.
- Per-metering-point fees now split personal metering points from community ones: the personal count excludes `COMMUNITY` assignments per window, and each active community meter contributes its own weight-split line, month-granular.
- Line items carry a community marker (4 locales) on any community-allocated bucket.
- Fixed a real gap this work surfaced in `pdf_stats.py`: a community-only participant (never the literal holder of any meter) showed up with an empty name in the period stats — names are now resolved from both window holders and community-share recipients.

## Test plan
- [x] Backend: `pytest backend` — 1212 passed
- [x] New `invoices/test_shared_metering.py` (17 tests): weighted consumption/production splits, mixed personal/community windows, per-metering-point community fees (including `is_active` mirroring and personal/community exclusivity), date- vs. month-granularity, kWh-total conservation, description marker in all four locales
- [x] `invoices/test_allocation_reconciliation.py`: new `CommunityMeterReconciliationTests` (2 tests) — engine, `pdf_stats`, and `analytics` all attribute the same weighted share, including to the meter's own holder of record
- [x] `invoices/test_pdf.py`: `test_shared_lines_render_with_marker` — the marker text actually reaches the rendered PDF, all four languages
- [x] `invoices/test_allocation_query_counts.py`: query bound bumped 13 → 17 (four new single-fetch queries, no N+1)
- [x] `ruff check` clean, `makemigrations --check --dry-run` clean (no model changes)
- [x] Mutation-tested: forced the weight-split division to a no-op (11/17 new tests failed as expected), reverted the `COMMUNITY` exclusion in the per-metering-point count (2 tests failed as expected), reverted the `pdf_stats` name fix (new reconciliation test failed with `KeyError` as expected) — all reverted and re-verified green

🤖 Generated with [Claude Code](https://claude.com/claude-code)