### PR TITLE
fix(invoices): clamp weight-split denominators to the tariff's own validity

### DIFF
--- a/backend/invoices/engine.py
+++ b/backend/invoices/engine.py
@@ -55,9 +55,12 @@ class PeriodReadings(NamedTuple):
     is what lets the pricing loops tell a true gap apart from energy that
     simply belongs to somebody, or something, else (§7.3).
 
-    ``weight_sum_by_date``/``weight_sum_by_month`` are the community's
-    allocation-weight denominators for the invoice period, used to turn a
-    community reading's price into this participant's share.
+    ``weight_sum_by_date`` is the community's date-granular allocation-weight
+    denominator for the invoice period, used to turn a community reading's
+    price into this participant's share. There is deliberately no month-
+    granular twin here: the fixed-fee denominators are clamped to each
+    tariff's own validity, so they are built inside ``_price_fixed_fees``
+    from one shared membership fetch rather than precomputed per invoice.
     """
 
     participant_consumption: models.QuerySet
@@ -67,7 +70,6 @@ class PeriodReadings(NamedTuple):
     zev_consumption_by_ts: dict
     zev_production_by_ts: dict
     weight_sum_by_date: dict
-    weight_sum_by_month: dict
     assignment_windows: AssignmentWindows
 
 
@@ -146,7 +148,6 @@ def _gather_period_readings(participant, period_start, period_end) -> PeriodRead
         zev_consumption_by_ts=zev_consumption_by_ts,
         zev_production_by_ts=zev_production_by_ts,
         weight_sum_by_date=_allocation_weight_sum_by_date(zev, period_start, period_end),
-        weight_sum_by_month=_allocation_weight_sum_by_month(zev, period_start, period_end),
         # ZEV-wide, not participant-scoped: the personal loops must be able to
         # resolve *any* window at a reading's timestamp — another
         # participant's, or a community one — to tell a true gap apart from
@@ -451,15 +452,13 @@ def _overlaps(valid_from: date, valid_to: date | None, start: date, end: date) -
     return valid_from <= end and (valid_to is None or valid_to >= start)
 
 
-def _billable_months(tariff: Tariff, period_start: date, period_end: date):
-    """Yield ``(month, billed_from, billed_to)`` for each month the fee covers.
+def _months_between(overlap_start: date, overlap_end: date):
+    """Yield ``(month, billed_from, billed_to)`` across ``overlap_start``..``overlap_end``.
 
     ``month`` is the first of the month and identifies it; the other two are
-    clamped to the part of it that is actually billed, which is what membership
-    is tested against. A period opening mid-month bills only from that day.
+    clamped to the part of it actually covered, which is what membership is
+    tested against.
     """
-    overlap_start = max(period_start, tariff.valid_from)
-    overlap_end = min(period_end, tariff.valid_to or period_end)
     if overlap_start > overlap_end:
         return
 
@@ -473,6 +472,19 @@ def _billable_months(tariff: Tariff, period_start: date, period_end: date):
             min(next_month - timedelta(days=1), overlap_end),
         )
         cursor = next_month
+
+
+def _billable_months(tariff: Tariff, period_start: date, period_end: date):
+    """Yield ``(month, billed_from, billed_to)`` for each month the fee covers.
+
+    Clamped to the overlap of the invoice period and the tariff's own validity,
+    so a period opening mid-month — or a tariff version starting mid-month —
+    bills only from that day.
+    """
+    yield from _months_between(
+        max(period_start, tariff.valid_from),
+        min(period_end, tariff.valid_to or period_end),
+    )
 
 
 def _count_active_participants_by_month(zev: Zev, tariff: Tariff, period_start: date, period_end: date) -> dict[date, int]:
@@ -514,41 +526,67 @@ def _count_active_participants_by_month(zev: Zev, tariff: Tariff, period_start: 
     return counts
 
 
-def _allocation_weight_sum_by_month(zev: Zev, period_start: date, period_end: date) -> dict[date, Decimal]:
-    """Sum of ``Participant.allocation_weight`` active in each billed month.
+def _participant_weight_windows(zev: Zev) -> list[tuple[date, date | None, Decimal]]:
+    """``(valid_from, valid_to, allocation_weight)`` for every participant of ``zev``.
 
-    Counted per month, not once over the period — same rationale as
-    ``_count_active_participants_by_month``: a joiner in February must not
-    dilute January's share. Read from ZEV membership, never from sibling
-    invoices, so generating one participant's invoice alone yields the same
-    share as a full run.
-
-    Unlike ``_count_active_participants_by_month`` this takes no ``tariff``:
-    it feeds both weight-keyed SHARED_* fees (which look up their own
-    tariff-clipped months here) and per-metering-point community fees, and
-    is computed once over the whole invoice period rather than once per
-    tariff. A month with no eligible participant is absent, not zero, so a
-    caller cannot divide by it.
+    Fetched once and resolved in Python by the weight-sum helpers below —
+    the same "single fetch, then Python" shape the rest of this module uses.
+    Callers pricing several tariffs in one invoice should fetch once and pass
+    the result down rather than re-querying per tariff.
     """
-    windows = list(
+    return list(
         Participant.objects.filter(zev=zev).values_list("valid_from", "valid_to", "allocation_weight")
     )
 
+
+def _allocation_weight_sum_by_month(
+    zev: Zev,
+    period_start: date,
+    period_end: date,
+    tariff: Tariff | None = None,
+    *,
+    windows: list | None = None,
+) -> dict[date, Decimal]:
+    """Sum of ``Participant.allocation_weight`` active in each billed month.
+
+    The weight-keyed counterpart of ``_count_active_participants_by_month``,
+    and it must clamp its months exactly the same way, because
+    ``_price_fixed_fees`` pairs this denominator with a numerator loop driven
+    by ``_billable_months(tariff, ...)``. Passing ``tariff`` clamps to the
+    overlap of the invoice period and that tariff's validity; omitting it
+    covers the whole period.
+
+    **Pass the tariff whenever one is in play.** Without it, a tariff clipped
+    inside the period — a version starting mid-month, say — would count a
+    participant who is a member of the calendar month but not of the part of
+    it the tariff actually bills. They would sit in the denominator while
+    their own numerator loop skips them, so the community would recover less
+    than the full fee (issue #465).
+
+    Counted per month, not once over the period: a joiner in February must not
+    dilute January's share. Read from ZEV membership, never from sibling
+    invoices, so generating one participant's invoice alone yields the same
+    share as a full run. A month with no eligible participant is absent, not
+    zero, so a caller cannot divide by it.
+    """
+    if windows is None:
+        windows = _participant_weight_windows(zev)
+
+    months = (
+        _billable_months(tariff, period_start, period_end)
+        if tariff is not None
+        else _months_between(period_start, period_end)
+    )
+
     sums: dict[date, Decimal] = {}
-    cursor = _month_start(period_start)
-    last_month = _month_start(period_end)
-    while cursor <= last_month:
-        next_month = _next_month(cursor)
-        billed_from = max(cursor, period_start)
-        billed_to = min(next_month - timedelta(days=1), period_end)
+    for month, billed_from, billed_to in months:
         total = sum(
             (weight for valid_from, valid_to, weight in windows
              if _overlaps(valid_from, valid_to, billed_from, billed_to)),
             Decimal("0"),
         )
         if total > 0:
-            sums[cursor] = total
-        cursor = next_month
+            sums[month] = total
 
     return sums
 
@@ -760,7 +798,22 @@ def _price_fixed_fees(participant, tariffs, period_start, period_end, accumulato
     community meter contributes its own weight-split ``bucket="shared"``
     line — ``split_key`` plays no part here, since a community meter's cost
     always allocates by weight.
+
+    Both weight-split paths share one fetch of the ZEV's participant windows,
+    resolved per tariff in Python: the denominator's *months* are
+    tariff-specific but the underlying membership rows are not, so querying
+    per tariff would be an N+1 over the ZEV's tariff list.
     """
+    weight_windows: list | None = None
+
+    def weight_sums_for(tariff: Tariff) -> dict[date, Decimal]:
+        nonlocal weight_windows
+        if weight_windows is None:
+            weight_windows = _participant_weight_windows(participant.zev)
+        return _allocation_weight_sum_by_month(
+            participant.zev, period_start, period_end, tariff, windows=weight_windows,
+        )
+
     for tariff in tariffs:
         if tariff.billing_mode in _ENERGY_BILLING_MODES:
             continue
@@ -798,8 +851,7 @@ def _price_fixed_fees(participant, tariffs, period_start, period_end, accumulato
             community_counts = _count_community_metering_points_by_month(
                 participant.zev, tariff, period_start, period_end)
             if community_counts:
-                weight_sums = _allocation_weight_sum_by_month(
-                    participant.zev, period_start, period_end)
+                weight_sums = weight_sums_for(tariff)
                 shared_total = Decimal("0")
                 shared_months = 0
                 for month, billed_from, billed_to in _billable_months(tariff, period_start, period_end):
@@ -827,9 +879,10 @@ def _price_fixed_fees(participant, tariffs, period_start, period_end, accumulato
             # key). EQUAL is today's headcount split — the numerator is 1
             # and the denominator is the same participant count, so it is
             # arithmetically identical to the pre-split_key behaviour.
+            # Both branches clamp their months to this tariff's validity, so
+            # the two keys agree exactly when every weight is 1.
             if tariff.split_key == SplitKey.WEIGHT:
-                shares = _allocation_weight_sum_by_month(
-                    participant.zev, period_start, period_end)
+                shares = weight_sums_for(tariff)
                 numerator = participant.allocation_weight
             else:
                 shares = _count_active_participants_by_month(

--- a/backend/invoices/test_allocation_query_counts.py
+++ b/backend/invoices/test_allocation_query_counts.py
@@ -13,6 +13,7 @@ Counts are measured on the shared multi-meter reconciliation fixture and
 verified to be identical on SQLite and PostgreSQL.
 """
 from datetime import date
+from decimal import Decimal
 
 from django.contrib.auth import get_user_model
 from django.db import connection
@@ -30,6 +31,8 @@ from invoices.test_allocation_reconciliation import (
     PERIOD_START,
     _ReconciliationBase,
 )
+from tariffs.models import BillingMode, SplitKey, TariffCategory
+from testing import factories
 from testing.helpers import make_named_participant
 from zev.models import MeteringPointType, Zev
 
@@ -106,14 +109,54 @@ class AllocationQueryCountTests(_ReconciliationBase):
 
     def test_engine_generate_invoice_query_count(self):
         # Windows fetch + readings fetch + tariff lookup + invoice writes.
-        # 13 -> 17: shared metering points (#387) add four queries — a
-        # community consumption and a community production reading fetch,
-        # plus one Participant fetch each for the date- and month-granular
-        # allocation-weight sums (_allocation_weight_sum_by_date/_by_month) —
-        # still a single query each regardless of how many community
-        # readings or how many months the period spans.
+        # 13 -> 17 -> 16: shared metering points (#387) added a community
+        # consumption and a community production reading fetch, plus a
+        # Participant fetch each for the date- and month-granular
+        # allocation-weight sums. #465 dropped the month-granular one from
+        # PeriodReadings: it was never read, because the fixed-fee
+        # denominators are tariff-clamped and are built inside
+        # _price_fixed_fees instead.
         self._call_at_most(
-            17, generate_invoice, self.alice, PERIOD_START, PERIOD_END
+            16, generate_invoice, self.alice, PERIOD_START, PERIOD_END
+        )
+
+    def test_weight_keyed_shared_fees_do_not_scale_queries_with_tariff_count(self):
+        """The single-fetch invariant across the *tariff* list, not just the
+        reading list.
+
+        ``_price_fixed_fees`` resolves a weight denominator per tariff (their
+        billed months differ), but the underlying ZEV membership rows do not
+        change between tariffs — so they must be fetched once per invoice, not
+        once per tariff. This was an N+1 until #465; the fixture above has no
+        weight-keyed or per-metering-point tariff, so the whole-engine bound
+        never exercised this path.
+        """
+        for index in range(6):
+            tariff = factories.TariffFactory(
+                zev=self.zev,
+                name=f"Weighted shared fee {index}",
+                category=TariffCategory.METERING,
+                billing_mode=BillingMode.SHARED_MONTHLY_FEE,
+                energy_type=None,
+                fixed_price_chf=Decimal("10.00"),
+                valid_from=PERIOD_START,
+                split_key=SplitKey.WEIGHT,
+            )
+            self.assertEqual(tariff.split_key, SplitKey.WEIGHT)
+
+        with CaptureQueriesContext(connection) as ctx:
+            generate_invoice(self.alice, PERIOD_START, PERIOD_END)
+
+        membership_fetches = [
+            query for query in ctx.captured_queries
+            if 'FROM "zev_participant"' in query["sql"] and "allocation_weight" in query["sql"]
+        ]
+        # One for the date-granular community-energy denominator, one shared
+        # by all six weight-keyed tariffs. Six tariffs must not mean six.
+        self.assertLessEqual(
+            len(membership_fetches), 2,
+            f"expected at most 2 membership fetches, got {len(membership_fetches)} "
+            f"for 6 weight-keyed tariffs — N+1 over the tariff list",
         )
 
     def test_pdf_stats_query_count(self):

--- a/backend/invoices/test_shared_fee.py
+++ b/backend/invoices/test_shared_fee.py
@@ -486,3 +486,69 @@ def test_an_indivisible_weighted_share_leaves_the_rappen_shortfall():
     )
 
     assert total == Decimal("99.99")
+
+
+# ---------------------------------------------------------------------------
+# Tariff-clamped denominators (regression: #465)
+#
+# ``_price_fixed_fees`` drives its numerator loop from
+# ``_billable_months(tariff, ...)``. A denominator clamped to the invoice
+# *period* instead of the tariff's own validity counts members of the calendar
+# month who are not members of the part the tariff actually bills — they land
+# in the denominator while their own numerator loop skips them, so the
+# community recovers less than the whole fee. Tariff versioning makes a
+# mid-period ``valid_from`` ordinary, so this is not an exotic shape.
+# ---------------------------------------------------------------------------
+
+def test_weight_and_equal_keys_agree_when_the_tariff_starts_mid_month():
+    """The isolation guarantee under a clipped tariff: with every weight at
+    the default 1, ``weight`` must bill exactly what ``equal`` bills."""
+    zev = factories.ZevFactory()
+    stayer = factories.ParticipantFactory(zev=zev, valid_from=JAN)
+    # Leaves on the 10th — before the tariff starts on the 15th, so they are
+    # never billed for it and must not sit in either denominator.
+    factories.ParticipantFactory(zev=zev, valid_from=JAN, valid_to=date(2026, 1, 10))
+
+    equal = shared_tariff(zev, price="100.00", name="Equal fee",
+                          valid_from=date(2026, 1, 15), split_key=SplitKey.EQUAL)
+    weight = shared_tariff(zev, price="100.00", name="Weight fee",
+                           valid_from=date(2026, 1, 15), split_key=SplitKey.WEIGHT)
+
+    invoice = generate_invoice(stayer, JAN, JAN_END)
+    by_name = {item.description.split(" (")[0]: item for item in invoice.items.all()}
+
+    assert by_name[equal.name].total_chf == Decimal("100.00")
+    assert by_name[weight.name].total_chf == by_name[equal.name].total_chf
+
+
+def test_weighted_shared_fee_is_fully_recovered_when_the_tariff_starts_mid_month():
+    """Reconciliation property under a clipped tariff: a full ZEV run recovers
+    the month's amount once, not a fraction of it."""
+    zev = factories.ZevFactory()
+    factories.ParticipantFactory(zev=zev, valid_from=JAN)
+    factories.ParticipantFactory(zev=zev, valid_from=JAN, valid_to=date(2026, 1, 10))
+    shared_tariff(zev, price="100.00", valid_from=date(2026, 1, 15),
+                  split_key=SplitKey.WEIGHT)
+
+    result = generate_invoices_for_zev(zev, JAN, JAN_END)
+    recovered = sum(
+        (item.total_chf for invoice in result.invoices
+         for item in invoice.items.filter(tariff_category=TariffCategory.METERING)),
+        Decimal("0"),
+    )
+
+    assert result.failures == []
+    assert recovered == Decimal("100.00")
+
+
+def test_weighted_shared_fee_denominator_still_tracks_the_billed_window():
+    """The clamp must not overshoot: a member who *is* active inside the
+    tariff's billed window still dilutes it."""
+    zev = factories.ZevFactory()
+    stayer = factories.ParticipantFactory(zev=zev, valid_from=JAN)
+    # Leaves on the 20th — inside the Jan 15..Jan 31 billed window.
+    factories.ParticipantFactory(zev=zev, valid_from=JAN, valid_to=date(2026, 1, 20))
+    shared_tariff(zev, price="100.00", valid_from=date(2026, 1, 15),
+                  split_key=SplitKey.WEIGHT)
+
+    assert fee_line(generate_invoice(stayer, JAN, JAN_END)).total_chf == Decimal("50.00")

--- a/backend/invoices/test_shared_metering.py
+++ b/backend/invoices/test_shared_metering.py
@@ -27,7 +27,7 @@ from tariffs.models import BillingMode, EnergyType, TariffCategory
 from testing import factories
 from zev.models import AllocationMode, MeteringPoint, MeteringPointAssignment, MeteringPointType, Zev
 
-from .engine import generate_invoice
+from .engine import generate_invoice, generate_invoices_for_zev
 
 pytestmark = pytest.mark.django_db
 
@@ -452,3 +452,53 @@ class InvoiceTotalsAndDescriptionTests(_SharedMeteringBase, TestCase):
                 invoice = generate_invoice(alice, JAN, JAN_END)
                 grid_item = self._grid_items(invoice)[0]
                 self.assertIn(marker, grid_item.description)
+
+
+class CommunityFeeTariffClampTests(_SharedMeteringBase, TestCase):
+    """A per-metering-point tariff clipped inside the invoice period must not
+    dilute its community contribution with members it never bills (#465).
+
+    ``_price_fixed_fees`` drives the numerator from
+    ``_billable_months(tariff, ...)``; a denominator clamped to the period
+    instead would leave part of the meter's fee recovered from nobody.
+    """
+
+    def test_community_meter_fee_is_fully_recovered_when_the_tariff_starts_mid_month(self):
+        alice = self._participant("Alice Muster", weight="1")
+        # Leaves before the tariff starts, so she is never billed for it.
+        self._participant("Bob Beispiel", valid_to=date(2026, 1, 10), weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-CLAMP-1")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        factories.TariffFactory(
+            zev=self.zev, billing_mode=BillingMode.PER_METERING_POINT_MONTHLY_FEE,
+            category=TariffCategory.METERING, energy_type=None,
+            fixed_price_chf=Decimal("10.00"), valid_from=date(2026, 1, 15),
+        )
+
+        result = generate_invoices_for_zev(self.zev, JAN, JAN_END)
+        recovered = sum(
+            (item.total_chf for invoice in result.invoices
+             for item in invoice.items.filter(tariff_category=TariffCategory.METERING)),
+            Decimal("0"),
+        )
+
+        self.assertEqual(result.failures, [])
+        self.assertEqual(recovered, Decimal("10.00"))
+
+    def test_a_member_inside_the_billed_window_still_shares_the_community_fee(self):
+        """The clamp must not overshoot — someone active during the billed
+        part of the month keeps their share."""
+        alice = self._participant("Alice Muster", weight="1")
+        self._participant("Bob Beispiel", valid_to=date(2026, 1, 20), weight="1")
+        community_mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-CLAMP-2")
+        self._assign(community_mp, alice, JAN, mode=AllocationMode.COMMUNITY)
+        factories.TariffFactory(
+            zev=self.zev, billing_mode=BillingMode.PER_METERING_POINT_MONTHLY_FEE,
+            category=TariffCategory.METERING, energy_type=None,
+            fixed_price_chf=Decimal("10.00"), valid_from=date(2026, 1, 15),
+        )
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        shared = next(i for i in self._fee_items(alice_invoice) if i.total_chf > 0)
+
+        self.assertEqual(shared.total_chf, Decimal("5.00"))

--- a/docs/specs/2026-03-tariffs-and-billing-engine.md
+++ b/docs/specs/2026-03-tariffs-and-billing-engine.md
@@ -451,14 +451,23 @@ own weight — the same key a `COMMUNITY`-mode metering point always uses
 (§4.6.4). With every weight at the default `1`, `weight` and `equal` agree
 exactly.
 
+**Both denominators are clamped to the same months as the numerator** — the
+overlap of the invoice period *and this tariff's own validity*, not the period
+alone. A tariff clipped inside the period (a version starting mid-month, which
+tariff versioning makes ordinary — §3.1.1) otherwise counts a participant who
+is a member of the calendar month but not of the part the tariff actually
+bills: they land in the denominator while the numerator loop below skips them,
+and the community recovers less than the whole fee. The weight-sum helper
+therefore takes the tariff, exactly as the headcount helper always has.
+
 ```
 monthly_amount = fixed_price_chf / 12  if shared_yearly_fee else fixed_price_chf
 IF split_key == WEIGHT:
     numerator   = participant.allocation_weight
-    denominator_for(month) = allocation_weight_sum_by_month[month]   # sum of every eligible participant's weight
+    denominator_for(month) = allocation_weight_sum_by_month(tariff)[month]  # weights active in the BILLED window
 ELSE:
     numerator   = 1
-    denominator_for(month) = N   # headcount, as below
+    denominator_for(month) = N   # headcount over the same billed window, as below
 
 total = 0
 charged_months = 0
@@ -533,7 +542,7 @@ shared_months = 0
 for each billable month M in community_counts:
     if this participant's validity does not overlap M (clamped to the overlap):
         continue
-    weight_sum = allocation_weight_sum_by_month[M]
+    weight_sum = allocation_weight_sum_by_month(tariff)[M]   # clamped to this tariff's billed window
     total += unit_price × community_counts[M] × participant.allocation_weight / weight_sum
     shared_months += 1
 
@@ -545,6 +554,11 @@ if shared_months > 0:
 billing modes. The cost being divided belongs to a community *metering
 point*, which always allocates by weight (§1.1 of the feature spec). A
 per-assignment split key is a documented follow-up, out of scope.
+
+Both weight-split paths (this one and §4.6.3) resolve their denominator per
+tariff but share **one** fetch of the ZEV's participant membership rows per
+invoice: the billed months differ between tariffs, the membership does not, so
+querying per tariff would be an N+1 over the ZEV's tariff list.
 
 ### 4.7 Item accumulation
 
@@ -935,6 +949,7 @@ The description renders as: `"Surcharge 50% (50% von CHF 0.32/kWh)"` (German).
 | CHF 100 across 3 participants recovers 99.99 | §4.6.3 documented rounding shortfall |
 | Description text and average-share unit price | §7.2 |
 | `equal` key ignores weights entirely (isolation guarantee); `weight` key splits by weight; default is `equal`; two shared tariffs can use different keys in the same invoice; default weights reproduce the equal split under `weight`; a joiner shifts the weight-sum denominator only from their own month; a negligible-weight member bills almost nothing; an indivisible weighted share leaves the documented rappen shortfall | §4.6.3 `split_key` (`SPEC-2026-08-shared-metering-points` §7.2) |
+| A tariff starting mid-month: both keys agree, a full ZEV run recovers the whole fee, and a member active *inside* the billed window still dilutes it | §4.6.3 tariff-clamped denominators (regression, #465) |
 
 ### Backend (`invoices/test_shared_metering.py`)
 


### PR DESCRIPTION
Fixes #465. Found while reviewing the merged shared-metering-points series (#459–#464).

## The bug

`_price_fixed_fees` drives its numerator from `_billable_months(tariff, …)` — clamped to the overlap of the invoice period and the tariff's own validity. `_allocation_weight_sum_by_month` clamped its denominator to the **period** only. A participant who is a member of the calendar month but not of the part the tariff actually bills therefore sat in the denominator while their own numerator loop skipped them.

`_count_active_participants_by_month` (the `equal` key) has always taken the tariff and clamped correctly — so the two keys disagreed where the spec says they must agree exactly.

CHF 100 shared fee, tariff valid from Jan 15, one member leaving Jan 10, **every weight at the default 1**:

```
split_key=equal  -> 100.00 CHF   (correct)
split_key=weight ->  50.00 CHF   (the other 50.00 billed to nobody)
```

Same root cause in the per-metering-point community contribution: a full `generate_invoices_for_zev` run recovered **CHF 5.00** of a CHF 10.00 community meter fee. That is not the documented sub-rappen shortfall — it is half the fee, and it broke both spec §7.1's "with all weights 1 the month sums equal headcounts" claim and the baseline spec's reconciliation property.

Tariff versioning makes a mid-period `valid_from` ordinary (§3.1.1), so any membership change in the same month as a version changeover triggers it. **Exposure was limited** — `split_key` defaults to `equal` and community meters are opt-in, so no existing ZEV could hit it without opting in first.

## Changes

- `_allocation_weight_sum_by_month` gains an optional `tariff` argument and clamps via `_billable_months` when given, mirroring the headcount helper. Both call sites pass their tariff.
- Extracted `_months_between` so `_billable_months` and the tariff-less branch share one month-walking generator.
- **N+1 fix this exposed:** the helper re-queried ZEV membership once per weight-keyed tariff (6 tariffs → 7 fetches). The rows don't change between tariffs — only the months do — so `_price_fixed_fees` now fetches once, lazily, and resolves each tariff's months in Python.
- Dropped `PeriodReadings.weight_sum_by_month` — populated with a real query per invoice and never read, since the fixed-fee denominators are tariff-clamped and built inside `_price_fixed_fees`. Engine query bound 17 → 16.
- Baseline spec §4.6.3/§4.6.4 updated to state the clamping rule and the shared fetch.

## Test plan
- [x] Backend: 1218 passed (1212 + 6 new), `ruff` clean, `makemigrations --check` clean (no model changes)
- [x] 5 new correctness tests across `test_shared_fee.py` and `test_shared_metering.py` — both keys agree under a clipped tariff, a full ZEV run recovers the whole fee (both the shared-fee and community-meter paths), and the clamp does **not** overshoot (a member active *inside* the billed window still dilutes it)
- [x] New `test_weight_keyed_shared_fees_do_not_scale_queries_with_tariff_count` pins the single-fetch invariant across the tariff list — the existing whole-engine bound could not catch this, since its fixture has no weight-keyed or per-metering-point tariff
- [x] Mutation-tested: reverting the tariff clamp fails all three new correctness tests; removing the shared fetch fails the new query guard with 7 fetches against a bound of 2. Both reverted and re-verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)