### PR TITLE
docs(user-guide): document shared metering points and allocation weights

### DIFF
--- a/docs/user-guide/03-participant-management.md
+++ b/docs/user-guide/03-participant-management.md
@@ -30,7 +30,10 @@ A **participant** is a member of a ZEV community:
 
    > **Tip:** Validity periods ensure participants are only billed during active membership.
 
-4. Click **Create**
+4. Set **Allocation Weight** (optional — leave empty for the default `1`).
+   See [Allocation Weight](#allocation-weight) below.
+
+5. Click **Create**
 
 The participant is created and added to a participant list.
 
@@ -63,6 +66,61 @@ To mark a participant as active/inactive:
 - **End membership:** Set **Valid To** to the last day of their invoice period
 
 > **Important:** Changing validity dates affects future invoices only—past invoices remain unchanged.
+
+## Allocation Weight
+
+**Allocation weight** decides how much of a shared cost a participant carries.
+It is used for:
+
+- [Community (common-area) metering points](04-metering-points.md#shared-common-area-metering-points) — always
+- Shared fees whose split key is set to *By allocation weight*
+  (see [Tariff Configuration](07-tariff-configuration.md#how-a-shared-fee-is-split))
+
+It is a **plain relative number, not a percentage.** Weights of `1`, `1`, `2`
+mean the third participant carries twice what each of the others does — the
+shares work out as 25 % / 25 % / 50 %. Weights of `10`, `10`, `20` give
+exactly the same result. There is no requirement that weights add up to
+anything in particular.
+
+> **Not a Wertquote.** The allocation weight is not the legal value quota
+> under Art. 712e ZGB, and OpenZEV does not treat it as one. If your community
+> has agreed to bill common-area costs by value quota, you may enter those
+> figures as weights — but that is your decision, recorded here as a plain
+> number.
+
+The default is `1`. Leave the field empty when adding a participant and every
+member shares common costs equally — the behaviour you get if you never touch
+this setting at all.
+
+Each participant card shows the resulting share, for example:
+
+```
+ALLOCATION WEIGHT
+25.0000 % — 1.0000 of 4.0000 weights
+```
+
+The percentage is informational and recomputed from current membership. It
+changes on its own when somebody joins or leaves, because the total changes.
+
+### Choosing weights
+
+Common bases a community might agree on:
+
+| Basis | Example weights |
+| --- | --- |
+| Equal split (default) | `1` for everyone |
+| Floor area (m²) | `85`, `120`, `64` |
+| Number of rooms | `2.5`, `4.5`, `3.5` |
+| Agreed value quota | `142`, `210`, `98` |
+
+Use whichever your community's regulations specify. Only one weight per
+participant is supported — you cannot bill the lift by value quota and the
+laundry by floor area.
+
+> **Editing a weight is retroactive on regeneration.** Changing a weight does
+> not alter invoices that have already been sent. But if you regenerate a
+> **draft** invoice for an earlier period, it is recalculated with the *new*
+> weight. Agree weights before a billing run rather than during one.
 
 ## Viewing Participant Metering Points
 

--- a/docs/user-guide/04-metering-points.md
+++ b/docs/user-guide/04-metering-points.md
@@ -41,6 +41,7 @@ OpenZEV supports three metering point types:
 4. Configure participant assignment window (if applicable):
    - **Valid From:** Assignment start date
    - **Valid To:** Assignment end date (leave empty for ongoing)
+   - **Allocation:** `Personal` (default) or `Community` — see below
 
 ## Data Resolution
 
@@ -86,6 +87,71 @@ Assignment validity affects:
 - Old assignment: **Valid To** = 2026-12-31
 - New assignment: **Valid From** = 2027-01-01
 - Result: No billing gaps or overlaps
+
+## Shared (Common-Area) Metering Points
+
+A common-area meter — *Allgemeinstrom*: stairwell lighting, lift, laundry,
+heat pump, the shared grid connection — measures energy the whole community
+uses, not one household's. Every assignment has an **Allocation** setting that
+decides who pays for it:
+
+| Allocation | Who pays |
+| --- | --- |
+| **Personal** (default) | The assigned participant alone. This is how every meter behaved before this setting existed. |
+| **Community** | Every participant of the ZEV, split by their [allocation weight](03-participant-management.md#allocation-weight). |
+
+> **The assigned participant does not change.** A community meter still has a
+> holder of record — usually the *Verwaltung* or a caretaker participant — who
+> stays responsible for the meter in the UI, in data-quality checks, and in
+> the audit log. `Community` changes only **who is billed**, not who holds it.
+> The holder pays their own weighted share like everybody else, with no
+> special case.
+
+Assignment rows set to `Community` are marked with a **Community** badge in
+the metering points list.
+
+### Switching a meter to Community
+
+1. Go to **Metering Points**
+2. Find the meter and click **Edit** on its assignment row
+3. Set **Allocation** to `Community`
+4. Click **Save Assignment**
+
+Regenerate any **draft** invoices for affected periods to pick up the change.
+Invoices that have already been sent are protected and will not change — see
+[Invoice Management](09-invoice-management.md).
+
+### Switching mid-period is safe
+
+Allocation is resolved **per reading**, not per invoice. A meter that is
+`Personal` in January and `Community` from February bills correctly on both
+sides of the change: January's readings go to the holder in full, February's
+are split across the community. No readings are lost and none are billed
+twice.
+
+### What gets split
+
+For a `Community` meter, all of the following are divided by allocation weight:
+
+- Energy consumed (both the local/solar share and the grid share), including
+  any levies and percentage-based tariffs on it
+- Energy produced, if the meter is a production or bidirectional meter —
+  credits follow the same weights as charges
+- Per-metering-point fees (see [Tariff Configuration](07-tariff-configuration.md))
+
+Invoice lines for a community share are labelled **Gemeinschaftsanteil**
+(*Community share* / *Part communautaire* / *Quota comunitaria*), so they are
+easy to tell apart from a participant's own consumption.
+
+### Eligibility is date-accurate
+
+A participant only shares readings from days they were actually a member. A
+mid-period joiner pays nothing towards community energy measured before their
+join date, and a leaver's share stops on their leave date.
+
+> **Note:** An **inactive** community meter (`Is Active` = false) bills nobody
+> for per-metering-point fees, exactly like an inactive personal meter. Its
+> historical readings still count towards the community energy pool.
 
 ## Viewing Metering Point Details
 

--- a/docs/user-guide/07-tariff-configuration.md
+++ b/docs/user-guide/07-tariff-configuration.md
@@ -115,7 +115,10 @@ Flat monthly, quarterly, or annual charges (not energy-dependent).
 **Charge types:**
 - **Monthly fee** — CHF X per month, charged to *each* participant
 - **Yearly fee** — CHF X per year, charged to each participant (paid monthly as CHF X/12)
-- **Per-metering-point fee** — CHF Y per active meter per month
+- **Per-metering-point fee** — CHF Y per active meter per month. A
+  [community metering point](04-metering-points.md#shared-common-area-metering-points)
+  is charged once and split across the community by allocation weight, instead
+  of being charged to its holder.
 - **Shared monthly fee** — CHF X per month for the *whole community*, divided between the participants
 - **Shared yearly fee** — CHF X per year for the whole community, divided and paid monthly
 
@@ -138,12 +141,37 @@ attributable to a participant's consumption or meters.
 > the **whole community** pays. Entering CHF 20 intending "per person" will bill
 > the community CHF 20 in total, not CHF 20 each.
 
-**How the split works:**
+#### How a shared fee is split
 
 - The amount is divided between the participants **active in each billed month**.
 - The division is recalculated every month, so somebody joining in February does
   not change what January cost.
 - Each participant is charged only for the months they were actually a member.
+
+**Split key.** When you pick one of the two shared billing modes, a **Split
+key** selector appears with two options:
+
+| Split key | Divides the amount by |
+| --- | --- |
+| **Equally between participants** (default) | Headcount — everybody pays the same share |
+| **By allocation weight** | Each participant's [allocation weight](03-participant-management.md#allocation-weight) |
+
+`Equally` is the original behaviour and stays the default, so existing shared
+fees are untouched. Choose *By allocation weight* when the community has agreed
+that a joint cost should follow the same key as common-area energy — for
+example, billing the caretaker contract by floor area rather than per head.
+
+With every participant left at the default weight of `1`, both keys produce
+exactly the same amounts.
+
+> **Switching the key changes what people pay.** The selector only appears for
+> the two shared modes, and the change is recorded in the audit log along with
+> the rest of the tariff edit. Regenerate draft invoices to apply it.
+
+The split key applies **only** to the two shared fee modes. Per-metering-point
+fees on a [community metering point](04-metering-points.md#shared-common-area-metering-points)
+always divide by allocation weight — there is nothing to configure, because the
+cost belongs to a shared *meter* rather than to the community as a whole.
 
 For a worked example of how a shared fee splits as members join and leave, and
 how rounding works, see

--- a/docs/user-guide/08-billing-allocation-explained.md
+++ b/docs/user-guide/08-billing-allocation-explained.md
@@ -194,6 +194,70 @@ own, so the community may end up a centime or two short: CHF 100 across 3
 participants bills 33.33 each and collects CHF 99.99. See
 [Rounding and VAT](#rounding-and-vat) below.
 
+A shared fee can also be divided by **allocation weight** instead of per head —
+see [Split key](07-tariff-configuration.md#how-a-shared-fee-is-split). The
+month-by-month logic above is identical; only the denominator changes.
+
+## Common-Area (Community) Metering Points
+
+Everything above attributes each reading to **one** participant: whoever held
+the meter at that moment. A common-area meter — stairwell, lift, laundry,
+shared heat pump — measures energy nobody uses alone.
+
+Marking an assignment as
+[Community](04-metering-points.md#shared-common-area-metering-points) changes
+how those readings are billed:
+
+1. **Price once.** The meter's reading is split into local and grid energy
+   against the community pool, and priced with the ordinary tariffs — exactly
+   the same arithmetic as any other meter. Nothing special happens here.
+2. **Allocate second.** The resulting kWh and francs are then divided between
+   every eligible participant by their
+   [allocation weight](03-participant-management.md#allocation-weight).
+
+The holder of record gets no special treatment: they pay their weighted share
+like everybody else.
+
+**Example — a 12 kWh common-area draw on one day, four participants:**
+
+| Participant | Weight | Share | Billed |
+| --- | --- | --- | --- |
+| Alice | 1 | 12.5 % | 1.5 kWh |
+| Bob | 1 | 12.5 % | 1.5 kWh |
+| Carol | 2 | 25.0 % | 3.0 kWh |
+| Dave | 4 | 50.0 % | 6.0 kWh |
+| **Total** | **8** | **100 %** | **12 kWh** |
+
+These kWh are added to each participant's own `total_local_kwh` /
+`total_grid_kwh` totals, and their invoice lines carry a
+**Gemeinschaftsanteil** (*Community share*) marker so the shared portion is
+visible next to their personal consumption.
+
+### Eligibility is checked per day
+
+Community energy uses the reading's **date**, not the month. A participant who
+joins on 16 February pays nothing towards common-area energy measured on
+15 February, and a leaver's share stops on their leave date.
+
+> **Fees work per month, energy per day.** A per-metering-point fee on a
+> community meter is a monthly charge, so anyone who was a member for *any*
+> part of the month shares it. Community *energy* is date-accurate. This is the
+> same distinction that already applies to personal fees versus personal
+> energy.
+
+### Production is shared symmetrically
+
+If the community meter is a production or bidirectional meter, its output is
+credited to eligible participants using the same weights and the same
+eligibility rule as consumption.
+
+### A meter can change mid-period
+
+Allocation is resolved per reading, so a meter that is `Personal` in January
+and `Community` from February bills correctly on both sides: the holder is
+charged in full for January, and February is split. Nothing is lost and
+nothing is billed twice.
+
 ## Rounding and VAT
 
 **Precision:**

--- a/docs/user-guide/15-glossary.md
+++ b/docs/user-guide/15-glossary.md
@@ -13,6 +13,15 @@ System administrator role with unrestricted access to all ZEVs, settings, and us
 **Allocation**
 Distribution of community energy production among participants proportional to their consumption at each timestamp. See [How Energy Allocation Works](08-billing-allocation-explained.md).
 
+**Allocation Mode**
+Setting on a metering point assignment deciding who pays for that meter: `Personal` (the assigned participant alone, the default) or `Community` (split across every participant by allocation weight). See [Metering Points](04-metering-points.md#shared-common-area-metering-points).
+
+**Allocation Weight**
+A plain relative number per participant deciding how much of a shared cost they carry — not a percentage and not a Wertquote. Defaults to `1`, which splits shared costs equally. See [Managing Participants](03-participant-management.md#allocation-weight).
+
+**Allgemeinstrom**
+German for common-area electricity: stairwell lighting, lift, laundry, shared heat pump. In OpenZEV, billed by marking the meter's assignment as `Community`. See [Metering Points](04-metering-points.md#shared-common-area-metering-points).
+
 ## B
 
 **Billing Interval**
@@ -25,6 +34,12 @@ A metering point that measures both consumption (IN) and production (OUT). Commo
 
 **Community**
 See **ZEV**.
+
+**Community Metering Point**
+A metering point whose assignment allocation mode is `Community`: its energy and per-metering-point fees are split across every eligible participant by allocation weight instead of being billed to its holder. The holder of record is unchanged. See [Metering Points](04-metering-points.md#shared-common-area-metering-points).
+
+**Community Share** (*Gemeinschaftsanteil*)
+The marker on an invoice line item showing that the amount is this participant's weighted share of a community metering point, rather than their own consumption.
 
 **Consumption**
 Energy drawn from the grid or ZEV production. Measured by consumption meters (type `IN`).
@@ -147,7 +162,10 @@ The fraction of local energy vs. total consumption. Example: 60 kWh local ÷ 100
 Invoice delivered to participant (email sent). Status: `Sent`. See [Invoice Management](09-invoice-management.md).
 
 **Shared Fee**
-A fixed fee where the configured amount is what the **whole community** pays, divided between the participants active in each billed month — rather than what each participant pays. Used for jointly carried costs such as a caretaker contract or insurance. See [Tariff Configuration](07-tariff-configuration.md#shared-fees).
+A fixed fee where the configured amount is what the **whole community** pays, divided between the participants active in each billed month — rather than what each participant pays. Used for jointly carried costs such as a caretaker contract or insurance.
+
+**Split Key**
+Setting on a shared fee tariff choosing how the amount is divided: equally between participants (the default) or by allocation weight. See [Tariff Configuration](07-tariff-configuration.md#how-a-shared-fee-is-split). See [Tariff Configuration](07-tariff-configuration.md#shared-fees).
 
 ## T
 
@@ -171,6 +189,11 @@ Value Added Tax. In Switzerland, 8.1% (standard rate). OpenZEV applies VAT if ZE
 
 **Validity Period**
 Date range during which a participant or a participant-meter assignment is active. Defined by **Valid From** and **Valid To** dates.
+
+## W
+
+**Wertquote**
+The legal value quota of a property share under Art. 712e ZGB. OpenZEV does **not** model it: the allocation weight is a plain relative number a community sets for itself. You may enter value quotas as weights, but that is a community decision, not a legal mapping the system enforces.
 
 ## Z
 


### PR DESCRIPTION
The shared-metering-points series (#459–#464) shipped three new user-facing controls — an **Allocation** selector on metering point assignments, an **Allocation weight** field on participants, and a **Split key** selector on shared fee tariffs — plus a new *Gemeinschaftsanteil* marker on invoice lines. The baseline specs were updated alongside the implementation, but the user guide was not: it still describes billing as if every reading belongs to exactly one participant.

Docs-only; no code changes.

## What's covered

| Page | Added |
| --- | --- |
| `04-metering-points.md` | New **Shared (Common-Area) Metering Points** section — what `Community` does, that the holder of record is unchanged and pays their own share with no special case, how to switch a meter, why switching mid-period is safe, what gets split, the invoice marker, date-accurate eligibility, and the inactive-meter rule |
| `03-participant-management.md` | New **Allocation Weight** section — it's a plain relative number, not a percentage (1/1/2 and 10/10/20 give identical shares), explicitly **not** a Wertquote, how to read the computed share on each card, bases a community might agree on, the single-weight limitation, and the retroactive-on-regeneration warning |
| `07-tariff-configuration.md` | The **Split key** selector, why *equally* stays the default, that both keys agree when every weight is 1, and that it does **not** apply to per-metering-point fees on a community meter |
| `08-billing-allocation-explained.md` | New **Common-Area (Community) Metering Points** section in the main allocation explainer — price-once-allocate-second, a worked 12 kWh / four-weights table, per-day energy vs. per-month fees, symmetric production credits, mid-period mode changes |
| `15-glossary.md` | Allocation Mode, Allocation Weight, Allgemeinstrom, Community Metering Point, Community Share, Split Key, and a **W** section for Wertquote |

## Points worth a reviewer's eye

- **"Not a Wertquote"** is stated in both the participant page and the glossary. The spec is explicit that the legal value quota (Art. 712e ZGB) is out of scope, and a reader could easily assume otherwise. The docs say you *may* enter value quotas as weights, but that this is a community decision rather than something the system models.
- **The retroactive-weight warning** — editing a weight doesn't touch sent invoices, but regenerating a draft for an earlier period recalculates it with the new weight. This is the spec's documented §9 risk; it deserved to be visible to the person doing the editing.
- **Fees are month-granular, energy is date-granular.** Called out explicitly, since a joiner diluting a whole month's meter fee while paying nothing towards that month's earlier energy looks like a bug if you don't know it's deliberate.

## Test plan
- [x] Every default and string checked against the code: weight `1`, mode `personal`, split key `equal`, marker `Gemeinschaftsanteil`
- [x] All internal doc anchors introduced here verified to resolve (script-checked across `docs/user-guide/`)
- [x] No screenshots added — the existing ones don't show the new controls; worth a follow-up refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)