### PR TITLE
fix(security): restrict render fetches and harden template preview

### DIFF
--- a/backend/invoices/pdf_render.py
+++ b/backend/invoices/pdf_render.py
@@ -10,11 +10,24 @@ the existing QR-Rechnung. WeasyPrint adds the required XMP identification,
 sRGB OutputIntent (with embedded ICC profile) and font subsets automatically.
 """
 from weasyprint import HTML
+from weasyprint.urls import URLFetcher
 
 # PDF/A-3b — see module docstring for the rationale behind this variant.
 PDF_VARIANT = "pdf/a-3b"
 
+# Every shipped PDF template is fully self-contained — inline CSS, inline SVG,
+# no external references — so document rendering never needs a protocol beyond
+# embedded data: URIs. Restricting the fetcher closes local-file reads
+# (explicit file: URLs and relative URLs resolved against base_url) and
+# outbound network calls (http/https/ftp) from admin-editable template content,
+# for stored documents and the stateless preview alike. A rejected resource
+# degrades like a missing one: WeasyPrint logs it and renders without it.
+ALLOWED_URL_PROTOCOLS = ("data",)
+
 
 def render_pdf(html_string: str, *, base_url: str = ".") -> bytes:
     """Render an HTML string to PDF/A bytes."""
-    return HTML(string=html_string, base_url=base_url).write_pdf(pdf_variant=PDF_VARIANT)
+    # A fresh fetcher per call: URLFetcher keeps transient per-request state,
+    # so one shared instance would race across concurrent renders.
+    fetcher = URLFetcher(allowed_protocols=ALLOWED_URL_PROTOCOLS)
+    return HTML(string=html_string, base_url=base_url, url_fetcher=fetcher).write_pdf(pdf_variant=PDF_VARIANT)

--- a/backend/invoices/test_template_admin.py
+++ b/backend/invoices/test_template_admin.py
@@ -14,10 +14,12 @@ drop them.
 
 from django.test import TestCase
 from rest_framework.test import APIClient
+from weasyprint.urls import URLFetcher
 
 from accounts.models import UserRole
 from audit.models import AuditActionCategory, AuditEvent, AuditEventStatus
 from invoices.contract_pdf import generate_contract_pdf
+from invoices.pdf_render import ALLOWED_URL_PROTOCOLS, render_pdf
 from invoices.test_helpers import make_participant, make_zev
 from testing.helpers import authenticate as auth, make_user
 
@@ -180,15 +182,19 @@ class PdfTemplatePreviewTests(TestCase):
                 self.assertEqual(resp.status_code, 200)
                 self.assertEqual(resp.data["html"], "<p>rendered</p>")
 
-    def test_unknown_template_type_falls_back_to_the_invoice_context(self):
+    def test_unknown_template_type_is_rejected(self):
+        """The preview reads template_type from the request body, so an unknown
+        value must 400 rather than silently render the invoice sample context
+        (the PATCH save path keeps the helper's fallback; its template_type
+        arrives from fixed URL routes)."""
         resp = self.client.post(
             "/api/v1/invoices/invoices/preview-pdf-template/",
             {"content": "{{ invoice.invoice_number }}", "template_type": "nonsense"},
             format="json",
         )
 
-        self.assertEqual(resp.status_code, 200)
-        self.assertTrue(resp.data["html"].strip())
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Unsupported template type", resp.data["error"])
 
     def test_broken_template_returns_400_not_500(self):
         resp = self.client.post(
@@ -372,3 +378,46 @@ class PdfTemplateOverrideIntegrityTests(TestCase):
 
         pdf = generate_contract_pdf(self._contract_participant())
         self.assertTrue(pdf.startswith(b"%PDF"))
+
+
+class PdfRenderFetchPolicyTests(TestCase):
+    """render_pdf's fetch policy: embedded data: URIs only.
+
+    Every shipped template is fully inline, so no legitimate render needs
+    another protocol; the allowlist is the boundary that keeps admin-editable
+    template content from reading local files or reaching the network.
+    """
+
+    def test_rejects_file_http_and_ftp_urls(self):
+        fetcher = URLFetcher(allowed_protocols=ALLOWED_URL_PROTOCOLS)
+        for url in (
+            "file:///etc/passwd",
+            "http://example.com/x.png",
+            "https://example.com/a.css",
+            "ftp://example.com/f",
+        ):
+            with self.subTest(url=url):
+                with self.assertRaises(ValueError):
+                    fetcher(url)
+
+    def test_allows_data_uris(self):
+        fetcher = URLFetcher(allowed_protocols=ALLOWED_URL_PROTOCOLS)
+
+        response = fetcher("data:text/plain,hello")
+
+        # urllib assigns no HTTP status to data: responses; the body is the proof.
+        self.assertEqual(response.read(), b"hello")
+
+    def test_render_pdf_degrades_past_external_references(self):
+        """A rejected resource degrades like a missing one instead of failing
+        the render, for stored documents and the stateless preview alike."""
+        html = (
+            "<html><body>"
+            '<img src="file:///etc/passwd">'
+            '<img src="http://example.invalid/x.png">'
+            "</body></html>"
+        )
+
+        pdf = render_pdf(html)
+
+        self.assertTrue(pdf.startswith(b"%PDF-"))

--- a/backend/invoices/views_templates.py
+++ b/backend/invoices/views_templates.py
@@ -43,6 +43,12 @@ SAMPLE_CONTEXTS = {
     "annual_statement": build_sample_annual_statement_context,
 }
 
+# Preview accepts exactly these template_type values. The PATCH save path
+# keeps the helper's invoice fallback (its template_type arrives from fixed
+# URL routes), but the preview reads template_type from the request body,
+# where an unknown value must not silently render the invoice sample context.
+PREVIEW_TEMPLATE_TYPES = frozenset(SAMPLE_CONTEXTS) | {"invoice"}
+
 
 def _read_default_template(template_name: str) -> str:
     """Read the on-disk (default) content for a template."""
@@ -56,10 +62,11 @@ INVALID_VAR_PATTERN = re.compile(r"__INVALID_TPL_VAR__:([A-Za-z0-9_.]+)")
 def _render_with_sample_context(template_type: str, content: str, *, strict: bool = False) -> str:
     """Render a template body against its sample context.
 
-    Used by the preview endpoint and, on save, by ``PdfTemplateView.patch`` so
-    a broken template or a context-key drift is rejected at edit time instead
-    of failing at document-render time. Unknown template types fall back to the
-    invoice sample context (mirrors the historical preview behaviour).
+    Used by the PATCH save path (``PdfTemplateView.patch``) so a broken
+    template or a context-key drift is rejected at edit time instead of
+    failing at document-render time. The preview endpoint validates
+    ``template_type`` against ``PREVIEW_TEMPLATE_TYPES`` before calling this
+    helper, so unknown types never reach here.
 
     In ``strict`` mode (save-time validation) the template renders through the
     ``strict-validation`` engine, whose ``string_if_invalid`` turns unknown
@@ -227,6 +234,8 @@ class PdfTemplatePreviewView(_AdminTemplateView):
 
         if not isinstance(content, str) or not content.strip():
             return Response({"error": "Template content is required."}, status=status.HTTP_400_BAD_REQUEST)
+        if not isinstance(template_type, str) or template_type not in PREVIEW_TEMPLATE_TYPES:
+            return Response({"error": "Unsupported template type."}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             rendered = _render_with_sample_context(template_type, content)

--- a/docs/specs/2026-03-admin-governance-and-settings.md
+++ b/docs/specs/2026-03-admin-governance-and-settings.md
@@ -211,7 +211,7 @@ All three PDF template endpoints are served by `PdfTemplateView` (`views_templat
 | `/api/v1/invoices/invoices/pdf-template/` | DELETE | `IsAdmin` | Deletes the DB override (reverts to on-disk default); audit-logged (`template.invoice_pdf.reset`). Returns `{ template_name, content, is_customized: false, detail }` with the default content |
 | `/api/v1/invoices/invoices/contract-pdf-template/` | GET/PATCH/DELETE | same | Same behaviour for `contracts/participant_contract_pdf.html` (audit prefix `template.contract_pdf`) |
 | `/api/v1/invoices/invoices/annual-statement-pdf-template/` | GET/PATCH/DELETE | same | Same behaviour for `invoices/annual_statement_pdf.html` (audit prefix `template.annual_statement_pdf`) |
-| `/api/v1/invoices/invoices/preview-pdf-template/` | POST | `IsAdmin` | Renders submitted `content` with sample data (`template_type`: `invoice` (default) / `contract` / `annual_statement`) and returns `{ html }`. Render errors or missing content → `400` |
+| `/api/v1/invoices/invoices/preview-pdf-template/` | POST | `IsAdmin` | Renders submitted `content` with sample data (`template_type`: `invoice` (default) / `contract` / `annual_statement`) and returns `{ html }`. Unknown `template_type`, render errors, or missing content → `400` |
 
 **Implementation:** The default content is read from the Django template loader via `_read_default_template(template_name)`. PDF rendering prefers the DB override (`invoices.pdf._render_template`); see §8.
 

--- a/docs/specs/2026-03-invoice-lifecycle-and-communication.md
+++ b/docs/specs/2026-03-invoice-lifecycle-and-communication.md
@@ -322,7 +322,7 @@ The invoice, contract, and annual-statement PDF templates are editable via the a
 |---|---|---|---|
 | `POST` | `/invoices/invoices/preview-pdf-template/` | `admin` only | Render submitted template content with sample data and return the rendered HTML |
 
-Request body: `{ "content": "<html>...", "template_type": "invoice" | "contract" | "annual_statement" }` (defaults to `invoice`). The sample context comes from `build_sample_invoice_context()`, `build_sample_contract_context()`, or `build_sample_annual_statement_context()` in `invoices/template_context.py`. Response: `{ "html": "<rendered html>" }`. Template rendering errors return `400` with `{ "error": "Template rendering error: ..." }`; missing/blank content returns `400`.
+Request body: `{ "content": "<html>...", "template_type": "invoice" | "contract" | "annual_statement" }` (defaults to `invoice`). The sample context comes from `build_sample_invoice_context()`, `build_sample_contract_context()`, or `build_sample_annual_statement_context()` in `invoices/template_context.py`. Response: `{ "html": "<rendered html>" }`. Template rendering errors return `400` with `{ "error": "Template rendering error: ..." }`; missing/blank content returns `400`; unknown `template_type` values return `400`.
 
 **Response shape (GET and PATCH):**
 
@@ -442,7 +442,7 @@ Admin-only endpoints manage the global `EmailTemplate` overrides (§3.5) for the
 2. Look up `PdfTemplate` by `template_name` in the database.
    - If a DB record exists: render using `django.template.Template(content).render(Context(context))`.
    - Otherwise: render from the on-disk default using `render_to_string(template_name, context)`.
-3. Convert HTML → PDF via WeasyPrint through `render_pdf()` in `invoices/pdf_render.py`, which emits **PDF/A-3b** (`PDF_VARIANT = "pdf/a-3b"`) — a long-term archival format suitable for Swiss GeBüV retention, with WeasyPrint adding the XMP identification, sRGB OutputIntent, and font subsets. The same helper renders contract, annual statement, and financial summary PDFs.
+3. Convert HTML → PDF via WeasyPrint through `render_pdf()` in `invoices/pdf_render.py`, which emits **PDF/A-3b** (`PDF_VARIANT = "pdf/a-3b"`) — a long-term archival format suitable for Swiss GeBüV retention, with WeasyPrint adding the XMP identification, sRGB OutputIntent, and font subsets. The same helper renders contract, annual statement, and financial summary PDFs. Because template content is admin-editable, the WeasyPrint fetcher is restricted to `data:` URIs (`ALLOWED_URL_PROTOCOLS` in `pdf_render.py`) — templates embed images as data URIs and cannot make the renderer read local files or request remote URLs.
 4. Save PDF to `invoice.pdf_file` (`invoices/pdf/invoice_{number}.pdf`).
 
 ### 8.2 Template context


### PR DESCRIPTION
## Summary

Hardens the WeasyPrint rendering pipeline behind the PDF templates and the stateless template preview. First PR of the UI print-parity stack (`feat/ui-print-parity` builds on this one).

**Threat model.** PDF templates are admin-editable HTML handed to WeasyPrint. Previously `render_pdf()` used the default fetcher, so any URL referenced by template content was fetched at render time: `file:` URLs and relative URLs resolved against `base_url` (local file reads, embedded into the rendered document), and outbound `http`/`https`/`ftp` (SSRF from the backend host). Exploitation requires admin template-edit rights, so this is privilege confinement / defence in depth — but a compromised or malicious admin account should not turn the renderer into a file-read or request primitive.

**Fix.**
- `render_pdf()` now passes a `URLFetcher` restricted to `data:` URIs on every render path — issued invoices, contracts, annual statements, financial summaries and the stateless preview alike. Safe by construction: every shipped template is fully self-contained (inline CSS, inline SVG, QR slip as inline SVG), so no legitimate document needs another protocol. A rejected resource degrades exactly like a missing one: WeasyPrint logs it and renders without it. A fresh fetcher is created per call, since `URLFetcher` keeps transient per-request state.
- `POST /invoices/invoices/preview-pdf-template/` now validates `template_type` against `invoice | contract | annual_statement` and returns `400` on unknown values; previously an unknown value silently fell through to the invoice sample context. The PATCH save path is unchanged — its `template_type` arrives from fixed URL routes.

No behaviour change for legitimate templates; the only API delta is the new `400` on unknown preview `template_type`.

## Linked spec
- Spec: `docs/specs/2026-03-invoice-lifecycle-and-communication.md` (§8 render pipeline + preview endpoint contract), `docs/specs/2026-03-admin-governance-and-settings.md`
- ADR: N/A — hardening inside the existing architecture, no design decision to record

## Validation
- Backend tests run: `python -m pytest -q` — full suite green, including four new/updated tests: `test_rejects_file_http_and_ftp_urls` and `test_allows_data_uris` (protocol boundary), `test_render_pdf_degrades_past_external_references` (a `file:///etc/passwd` img renders through without embedding), `test_unknown_template_type_is_rejected` (preview 400s on unknown types)
- Lint: `ruff check .` green
- N/A: frontend build/tests, screenshots — backend-only change
- Manual checks: invoice/contract/annual-statement renders unchanged, QR-Rechnung slip intact (inline SVG, unaffected by the fetcher); preview endpoint verified for all three template types; stored `PdfTemplate` overrides render as before

## Checklist
- [x] Spec updated/linked for larger or risky changes
- N/A: ADR — no architecture decision changed
- [x] Backend and frontend updated together where API contracts changed — backend-only; the `400` on unknown `template_type` is additive and no frontend caller sends unknown types
