### PR TITLE
refactor(css): remove unused .button-icon selector

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1079,7 +1079,6 @@ h3 {
   font-size: 0.82rem;
 }
 
-.button-icon,
 .menu-item-icon {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Removes the `.button-icon` CSS selector from `index.css` — no element uses this class anywhere in the codebase.

## Linked spec
- No spec needed because: isolated CSS dead-code removal, no API or workflow impact

## Validation
- Frontend build run: `npm run build` — clean