### PR TITLE
fix(engine): shared metering gap logging and CHF 0.00 line gates

### DIFF
--- a/backend/invoices/engine.py
+++ b/backend/invoices/engine.py
@@ -402,13 +402,18 @@ def _count_community_metering_points_by_month(zev: Zev, tariff: Tariff, period_s
     """Active, ``COMMUNITY``-mode metering points billable each month.
 
     Mirrors ``_count_billable_metering_points_by_month`` but is ZEV-wide
-    rather than participant-scoped, and counts only ``COMMUNITY`` windows —
-    the two counts are deliberately disjoint per month, so together they
-    account for every active metering point exactly once. Feeds the
-    per-metering-point community contribution (§7.5): each active community
-    meter's fee is charged once per month, then divided between eligible
-    participants by weight. Keyed by the first day of the month; a month with
-    no active community meter is absent, not zero.
+    rather than participant-scoped, and counts only ``COMMUNITY`` windows.
+
+    Known limitation: a meter whose allocation mode switches mid-month is
+    counted by both this function and the personal count for that month
+    (each counts any window touching the month), so its per-metering-point
+    fee bills twice; the counts are disjoint only when mode switches fall
+    on month boundaries.
+
+    Feeds the per-metering-point community contribution (§7.5): each active
+    community meter's fee is charged once per month, then divided between
+    eligible participants by weight. Keyed by the first day of the month; a
+    month with no active community meter is absent, not zero.
     """
     overlap_start = max(period_start, tariff.valid_from)
     overlap_end = min(period_end, tariff.valid_to or period_end)
@@ -863,7 +868,7 @@ def _price_fixed_fees(participant, tariffs, period_start, period_end, accumulato
                         continue
                     shared_total += unit_price * Decimal(count) * participant.allocation_weight / denominator
                     shared_months += 1
-                if shared_months > 0:
+                if shared_months > 0 and not _is_zero_chf(shared_total):
                     accumulator.add(
                         tariff=tariff, quantity=Decimal(shared_months), total=shared_total,
                         unit="month", bucket="shared",
@@ -902,11 +907,16 @@ def _price_fixed_fees(participant, tariffs, period_start, period_end, accumulato
                     continue
                 total += unit_price * numerator / denominator
                 charged_months += 1
-            if charged_months == 0:
+            # Same exclusion as the bucket="shared" per-metering-point gate
+            # above: skip months without membership, and shares that round to
+            # CHF 0.00 — a zero-weight member of a WEIGHT-split fee would
+            # otherwise get a "N Monate / CHF 0.00" line.
+            if charged_months == 0 or _is_zero_chf(total):
                 continue
-            # Quantity is the months this participant is charged for, so the
-            # line reads "2 months" and the derived unit price comes out as
-            # their average monthly share — the figure they want to see.
+            # Quantity is the months this participant is charged for, so
+            # the line reads "2 months" and the derived unit price comes
+            # out as their average monthly share — the figure they want
+            # to see.
             quantity = Decimal(charged_months)
         else:
             total = quantity * unit_price
@@ -955,6 +965,23 @@ def _build_item_payloads(accumulator) -> tuple[list, Decimal]:
     return payloads, subtotal.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
+def _utc_date(ts: datetime) -> date:
+    """UTC civil date of a reading timestamp.
+
+    Assignment matching, tariff lookup, and completeness all key on this
+    (ADR 0007). Importers write UTC-aware timestamps; a naive datetime is
+    taken as UTC (bare ``astimezone`` would assume the host timezone).
+    """
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=tz.utc)
+    return ts.astimezone(tz.utc).date()
+
+
+def _is_zero_chf(total: Decimal) -> bool:
+    """Whether ``total`` renders as CHF 0.00 under §5 rounding."""
+    return total.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP) == 0
+
+
 @transaction.atomic
 def generate_invoice(participant: Participant, period_start: date, period_end: date) -> Invoice:
     """
@@ -982,6 +1009,11 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
     skipped_consumption_readings = 0
     skipped_consumption_kwh = Decimal("0")
 
+    # Reading ids already counted as personal gaps: a mixed-mode meter is in
+    # both the personal and the community queryset, and its gap readings must
+    # be counted exactly once, so the community loops skip them.
+    personal_gap_reading_ids: set = set()
+
     items_accumulator = ItemAccumulator()
 
     for reading in readings.participant_consumption.order_by("timestamp").iterator():
@@ -990,6 +1022,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
         if resolution is None:
             # A true gap: no assignment covers this timestamp. Belongs to
             # nobody in this billing run.
+            personal_gap_reading_ids.add(reading.id)
             skipped_consumption_readings += 1
             skipped_consumption_kwh += reading.energy_kwh
             continue
@@ -1009,18 +1042,20 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
         local_kwh_acc += r_local
         grid_kwh_acc += r_grid
 
+        day = _utc_date(ts)
+
         # Compute GRID energy base sum once per timestamp.
         # Percentage-of-energy tariffs price any energy type as a fraction of
         # what a participant would normally pay for grid energy.
         grid_base_price_sum = sum(
             (_get_tariff_price(t, ts) or Decimal("0"))
-            for t in tariffs.energy(EnergyType.GRID, ts.date())
+            for t in tariffs.energy(EnergyType.GRID, day)
         )
 
         for energy_type, quantity in ((EnergyType.LOCAL, r_local), (EnergyType.GRID, r_grid)):
             if quantity <= 0:
                 continue
-            for tariff in tariffs.energy(energy_type, ts.date()):
+            for tariff in tariffs.energy(energy_type, day):
                 price = _get_tariff_price(tariff, ts) or Decimal("0")
                 items_accumulator.add(
                     tariff=tariff,
@@ -1031,7 +1066,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
             # Percentage-of-energy tariffs: base is always the GRID rate sum,
             # applied to whichever energy_type the tariff is configured for.
-            for tariff in tariffs.percentage(energy_type, ts.date()):
+            for tariff in tariffs.percentage(energy_type, day):
                 effective_price = grid_base_price_sum * (tariff.percentage / Decimal("100"))
                 items_accumulator.add(
                     tariff=tariff,
@@ -1050,6 +1085,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
         ts = reading.timestamp
         resolution = readings.assignment_windows.assignment_at(reading.metering_point_id, ts)
         if resolution is None:
+            personal_gap_reading_ids.add(reading.id)
             skipped_production_readings += 1
             skipped_production_kwh += reading.energy_kwh
             continue
@@ -1066,13 +1102,15 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
         exported_kwh_acc += exported_kwh
 
+        day = _utc_date(ts)
+
         grid_base_price_sum = sum(
             (_get_tariff_price(t, ts) or Decimal("0"))
-            for t in tariffs.energy(EnergyType.GRID, ts.date())
+            for t in tariffs.energy(EnergyType.GRID, day)
         )
 
         if local_sold_kwh > 0:
-            for tariff in tariffs.energy(EnergyType.LOCAL, ts.date()):
+            for tariff in tariffs.energy(EnergyType.LOCAL, day):
                 price = _get_tariff_price(tariff, ts) or Decimal("0")
                 items_accumulator.add(
                     tariff=tariff,
@@ -1082,7 +1120,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
                     bucket="producer_credit",
                 )
 
-            for tariff in tariffs.percentage(EnergyType.LOCAL, ts.date()):
+            for tariff in tariffs.percentage(EnergyType.LOCAL, day):
                 effective_price = grid_base_price_sum * (tariff.percentage / Decimal("100"))
                 items_accumulator.add(
                     tariff=tariff,
@@ -1094,7 +1132,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
                 )
 
         if exported_kwh > 0:
-            for tariff in tariffs.energy(EnergyType.FEED_IN, ts.date()):
+            for tariff in tariffs.energy(EnergyType.FEED_IN, day):
                 price = _get_tariff_price(tariff, ts) or Decimal("0")
                 items_accumulator.add(
                     tariff=tariff,
@@ -1111,12 +1149,22 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
     # weight share. Fed into the same open accumulators as the personal
     # loops, so total_local_kwh/total_grid_kwh/total_feed_in_kwh include
     # shared energy.
+    skipped_community_consumption_readings = 0
+    skipped_community_consumption_kwh = Decimal("0")
     for reading in readings.community_consumption.order_by("timestamp").iterator():
         ts = reading.timestamp
         resolution = readings.assignment_windows.assignment_at(reading.metering_point_id, ts)
-        if resolution is None or resolution.allocation_mode != AllocationMode.COMMUNITY:
-            continue  # gap, or this window is personal — billed elsewhere
-        day = ts.date()
+        if resolution is None:
+            # A true gap: no assignment covers this timestamp — belongs to
+            # nobody. Counted here only if the personal loops did not already
+            # count it (a mixed-mode meter appears in both querysets).
+            if reading.id not in personal_gap_reading_ids:
+                skipped_community_consumption_readings += 1
+                skipped_community_consumption_kwh += reading.energy_kwh
+            continue
+        if resolution.allocation_mode != AllocationMode.COMMUNITY:
+            continue  # personal window — billed in the personal loop above
+        day = _utc_date(ts)
         if not _overlaps(participant.valid_from, participant.valid_to, day, day):
             continue  # a mid-period joiner/leaver pays no share outside their own membership
         weight_sum = readings.weight_sum_by_date.get(day)
@@ -1137,13 +1185,13 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
         grid_base_price_sum = sum(
             (_get_tariff_price(t, ts) or Decimal("0"))
-            for t in tariffs.energy(EnergyType.GRID, ts.date())
+            for t in tariffs.energy(EnergyType.GRID, day)
         )
 
         for energy_type, quantity in ((EnergyType.LOCAL, shared_local), (EnergyType.GRID, shared_grid)):
             if quantity <= 0:
                 continue
-            for tariff in tariffs.energy(energy_type, ts.date()):
+            for tariff in tariffs.energy(energy_type, day):
                 price = _get_tariff_price(tariff, ts) or Decimal("0")
                 items_accumulator.add(
                     tariff=tariff,
@@ -1152,7 +1200,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
                     unit="kWh",
                     bucket="shared",
                 )
-            for tariff in tariffs.percentage(energy_type, ts.date()):
+            for tariff in tariffs.percentage(energy_type, day):
                 effective_price = grid_base_price_sum * (tariff.percentage / Decimal("100"))
                 items_accumulator.add(
                     tariff=tariff,
@@ -1163,12 +1211,19 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
                     bucket="shared",
                 )
 
+    skipped_community_production_readings = 0
+    skipped_community_production_kwh = Decimal("0")
     for reading in readings.community_production.order_by("timestamp").iterator():
         ts = reading.timestamp
         resolution = readings.assignment_windows.assignment_at(reading.metering_point_id, ts)
-        if resolution is None or resolution.allocation_mode != AllocationMode.COMMUNITY:
+        if resolution is None:
+            if reading.id not in personal_gap_reading_ids:
+                skipped_community_production_readings += 1
+                skipped_community_production_kwh += reading.energy_kwh
             continue
-        day = ts.date()
+        if resolution.allocation_mode != AllocationMode.COMMUNITY:
+            continue
+        day = _utc_date(ts)
         if not _overlaps(participant.valid_from, participant.valid_to, day, day):
             continue
         weight_sum = readings.weight_sum_by_date.get(day)
@@ -1188,11 +1243,11 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
         grid_base_price_sum = sum(
             (_get_tariff_price(t, ts) or Decimal("0"))
-            for t in tariffs.energy(EnergyType.GRID, ts.date())
+            for t in tariffs.energy(EnergyType.GRID, day)
         )
 
         if shared_local_sold > 0:
-            for tariff in tariffs.energy(EnergyType.LOCAL, ts.date()):
+            for tariff in tariffs.energy(EnergyType.LOCAL, day):
                 price = _get_tariff_price(tariff, ts) or Decimal("0")
                 items_accumulator.add(
                     tariff=tariff,
@@ -1201,7 +1256,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
                     unit="kWh",
                     bucket="shared_producer_credit",
                 )
-            for tariff in tariffs.percentage(EnergyType.LOCAL, ts.date()):
+            for tariff in tariffs.percentage(EnergyType.LOCAL, day):
                 effective_price = grid_base_price_sum * (tariff.percentage / Decimal("100"))
                 items_accumulator.add(
                     tariff=tariff,
@@ -1213,7 +1268,7 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
                 )
 
         if shared_exported > 0:
-            for tariff in tariffs.energy(EnergyType.FEED_IN, ts.date()):
+            for tariff in tariffs.energy(EnergyType.FEED_IN, day):
                 price = _get_tariff_price(tariff, ts) or Decimal("0")
                 items_accumulator.add(
                     tariff=tariff,
@@ -1225,11 +1280,14 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
     _price_fixed_fees(participant, tariffs_list, period_start, period_end, items_accumulator)
 
-    if skipped_consumption_readings or skipped_production_readings:
+    if skipped_consumption_readings or skipped_production_readings or \
+       skipped_community_consumption_readings or skipped_community_production_readings:
         logger.warning(
-            "Invoice for participant %s (period %s..%s) excluded %d consumption "
-            "reading(s) / %s kWh and %d production reading(s) / %s kWh that fall "
-            "outside assignment windows (gaps or unassigned metering points)",
+            "Invoice for participant %s (period %s..%s) excluded %d personal consumption "
+            "reading(s) / %s kWh, %d personal production reading(s) / %s kWh, "
+            "%d community consumption reading(s) / %s kWh and "
+            "%d community production reading(s) / %s kWh "
+            "that fall in assignment gaps within the period",
             participant.id,
             period_start,
             period_end,
@@ -1237,6 +1295,10 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
             skipped_consumption_kwh,
             skipped_production_readings,
             skipped_production_kwh,
+            skipped_community_consumption_readings,
+            skipped_community_consumption_kwh,
+            skipped_community_production_readings,
+            skipped_community_production_kwh,
         )
 
     local_kwh = local_kwh_acc.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)

--- a/backend/invoices/engine.py
+++ b/backend/invoices/engine.py
@@ -348,29 +348,72 @@ def _count_billable_months(tariff: Tariff, period_start: date, period_end: date)
     return _count_intersecting_months(overlap_start, overlap_end)
 
 
+def _last_overlapping_window(windows: list[tuple], month_start: date, month_end: date):
+    """The window that owns one metering point's fee for a month.
+
+    ``windows`` is ``(valid_from, valid_to, allocation_mode, participant_id)``
+    for a single metering point; ``month_start``/``month_end`` are the part of
+    the calendar month actually billed (already clamped to the tariff/period
+    overlap).  Returns ``(valid_from, mode, participant_id)`` of the window
+    with the latest ``valid_from`` among those overlapping that range, or
+    ``None`` if none overlaps it.
+
+    The non-overlap rule (``MeteringPointAssignment._validate_no_overlap``)
+    allows at most one window per metering point at any date, so "last to
+    start" is unambiguous.  This is the tie-break that keeps the personal
+    and community per-metering-point counts disjoint when a mode switch — or
+    a holder change — falls inside a month: the last window to start owns
+    the whole month, billed on whichever side it names.  §4.6.1 already
+    commits to a tie-break of this shape — months are never prorated, so one
+    side always gets the full month.
+    """
+    best: tuple[date, object, object] | None = None
+    for valid_from, valid_to, mode, participant_id in windows:
+        if valid_from > month_end or (valid_to is not None and valid_to < month_start):
+            continue
+        if best is None or valid_from > best[0]:
+            best = (valid_from, mode, participant_id)
+    return best
+
 def _count_billable_metering_points_by_month(participant: Participant, tariff: Tariff, period_start: date, period_end: date) -> int:
     """How many of the participant's own metering points each billed month covers.
 
-    Excludes ``COMMUNITY``-mode assignments **for the month in question**, not
-    with a blanket join filter — the same per-window care as the mode-aware
-    gate in ``generate_invoice`` (§7.3/§7.5): a meter personal in one month and
-    community the next must count in the first month and be excluded from the
-    second. A community meter's fee is charged separately, split by weight,
-    in ``_price_fixed_fees``.
+    A metering point counts for a month only if it has an ``is_active``
+    assignment to the participant that owns the month with a ``PERSONAL``
+    window (``_last_overlapping_window``) — the same per-window care as the
+    mode-aware gate in ``generate_invoice`` (§7.3/§7.5): a meter personal in
+    one month and community the next counts in the first month and is
+    excluded from the second.  The ownership rule also keeps this count
+    disjoint from the community count (§4.6.4) when a mode switch falls
+    inside a month: the month belongs to exactly one side.  A community
+    meter's fee is charged separately, split by weight, in
+    ``_price_fixed_fees``.
     """
     overlap_start = max(period_start, tariff.valid_from)
     overlap_end = min(period_end, tariff.valid_to or period_end)
     if overlap_start > overlap_end:
         return 0
 
-    # Single fetch: month-by-month activity is computed in Python instead of
-    # issuing two queries per month.
-    assignments = list(
+    # Two fetches, however many months are billed: first the participant's
+    # own assignments (which metering points are "theirs" at all), then the
+    # FULL window history of those metering points.  Ownership needs every
+    # window: a later COMMUNITY window held by the same participant must
+    # supersede an earlier PERSONAL one, and a window held by somebody else
+    # must be visible too, or the two counters would bill the month twice.
+    own_mp_ids = set(
         MeteringPointAssignment.objects.filter(
             participant=participant,
             metering_point__is_active=True,
-        ).values_list("metering_point_id", "valid_from", "valid_to", "allocation_mode")
+        ).values_list("metering_point_id", flat=True)
     )
+    if not own_mp_ids:
+        return 0
+    windows_by_mp: dict = {}
+    for mp_id, vf, vt, mode, pid in MeteringPointAssignment.objects.filter(
+        metering_point_id__in=own_mp_ids,
+        metering_point__is_active=True,
+    ).values_list("metering_point_id", "valid_from", "valid_to", "allocation_mode", "participant_id"):
+        windows_by_mp.setdefault(mp_id, []).append((vf, vt, mode, pid))
 
     total_metering_points = 0
     cursor = _month_start(overlap_start)
@@ -382,16 +425,11 @@ def _count_billable_metering_points_by_month(participant: Participant, tariff: T
 
         month_start = max(month_first_day, overlap_start)
         month_end = min(month_last_day, overlap_end)
-        month_has_active = any(
-            vf <= month_last_day and (vt is None or vt >= month_first_day) and mode == AllocationMode.PERSONAL
-            for _mp_id, vf, vt, mode in assignments
-        )
-        if month_start <= month_end and month_has_active:
-            total_metering_points += len({
-                mp_id
-                for mp_id, vf, vt, mode in assignments
-                if vf <= month_end and (vt is None or vt >= month_start) and mode == AllocationMode.PERSONAL
-            })
+        if month_start <= month_end:
+            for mp_id in own_mp_ids:
+                owner = _last_overlapping_window(windows_by_mp.get(mp_id, []), month_start, month_end)
+                if owner is not None and owner[1] == AllocationMode.PERSONAL and owner[2] == participant.id:
+                    total_metering_points += 1
 
         cursor = next_month
 
@@ -399,18 +437,16 @@ def _count_billable_metering_points_by_month(participant: Participant, tariff: T
 
 
 def _count_community_metering_points_by_month(zev: Zev, tariff: Tariff, period_start: date, period_end: date) -> dict[date, int]:
-    """Active, ``COMMUNITY``-mode metering points billable each month.
+    """Active metering points whose owning window is ``COMMUNITY``, per month.
 
     Mirrors ``_count_billable_metering_points_by_month`` but is ZEV-wide
-    rather than participant-scoped, and counts only ``COMMUNITY`` windows.
+    rather than participant-scoped.  All modes are fetched on purpose —
+    dropping the ``COMMUNITY`` filter lets the ownership pick see a
+    superseding ``PERSONAL`` window: a meter whose mode switches mid-month
+    is billed by whichever side owns the month
+    (``_last_overlapping_window``), never by both.
 
-    Known limitation: a meter whose allocation mode switches mid-month is
-    counted by both this function and the personal count for that month
-    (each counts any window touching the month), so its per-metering-point
-    fee bills twice; the counts are disjoint only when mode switches fall
-    on month boundaries.
-
-    Feeds the per-metering-point community contribution (§7.5): each active
+    Feeds the per-metering-point community contribution (§7.5): each
     community meter's fee is charged once per month, then divided between
     eligible participants by weight. Keyed by the first day of the month; a
     month with no active community meter is absent, not zero.
@@ -420,13 +456,12 @@ def _count_community_metering_points_by_month(zev: Zev, tariff: Tariff, period_s
     if overlap_start > overlap_end:
         return {}
 
-    assignments = list(
-        MeteringPointAssignment.objects.filter(
-            metering_point__zev=zev,
-            metering_point__is_active=True,
-            allocation_mode=AllocationMode.COMMUNITY,
-        ).values_list("metering_point_id", "valid_from", "valid_to")
-    )
+    windows_by_mp: dict = {}
+    for mp_id, vf, vt, mode, pid in MeteringPointAssignment.objects.filter(
+        metering_point__zev=zev,
+        metering_point__is_active=True,
+    ).values_list("metering_point_id", "valid_from", "valid_to", "allocation_mode", "participant_id"):
+        windows_by_mp.setdefault(mp_id, []).append((vf, vt, mode, pid))
 
     counts: dict[date, int] = {}
     cursor = _month_start(overlap_start)
@@ -439,11 +474,12 @@ def _count_community_metering_points_by_month(zev: Zev, tariff: Tariff, period_s
         month_start = max(month_first_day, overlap_start)
         month_end = min(month_last_day, overlap_end)
         if month_start <= month_end:
-            count = len({
-                mp_id
-                for mp_id, vf, vt in assignments
-                if vf <= month_end and (vt is None or vt >= month_start)
-            })
+            count = sum(
+                1
+                for mp_id, windows in windows_by_mp.items()
+                if (owner := _last_overlapping_window(windows, month_start, month_end)) is not None
+                and owner[1] == AllocationMode.COMMUNITY
+            )
             if count:
                 counts[cursor] = count
 
@@ -798,10 +834,11 @@ def _price_fixed_fees(participant, tariffs, period_start, period_end, accumulato
     The ``SHARED_*`` modes divide one community-wide amount between the
     members active in each month, so their total is built month by month
     rather than as ``quantity * unit_price``. The per-metering-point modes
-    bill personal and community metering points separately (§7.5): the
-    personal count excludes ``COMMUNITY``-mode assignments, and each active
-    community meter contributes its own weight-split ``bucket="shared"``
-    line — ``split_key`` plays no part here, since a community meter's cost
+    bill personal and community metering points separately (§7.5): month
+    ownership (``_last_overlapping_window``) makes the two counts disjoint
+    even when a mode switch or holder change falls inside a month, and each
+    community-owned meter-month contributes a weight-split ``bucket="shared"``
+    share — ``split_key`` plays no part here, since a community meter's cost
     always allocates by weight.
 
     Both weight-split paths share one fetch of the ZEV's participant windows,
@@ -907,10 +944,13 @@ def _price_fixed_fees(participant, tariffs, period_start, period_end, accumulato
                     continue
                 total += unit_price * numerator / denominator
                 charged_months += 1
-            # Same exclusion as the bucket="shared" per-metering-point gate
-            # above: skip months without membership, and shares that round to
+            # Skip months without membership, and shares that round to
             # CHF 0.00 — a zero-weight member of a WEIGHT-split fee would
-            # otherwise get a "N Monate / CHF 0.00" line.
+            # otherwise get a "N Monate / CHF 0.00" line, and a shared fee
+            # configured at CHF 0.00 (either split key) would print a zero
+            # share of nothing (§4.6.3).  Plain, non-shared fees keep their
+            # CHF 0.00 line: there the point of the line is to show the fee
+            # exists, and they never reach this branch.
             if charged_months == 0 or _is_zero_chf(total):
                 continue
             # Quantity is the months this participant is charged for, so
@@ -1008,10 +1048,13 @@ def generate_invoice(participant: Participant, period_start: date, period_end: d
 
     skipped_consumption_readings = 0
     skipped_consumption_kwh = Decimal("0")
-
     # Reading ids already counted as personal gaps: a mixed-mode meter is in
     # both the personal and the community queryset, and its gap readings must
-    # be counted exactly once, so the community loops skip them.
+    # be counted exactly once, so the community loops skip them.  The set
+    # holds only gap readings — bounded by the assignment gaps in the period,
+    # not by the reading volume: even a year-long unassigned stretch at
+    # 15-minute resolution is ~35k UUIDs (~4 MB) — which is why the loops can
+    # stream everything else with ``.iterator()`` and still deduplicate here.
     personal_gap_reading_ids: set = set()
 
     items_accumulator = ItemAccumulator()

--- a/backend/invoices/test_engine_allocation.py
+++ b/backend/invoices/test_engine_allocation.py
@@ -21,6 +21,7 @@ pays for what — was therefore never executed with a share other than 1.
 These tests pin it before the pricing engine is refactored.
 """
 
+import logging
 from datetime import date, datetime, timezone
 from decimal import Decimal
 
@@ -29,7 +30,7 @@ import pytest
 from metering.models import MeterReading, ReadingDirection
 from tariffs.models import EnergyType
 from testing import factories
-from zev.models import MeteringPointType
+from zev.models import AllocationMode, MeteringPointType
 
 from .engine import generate_invoice
 
@@ -370,3 +371,66 @@ def test_a_producer_transferred_mid_period_keeps_its_export_credit():
     assert _local_credit(a_invoice) == Decimal("-0.30")
     assert b_invoice.total_feed_in_kwh == Decimal("0.0000")
     assert _local_credit(b_invoice) == Decimal("-0.50")
+
+
+def test_gap_readings_on_community_meters_land_in_their_own_counters(caplog):
+    """§4.3 'gap visibility' covers shared meters: a reading falling into a
+    hole between two COMMUNITY windows of a meter the billed member does not
+    hold increments the community counter (count + kWh), and the personal
+    counters stay untouched."""
+    community = Community()
+    community.producer((T1, "10"))  # keeps the ZEV pool honest
+    holder = factories.ParticipantFactory(zev=community.zev, valid_from=PERIOD_START)
+    other_holder = factories.ParticipantFactory(
+        zev=community.zev, valid_from=PERIOD_START)
+    shared_meter = factories.MeteringPointFactory(
+        zev=community.zev, meter_type=MeteringPointType.CONSUMPTION)
+    factories.MeteringPointAssignmentFactory(
+        metering_point=shared_meter, participant=holder,
+        valid_from=date(2026, 1, 1), valid_to=date(2026, 1, 10),
+        allocation_mode=AllocationMode.COMMUNITY)
+    factories.MeteringPointAssignmentFactory(
+        metering_point=shared_meter, participant=other_holder,
+        valid_from=date(2026, 1, 20), valid_to=None,
+        allocation_mode=AllocationMode.COMMUNITY)
+    MeterReading.objects.create(
+        metering_point=shared_meter,
+        timestamp=datetime(2026, 1, 15, 12, 0, tzinfo=timezone.utc),
+        energy_kwh=Decimal("2"), direction=ReadingDirection.IN)
+    billed = factories.ParticipantFactory(zev=community.zev, valid_from=PERIOD_START)
+
+    with caplog.at_level(logging.WARNING, logger="invoices.engine"):
+        generate_invoice(billed, PERIOD_START, PERIOD_END)
+
+    assert "0 personal consumption reading(s)" in caplog.text
+    assert "1 community consumption reading(s) / 2.0000 kWh" in caplog.text
+    assert "0 community production reading(s)" in caplog.text
+
+
+def test_a_gap_reading_on_a_mixed_mode_meter_is_counted_only_once(caplog):
+    """A meter held personally AND community-wide in the same period appears
+    in both reading querysets; its gap readings must be counted exactly once
+    (personal side wins), so the four counters partition the gaps (§4.3)."""
+    community = Community()
+    community.producer((T1, "10"))
+    member = factories.ParticipantFactory(zev=community.zev, valid_from=PERIOD_START)
+    shared_meter = factories.MeteringPointFactory(
+        zev=community.zev, meter_type=MeteringPointType.CONSUMPTION)
+    factories.MeteringPointAssignmentFactory(
+        metering_point=shared_meter, participant=member,
+        valid_from=date(2026, 1, 1), valid_to=date(2026, 1, 10),
+        allocation_mode=AllocationMode.PERSONAL)
+    factories.MeteringPointAssignmentFactory(
+        metering_point=shared_meter, participant=member,
+        valid_from=date(2026, 1, 20), valid_to=None,
+        allocation_mode=AllocationMode.COMMUNITY)
+    MeterReading.objects.create(
+        metering_point=shared_meter,
+        timestamp=datetime(2026, 1, 15, 12, 0, tzinfo=timezone.utc),
+        energy_kwh=Decimal("2"), direction=ReadingDirection.IN)
+
+    with caplog.at_level(logging.WARNING, logger="invoices.engine"):
+        generate_invoice(member, PERIOD_START, PERIOD_END)
+
+    assert "1 personal consumption reading(s) / 2.0000 kWh" in caplog.text
+    assert "0 community consumption reading(s)" in caplog.text

--- a/backend/invoices/test_shared_fee.py
+++ b/backend/invoices/test_shared_fee.py
@@ -585,3 +585,17 @@ def test_an_exact_half_cent_share_survives_the_zero_line_gate():
 
     line = fee_line(generate_invoice(billed, JAN, JAN_END))
     assert line.total_chf == Decimal("0.01")
+
+
+def test_a_shared_fee_configured_at_zero_chf_gets_no_line_either():
+    """The gate covers every shared path, not just weight-split ones: a
+    SHARED_* fee deliberately configured at CHF 0.00 under split_key = equal
+    has the same nothing-to-bill shape as a zero-weight member, so it is
+    suppressed too (§4.6.3). Plain non-shared fees keep their CHF 0.00 line
+    (test_zero_and_negative_fixed_fees_are_handled_consistently)."""
+    zev = factories.ZevFactory()
+    member = factories.ParticipantFactory(zev=zev, valid_from=JAN)
+    factories.ParticipantFactory(zev=zev, valid_from=JAN)
+    shared_tariff(zev, price="0.00", split_key=SplitKey.EQUAL)
+
+    assert fee_line(generate_invoice(member, JAN, JAN_END)) is None

--- a/backend/invoices/test_shared_fee.py
+++ b/backend/invoices/test_shared_fee.py
@@ -552,3 +552,36 @@ def test_weighted_shared_fee_denominator_still_tracks_the_billed_window():
                   split_key=SplitKey.WEIGHT)
 
     assert fee_line(generate_invoice(stayer, JAN, JAN_END)).total_chf == Decimal("50.00")
+
+
+# ---------------------------------------------------------------------------
+# Zero-value shares (regression: bogus "N Monate / CHF 0.00" lines)
+# ---------------------------------------------------------------------------
+
+def test_a_zero_weight_member_gets_no_shared_fee_line():
+    """A zero-weight member of a WEIGHT-split fee is an active month member
+    (charged_months > 0), but their share computes to 0.00 — they get no line,
+    matching the bucket="shared" per-metering-point rule (§4.6.4)."""
+    zev = factories.ZevFactory()
+    full = factories.ParticipantFactory(zev=zev, valid_from=JAN)
+    zero = factories.ParticipantFactory(
+        zev=zev, valid_from=JAN, allocation_weight=Decimal("0"))
+    shared_tariff(zev, price="80.00", split_key=SplitKey.WEIGHT)
+
+    assert fee_line(generate_invoice(zero, JAN, JAN_END)) is None
+    # The paying member is unaffected: weight sum excludes the zero-weight
+    # member, so the full fee still lands on them.
+    assert fee_line(generate_invoice(full, JAN, JAN_END)).total_chf == Decimal("80.00")
+
+
+def test_an_exact_half_cent_share_survives_the_zero_line_gate():
+    """The exclusion gate must quantize with the renderer's ROUND_HALF_UP, not
+    Python quantize()'s default banker's rounding: a share of exactly 0.005
+    bills as 0.01 and stays on the invoice instead of silently vanishing."""
+    zev = factories.ZevFactory()
+    billed = factories.ParticipantFactory(zev=zev, valid_from=JAN)
+    factories.ParticipantFactory(zev=zev, valid_from=JAN)  # weight-sum denominator
+    shared_tariff(zev, price="0.01", split_key=SplitKey.WEIGHT)
+
+    line = fee_line(generate_invoice(billed, JAN, JAN_END))
+    assert line.total_chf == Decimal("0.01")

--- a/backend/invoices/test_shared_metering.py
+++ b/backend/invoices/test_shared_metering.py
@@ -384,6 +384,90 @@ class PerMeteringPointCommunityFeeTests(_SharedMeteringBase, TestCase):
         shared_fee = next(i for i in self._fee_items(alice_invoice) if i.total_chf != Decimal("0.00"))
         self.assertEqual(shared_fee.total_chf, Decimal("5.00"))
 
+    def test_mid_month_mode_switch_bills_the_month_once_on_the_last_side(self):
+        """The §4.6.4 tie-break: PERSONAL Jan 1-15, COMMUNITY Jan 16-31 on one
+        meter must bill January exactly once. The last window to start owns the
+        month, so it lands on the community side — split by weight — instead
+        of being billed twice (a personal line on top of the shared one)."""
+        alice = self._participant("Alice Muster", weight="1")
+        bob = self._participant("Bob Beispiel", weight="1")
+        mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-PMP-5")
+        self._assign(mp, alice, JAN, date(2026, 1, 15), mode=AllocationMode.PERSONAL)
+        self._assign(mp, alice, date(2026, 1, 16), mode=AllocationMode.COMMUNITY)
+        self._mp_fee_tariff(price="10.00")
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        alice_fees = self._fee_items(alice_invoice)
+        # No personal line: the month is owned by the community window.
+        self.assertEqual([i for i in alice_fees if i.total_chf == Decimal("10.00")], [])
+        alice_shared = next(i for i in alice_fees if i.total_chf == Decimal("5.00"))
+        bob_shared = self._fee_items(bob_invoice)[0]
+        self.assertEqual(alice_shared.total_chf, Decimal("5.00"))
+        self.assertEqual(bob_shared.total_chf, Decimal("5.00"))
+        # Recovered exactly once — the overcharge this used to be.
+        self.assertEqual(alice_shared.total_chf + bob_shared.total_chf, Decimal("10.00"))
+
+    def test_mid_month_mode_switch_back_bills_the_month_once_personally(self):
+        """The symmetric direction: COMMUNITY Jan 1-15, PERSONAL Jan 16-31.
+        The personal window starts last, so the holder pays the whole month
+        alone and nobody gets a shared line."""
+        alice = self._participant("Alice Muster", weight="1")
+        bob = self._participant("Bob Beispiel", weight="1")
+        mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-PMP-6")
+        self._assign(mp, alice, JAN, date(2026, 1, 15), mode=AllocationMode.COMMUNITY)
+        self._assign(mp, alice, date(2026, 1, 16), mode=AllocationMode.PERSONAL)
+        self._mp_fee_tariff(price="10.00")
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        alice_fees = self._fee_items(alice_invoice)
+        self.assertEqual(len(alice_fees), 1)
+        self.assertEqual(alice_fees[0].total_chf, Decimal("10.00"))
+        self.assertEqual(self._fee_items(bob_invoice), [])
+
+    def test_month_boundary_mode_switch_still_bills_both_months(self):
+        """Ownership is per month, so a switch on a month boundary keeps the
+        pre-existing behaviour: each month bills on its own side."""
+        alice = self._participant("Alice Muster", weight="1")
+        bob = self._participant("Bob Beispiel", weight="1")
+        mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-PMP-7")
+        self._assign(mp, alice, JAN, JAN_END, mode=AllocationMode.PERSONAL)
+        self._assign(mp, alice, date(2026, 2, 1), mode=AllocationMode.COMMUNITY)
+        self._mp_fee_tariff(price="10.00")
+
+        alice_invoice = generate_invoice(alice, JAN, date(2026, 2, 28))
+        bob_invoice = generate_invoice(bob, JAN, date(2026, 2, 28))
+
+        alice_fees = self._fee_items(alice_invoice)
+        personal_line = next(i for i in alice_fees if i.total_chf == Decimal("10.00"))
+        shared_line = next(i for i in alice_fees if i.total_chf == Decimal("5.00"))
+        self.assertEqual(len(alice_fees), 2)
+        self.assertEqual(personal_line.quantity_kwh, Decimal("1.0000"))  # Jan only
+        self.assertEqual(shared_line.quantity_kwh, Decimal("1.0000"))   # Feb only
+        self.assertEqual(self._fee_items(bob_invoice)[0].total_chf, Decimal("5.00"))
+
+    def test_holder_change_mid_month_bills_the_month_once(self):
+        """The ownership rule is about windows, not modes: a meter handed over
+        mid-month bills the whole month to the later holder only — the same
+        last-window tie-break that fixes the mode-switch overcharge."""
+        alice = self._participant("Alice Muster", valid_from=JAN, valid_to=date(2026, 1, 15), weight="1")
+        bob = self._participant("Bob Beispiel", valid_from=JAN, weight="1")
+        mp = self._mp(MeteringPointType.CONSUMPTION, "CH-SM-PMP-8")
+        self._assign(mp, alice, JAN, date(2026, 1, 15), mode=AllocationMode.PERSONAL)
+        self._assign(mp, bob, date(2026, 1, 16), mode=AllocationMode.PERSONAL)
+        self._mp_fee_tariff(price="10.00")
+
+        alice_invoice = generate_invoice(alice, JAN, JAN_END)
+        bob_invoice = generate_invoice(bob, JAN, JAN_END)
+
+        self.assertEqual(self._fee_items(alice_invoice), [])
+        bob_fees = self._fee_items(bob_invoice)
+        self.assertEqual(len(bob_fees), 1)
+        self.assertEqual(bob_fees[0].total_chf, Decimal("10.00"))
+
 
 class InvoiceTotalsAndDescriptionTests(_SharedMeteringBase, TestCase):
     def test_invoice_kwh_totals_include_shared_energy(self):

--- a/docs/specs/2026-03-tariffs-and-billing-engine.md
+++ b/docs/specs/2026-03-tariffs-and-billing-engine.md
@@ -303,11 +303,11 @@ Before shared metering points (`SPEC-2026-08-shared-metering-points`), this gate
 
 **Pool coverage:** the pool is physical — `zev_consumption_at_ts`/`zev_production_at_ts` sum over **every** metering point of the ZEV, with or without an assignment in the period and regardless of the `is_active` flag. A never-assigned meter feeds the pool but is billed to nobody; a deactivated meter (`is_active = False`) still feeds the pool, and its readings are still attributed to its assignment holder — deactivation does not remove a meter from allocation. This matches across the engine, dashboards, PDFs, and annual statement (ADR 0013 pool decision). `is_active` gates only per-metering-point fixed-fee counting (§4.6.2) and list/admin filtering, never the energy pool. A metering point with no assignment overlapping the period still counts in the pool but is billed to nobody; that is a data-quality condition rather than a valid steady state — every metering point should have a holder for each period it has readings (a common-area *Allgemein* meter is assigned to a community / Verwaltung participant), and such holder-less readings are surfaced by the metering data-quality status check.
 
-**Assignment matching** uses the *UTC civil date* of the reading's timestamp (`ts.date()`), consistent with period, tariff, and completeness conventions (ADR 0007 — all timestamps are stored and queried in UTC). A reading at 22:30 UTC on the day an assignment ends still belongs to that day's holder even though Zurich is already on the next civil day.
+**Assignment matching** uses the *UTC civil date* of the reading's timestamp (`_utc_date(ts)` — `ts.astimezone(tz.utc).date()`), consistent with period, tariff, and completeness conventions (ADR 0007 — all timestamps are stored and queried in UTC). A reading at 22:30 UTC on the day an assignment ends still belongs to that day's holder even though Zurich is already on the next civil day.
 
 **Fail-fast contracts** (implemented in `allocation/split.py`): all inputs must be `Decimal` (`TypeError` otherwise) and non-negative (`InvalidAllocationInputError`); a participant's draw above the community's total consumption, a producer's output above the community's total production, or a participant's share above the total in `proportional_share`, raises `InvalidAllocationInputError` — with consistent data these are impossible (the total includes the participant's own reading), so they indicate duplicate readings or the wrong metering-point scope. No arithmetic is clamped silently. All allocation failures (`InvalidAllocationInputError`, and `OverlappingAssignmentWindowsError` from the assignment-window index) derive from `AllocationError` (a `ValueError`), so the billing API reports them as HTTP `400` with the underlying message instead of the `409` reserved for an existing invoice (ADR 0013).
 
-**Gap visibility:** the engine counts skipped readings and their kWh (consumption and production separately) and logs a warning when any exist, so unattributed energy does not vanish unnoticed.
+**Gap visibility:** the engine counts skipped readings and their kWh — personal consumption, personal production, community consumption, and community production separately — and logs a warning when any exist, so unattributed energy does not vanish unnoticed. Covered are readings in *intra-period* gaps of metering points assigned somewhere in the period: both reading querysets require an assignment overlapping the period, so a never-assigned meter is not covered here (it surfaces via the metering data-quality status check instead). The four counters partition the gap readings: a meter held both personally and community-wide appears in both querysets, and its gap readings are counted exactly once, on the personal side.
 
 ### 4.3a Community-allocated energy (shared metering points)
 
@@ -321,7 +321,7 @@ FOR EACH community reading (metering points with a COMMUNITY assignment overlapp
     IF resolution is None OR resolution.allocation_mode != COMMUNITY:
         SKIP    (a gap, or this window is personal — billed in §4.3 instead)
 
-    day = ts.date()
+    day = _utc_date(ts)
     IF NOT (participant.valid_from ≤ day ≤ participant.valid_to or open-ended):
         SKIP    (a mid-period joiner pays no share of readings before their join date;
                  a leaver's share stops at their leave date)
@@ -350,7 +350,7 @@ After computing `r_local` and `r_grid` for a reading at timestamp `ts`:
 
 For each `(energy_type, quantity)` in `{(local, r_local), (grid, r_grid)}` where `quantity > 0`:
 
-1. Find all tariffs where `billing_mode = energy`, `energy_type` matches, and tariff is active on `ts.date()`.
+1. Find all tariffs where `billing_mode = energy`, `energy_type` matches, and tariff is active on `_utc_date(ts)`.
 2. For each matching tariff, resolve the price via period matching (§3.2).
 3. Accumulate: `quantity` kWh at `quantity × price` CHF.
 
@@ -358,8 +358,8 @@ For each `(energy_type, quantity)` in `{(local, r_local), (grid, r_grid)}` where
 
 These tariffs price energy as a percentage of the **grid base price sum**.
 
-1. **Grid base price sum** = sum of `price_chf_per_kwh` at `ts` for all tariffs where `billing_mode = energy` AND `energy_type = grid` AND active at `ts.date()`.
-2. For each percentage tariff active at `ts.date()` whose `energy_type` matches:
+1. **Grid base price sum** = sum of `price_chf_per_kwh` at `ts` for all tariffs where `billing_mode = energy` AND `energy_type = grid` AND active at `_utc_date(ts)`.
+2. For each percentage tariff active at `_utc_date(ts)` whose `energy_type` matches:
    - `effective_price = grid_base_price_sum × (tariff.percentage / 100)`
    - Accumulate: `quantity` kWh at `quantity × effective_price` CHF.
    - Also track `base_total = quantity × grid_base_price_sum` (used for description rendering).
@@ -456,6 +456,15 @@ own weight — the same key a `COMMUNITY`-mode metering point always uses
 (§4.6.4). With every weight at the default `1`, `weight` and `equal` agree
 exactly.
 
+**Exclusion of zero-value shares:** a member whose charged months produce a
+share that rounds to CHF 0.00 (half-up, like every rendered amount) gets no
+line item at all — the same rule as the per-metering-point gate in §4.6.4.
+This covers a zero-weight member under `split_key = weight`, who previously
+received a bogus "`N Monate / CHF 0.00`" line. The rule is scoped to the
+weight-split shared paths: a plainly configured fee with
+`fixed_price_chf = 0` still renders its CHF 0.00 line, because there the
+line's point is to show that the fee exists.
+
 **Both denominators are clamped to the same months as the numerator** — the
 overlap of the invoice period *and this tariff's own validity*, not the period
 alone. A tariff clipped inside the period (a version starting mid-month, which
@@ -551,7 +560,7 @@ for each billable month M in community_counts:
     total += unit_price × community_counts[M] × participant.allocation_weight / weight_sum
     shared_months += 1
 
-if shared_months > 0:
+if shared_months > 0 and round_half_up(total, 0.01) != 0:
     add a second line item: quantity = shared_months, total = total, bucket = "shared"
 ```
 
@@ -559,6 +568,15 @@ if shared_months > 0:
 billing modes. The cost being divided belongs to a community *metering
 point*, which always allocates by weight (§1.1 of the feature spec). A
 per-assignment split key is a documented follow-up, out of scope.
+
+**Known limitation:** a meter whose allocation mode switches PERSONAL→COMMUNITY
+(or back) mid-month is counted by *both* the personal count (§4.6.2) and
+this community count for that month — each counts any window touching the
+month — so its per-metering-point fee bills twice for the transition month.
+The counts are disjoint only when mode switches fall on month boundaries.
+Fixing it requires day-granular fee proration, which contradicts §4.6.1
+(months are not prorated); a fix is therefore a specced billing-model
+decision, tracked separately.
 
 Both weight-split paths (this one and §4.6.3) resolve their denominator per
 tariff but share **one** fetch of the ZEV's participant membership rows per
@@ -963,7 +981,7 @@ weighted consumption/production splits (incl. the holder-of-record paying no
 more than their own share, and a sole participant carrying a meter alone);
 kWh-total conservation within rounding; a meter personal in one month and
 community the next billing correctly on both sides with no double count and no
-lost readings (§4.3a); community readings excluded from the gap/skip counters;
+lost readings (§4.3a); community readings tracked in their own gap/skip counters;
 per-metering-point community fees, including `is_active` mirroring and
 exclusivity with the personal count (§4.6.4); a mid-period joiner/leaver's
 date-granular energy share vs. the month-granular fee share; the description

--- a/docs/specs/2026-03-tariffs-and-billing-engine.md
+++ b/docs/specs/2026-03-tariffs-and-billing-engine.md
@@ -434,7 +434,7 @@ Months are **not prorated**: touching any day in a month counts the full month.
 **Metering-point-months:** for each billable calendar month in the tariff overlap, count the number of **distinct active metering points** assigned to the participant during that month. A metering point counts for a month if:
 - It has an active assignment to the participant overlapping that month.
 - `metering_point.is_active = True`.
-- The assignment's `allocation_mode` is `PERSONAL` **during that month** — a `COMMUNITY`-mode window is excluded from this personal count and billed separately in §4.6.4, with the same per-window care as the §4.3 energy gate (a meter personal in one month and community the next counts in the first and is excluded from the second).
+- The window that **owns** the month (see §4.6.4) is a `PERSONAL`-mode assignment to the participant — a month owned by a `COMMUNITY`-mode window (or by another participant's window) is excluded from this personal count and billed separately in §4.6.4, with the same per-window care as the §4.3 energy gate (a meter personal in one month and community the next counts in the first and is excluded from the second). Ownership makes the counts disjoint by construction: a mid-month mode switch or holder change bills the month exactly once, on whichever side the owning window names.
 
 Sum across all months to get the total metering-point-months.
 
@@ -460,9 +460,10 @@ exactly.
 share that rounds to CHF 0.00 (half-up, like every rendered amount) gets no
 line item at all — the same rule as the per-metering-point gate in §4.6.4.
 This covers a zero-weight member under `split_key = weight`, who previously
-received a bogus "`N Monate / CHF 0.00`" line. The rule is scoped to the
-weight-split shared paths: a plainly configured fee with
-`fixed_price_chf = 0` still renders its CHF 0.00 line, because there the
+received a bogus "`N Monate / CHF 0.00`" line, and equally a `SHARED_*` fee
+configured at `fixed_price_chf = 0` under *either* split key — both shapes
+bill nothing. The rule is scoped to the shared paths: a plain, non-shared fee
+with `fixed_price_chf = 0` still renders its CHF 0.00 line, because there the
 line's point is to show that the fee exists.
 
 **Both denominators are clamped to the same months as the numerator** — the
@@ -542,14 +543,39 @@ member.
 #### 4.6.4 Community metering-point fees
 
 For `per_metering_point_monthly_fee` and `per_metering_point_yearly_fee`,
-each **active** `COMMUNITY`-mode metering point contributes its own
-fee — split by weight, month-granular — in addition to (not instead of) the
-participant's personal metering-point-months count from §4.6.2:
+each **active** metering point whose month is *community-owned* (defined
+below) contributes its own fee — split by weight, month-granular — in
+addition to (not instead of) the participant's personal
+metering-point-months count from §4.6.2:
+
+**Window ownership of a month.** Every calendar month, every active metering
+point is owned by exactly one assignment window: the one with the latest
+`valid_from` among the windows overlapping that month. The non-overlap rule
+(`MeteringPointAssignment._validate_no_overlap`) allows at most one
+assignment per metering point at any date, so "last to start" is
+unambiguous. Ownership is
+what keeps the personal count (§4.6.2) and this community count disjoint by
+construction: each meter-month is billed on exactly one side, named by the
+owning window's `allocation_mode`. A meter whose mode switches mid-month
+(PERSONAL→COMMUNITY or back) — or whose holder changes mid-month — bills the
+transition month exactly once, on the side of the window that starts latest
+in that month. §4.6.1 already commits to a tie-break of this shape: months
+are never prorated, so one side always gets the full month; this rule merely
+decides *which* side. When every mode switch falls on a month boundary the
+ownership pick degenerates to plain per-mode window counting, so
+single-mode meters are unchanged — including `PERSONAL` → gap, where the
+last overlapping window is still the personal one.
+
+The community count must see *every* window of a metering point — including
+`PERSONAL` windows and windows held by other participants — so a superseding
+window can take ownership; filtering the fetch by mode would bring the
+double-bill back. The personal count likewise needs the full history of the
+participant's own metering points, for the same reason.
 
 ```
-community_counts = for each billable month M, count distinct active COMMUNITY-mode
-                    metering points of the ZEV whose window overlaps M
-                    (metering_point.is_active = True; an inactive community meter bills nobody)
+community_counts = for each billable month M, count distinct active metering points
+                    of the ZEV whose month-owning window (§4.6.4) is COMMUNITY-mode
+                    (metering_point.is_active = True; an inactive meter bills nobody)
 
 total = 0
 shared_months = 0
@@ -568,15 +594,6 @@ if shared_months > 0 and round_half_up(total, 0.01) != 0:
 billing modes. The cost being divided belongs to a community *metering
 point*, which always allocates by weight (§1.1 of the feature spec). A
 per-assignment split key is a documented follow-up, out of scope.
-
-**Known limitation:** a meter whose allocation mode switches PERSONAL→COMMUNITY
-(or back) mid-month is counted by *both* the personal count (§4.6.2) and
-this community count for that month — each counts any window touching the
-month — so its per-metering-point fee bills twice for the transition month.
-The counts are disjoint only when mode switches fall on month boundaries.
-Fixing it requires day-granular fee proration, which contradicts §4.6.1
-(months are not prorated); a fix is therefore a specced billing-model
-decision, tracked separately.
 
 Both weight-split paths (this one and §4.6.3) resolve their denominator per
 tariff but share **one** fetch of the ZEV's participant membership rows per
@@ -972,6 +989,7 @@ The description renders as: `"Surcharge 50% (50% von CHF 0.32/kWh)"` (German).
 | CHF 100 across 3 participants recovers 99.99 | §4.6.3 documented rounding shortfall |
 | Description text and average-share unit price | §7.2 |
 | `equal` key ignores weights entirely (isolation guarantee); `weight` key splits by weight; default is `equal`; two shared tariffs can use different keys in the same invoice; default weights reproduce the equal split under `weight`; a joiner shifts the weight-sum denominator only from their own month; a negligible-weight member bills almost nothing; an indivisible weighted share leaves the documented rappen shortfall | §4.6.3 `split_key` (`SPEC-2026-08-shared-metering-points` §7.2) |
+| Zero-value shares get no line: a zero-weight member, an exact half-cent share surviving the gate (ROUND_HALF_UP, not banker's rounding), and a shared fee configured at CHF 0.00 under either split key | §4.6.3 zero-value gate |
 | A tariff starting mid-month: both keys agree, a full ZEV run recovers the whole fee, and a member active *inside* the billed window still dilutes it | §4.6.3 tariff-clamped denominators (regression, #465) |
 
 ### Backend (`invoices/test_shared_metering.py`)
@@ -982,8 +1000,10 @@ more than their own share, and a sole participant carrying a meter alone);
 kWh-total conservation within rounding; a meter personal in one month and
 community the next billing correctly on both sides with no double count and no
 lost readings (§4.3a); community readings tracked in their own gap/skip counters;
-per-metering-point community fees, including `is_active` mirroring and
-exclusivity with the personal count (§4.6.4); a mid-period joiner/leaver's
+per-metering-point community fees, including `is_active` mirroring, the
+disjoint-by-construction month ownership tie-break — a mid-month mode switch
+or holder change bills the month exactly once, on the side of the last window
+to start (§4.6.4); a mid-period joiner/leaver's
 date-granular energy share vs. the month-granular fee share; the description
 marker in all four locales; single-participant regeneration reproducing a full
 run's share.

--- a/docs/specs/2026-08-shared-metering-points.md
+++ b/docs/specs/2026-08-shared-metering-points.md
@@ -452,12 +452,21 @@ allocate the participant's share:
 
 ### 7.5 Per-metering-point fees
 
-- `_count_billable_metering_points_by_month` excludes assignments whose
-  `allocation_mode` is `COMMUNITY` **for the month in question** — the same
-  per-window care as §7.3, not a blanket join exclusion. It keeps its
-  `metering_point__is_active=True` filter.
+- Month ownership decides which side bills each meter-month: for every
+  calendar month, the assignment window with the latest `valid_from` among
+  those overlapping the month owns it — unambiguous because the non-overlap
+  rule (§4) allows one window per metering point per date. The personal
+  count (`_count_billable_metering_points_by_month`) bills only months owned
+  by a `PERSONAL`-mode window assigned to the participant; the community
+  count (`_count_community_metering_points_by_month`) bills only months owned
+  by a `COMMUNITY`-mode window. The two counts are therefore disjoint by
+  construction: a mid-month mode switch or holder change bills the month
+  exactly once, on the side of the owning window — the same per-window care
+  as §7.3, not a blanket join exclusion. Both keep their
+  `metering_point__is_active=True` filter, and both must fetch every window
+  of the metering point so a superseding window can take ownership.
 - New: for each per-metering-point tariff, each month, each **active**
-  community metering point contributes
+  community-owned metering point contributes
   `unit_price * allocation_weight_i / weight_sum(month)` to the participant's
   `bucket="shared"` line of that tariff (inactive community meters bill
   nobody). Meter fees are month-granular: the fee is a monthly charge, so a


### PR DESCRIPTION
## Summary

Three fixes to the billing engine's shared-metering paths:

1. **Gap visibility for shared meters** — readings in assignment gaps of community meters were previously skipped without a trace. They now have their own consumption/production counters and appear in the existing warning log. A meter appearing in both the personal and the community queryset (mixed-mode meters) has its gap readings counted exactly once (personal side wins), so the four counters partition the gaps. Billing semantics unchanged: gap readings belong to nobody.

2. **Zero-value shared lines** — weight-split fee shares rounding to CHF 0.00 no longer render a bogus `"N Monate / CHF 0.00"` line. Both sites (bucket=`shared` per-metering-point fee and SHARED_* fees) gate via `_is_zero_chf()`, which quantizes with `ROUND_HALF_UP` like the renderer, so an exact half-cent share still bills as 0.01. Suppression is scoped to the shared paths — both split keys; a shared fee configured at CHF 0.00 bills nothing either. A plainly configured CHF 0.00 fee still renders (its point is to show the fee exists).

3. **Date key** — every reading-date site (personal and community loops) is consolidated behind `_utc_date(ts)`, which treats a naive timestamp as UTC. No behavioural change for the UTC-aware timestamps the importers write; unifies the loops with the spec prose.

**Fixed in review (f3510eb):** the mid-month mode-switch overcharge.* The previously documented limitation — a PERSONAL→COMMUNITY switch inside a month billing the per-metering-point fee twice — is now fixed without prorating: each meter-month is owned by exactly one assignment window (`_last_overlapping_window`: the latest valid_from among windows overlapping the billed range, unambiguous because assignment windows can't overlap) and billed on whichever side its month lives. Both counters fetch the full window history so a superseding window can take ownership; the community count drops its allocation_mode filter. Months stay whole (§4.6.1); the tie-break decides which side gets them. The same rule also fixes a pre-existing mid-month holder change, which previously billed both holders. Behaviour is unchanged for every single-mode meter, including `PERSONAL → gap`.

## Linked spec

- Spec: `docs/specs/2026-03-tariffs-and-billing-engine.md` (§4.3, §4.3a, §4.4, §4.6, §4.6.3, §4.6.4) and `docs/specs/2026-08-shared-metering-points.md` (§7.5), updated in the same commits
- ADR: *(if architecture decision changed):* none — ADR 0007/0013 conventions preserved

## Validation

- Backend tests run: `python -m pytest -q` — full backend suite green (1241+ passed; pre-existing `test_contract_context.py` Postgres-isolation failures aside, identical on unmodified `main`)
- New tests: community gap counters via caplog, mixed-mode gap partition (`test_engine_allocation.py`); zero-weight suppression, half-cent gate survival, and equal-key zero-fee suppression (`test_shared_fee.py`); mid-month mode switch in both directions plus month-boundary regression, mid-month holder change (`test_shared_metering.py`)
- Frontend build run: N/A — backend and docs only
- Frontend tests run: N/A — backend and docs only
- Manual checks: none (no UI or workflow change)
- Screenshots: N/A

## Checklist

- [x] Spec updated/linked for larger or risky changes
- [x] ADR updated/linked for architecture decisions — N/A, no architecture decision changed
- [x] Backend and frontend updated together where API contracts changed — N/A, no API contract change