### PR TITLE
fix(frontend): let owners of multiple ZEVs switch between them

### DIFF
--- a/docs/specs/2026-03-community-and-access.md
+++ b/docs/specs/2026-03-community-and-access.md
@@ -622,8 +622,8 @@ The sidebar (`Layout.tsx`) shows sections conditionally:
 **Behaviour:**
 - Fetches ZEV list only if `canManageZev` (admin or zev_owner).
 - `admin` → all ZEVs; can switch via dropdown (`isSelectable = true`).
-- `zev_owner` → only owned ZEVs; auto-selects first owned ZEV
-  (`isSelectable = false`).
+- `zev_owner` → only owned ZEVs. One ZEV: pin it (`isSelectable = false`).
+  Two or more: switch among them (`isSelectable = true`).
 - `participant` / `guest` → empty list, no selection.
 - Persists selected ZEV ID in `localStorage` key `openzev.selectedZevId`.
 - Auto-fallback: if stored ID is no longer valid, select first available ZEV.

--- a/frontend/src/lib/managedZev.tsx
+++ b/frontend/src/lib/managedZev.tsx
@@ -3,7 +3,9 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchZevs } from './api/zev'
 import { queryKeys } from './api/queryKeys'
 import { useAuth } from './auth'
-import type { Zev } from '../types/api'
+import type { UserRole, Zev } from '../types/api'
+
+const STORAGE_KEY = 'openzev.selectedZevId'
 
 interface ManagedZevContextValue {
     managedZevs: Zev[]
@@ -12,6 +14,45 @@ interface ManagedZevContextValue {
     isSelectable: boolean
     isLoading: boolean
     setSelectedZevId: (zevId: string) => void
+}
+
+interface ManagedSelectionInput {
+    role?: UserRole
+    managedZevs: ReadonlyArray<Pick<Zev, 'id'>>
+    currentId: string
+}
+
+interface ManagedSelection {
+    /** User may switch between managed ZEVs. */
+    isSelectable: boolean
+    /** Reconciled selection: keeps the current ID while it is still managed, otherwise falls back to the first managed ZEV. */
+    selection: string
+    /** Whether a user-initiated selection request targets a managed ZEV. */
+    isAllowedId: (zevId: string) => boolean
+}
+
+/**
+ * Admin: always switch. Owner: switch only with 2+ ZEVs. Else: no selection.
+ * (No hooks, unit-testable.)
+ */
+export function resolveManagedSelection({
+    role,
+    managedZevs,
+    currentId,
+}: ManagedSelectionInput): ManagedSelection {
+    const isAdmin = role === 'admin'
+    const isOwner = role === 'zev_owner'
+    const canManage = isAdmin || isOwner
+    const allowedIds = new Set(managedZevs.map((zev) => zev.id))
+
+    return {
+        isSelectable: isAdmin || (isOwner && managedZevs.length > 1),
+        selection:
+            canManage && managedZevs.length > 0
+                ? (allowedIds.has(currentId) ? currentId : managedZevs[0].id)
+                : '',
+        isAllowedId: (zevId) => canManage && allowedIds.has(zevId),
+    }
 }
 
 const ManagedZevContext = createContext<ManagedZevContextValue | undefined>(undefined)
@@ -35,42 +76,33 @@ export function ManagedZevProvider({ children }: { children: ReactNode }) {
         return []
     }, [isAdmin, isOwner, user, zevsQuery.data?.results])
 
-    const [selectedZevId, setSelectedZevIdState] = useState('')
+    // Restore the persisted selection directly, so it survives the loading
+    // phase instead of being raced by the reconcile effect below.
+    const [selectedZevId, setSelectedZevIdState] = useState(
+        () => window.localStorage.getItem(STORAGE_KEY) ?? '',
+    )
+
+    const resolution = useMemo(
+        () =>
+            resolveManagedSelection({
+                role: user?.role,
+                managedZevs,
+                currentId: selectedZevId,
+            }),
+        [user?.role, managedZevs, selectedZevId],
+    )
 
     useEffect(() => {
-        const stored = window.localStorage.getItem('openzev.selectedZevId')
-        if (stored) {
-            setSelectedZevIdState(stored)
+        // Don't erase a restored ID while the managed list is still loading.
+        if (canManageZev && zevsQuery.isLoading) return
+        if (selectedZevId === resolution.selection) return
+        setSelectedZevIdState(resolution.selection)
+        if (resolution.selection) {
+            window.localStorage.setItem(STORAGE_KEY, resolution.selection)
+        } else {
+            window.localStorage.removeItem(STORAGE_KEY)
         }
-    }, [])
-
-    useEffect(() => {
-        if (!canManageZev) {
-            setSelectedZevIdState('')
-            return
-        }
-
-        if (!managedZevs.length) {
-            setSelectedZevIdState('')
-            return
-        }
-
-        if (isOwner) {
-            const ownedZevId = managedZevs[0].id
-            if (selectedZevId !== ownedZevId) {
-                setSelectedZevIdState(ownedZevId)
-                window.localStorage.setItem('openzev.selectedZevId', ownedZevId)
-            }
-            return
-        }
-
-        const isCurrentValid = managedZevs.some((zev) => zev.id === selectedZevId)
-        if (!isCurrentValid) {
-            const fallback = managedZevs[0].id
-            setSelectedZevIdState(fallback)
-            window.localStorage.setItem('openzev.selectedZevId', fallback)
-        }
-    }, [canManageZev, managedZevs, selectedZevId, isOwner])
+    }, [canManageZev, zevsQuery.isLoading, selectedZevId, resolution])
 
     const selectedZev = managedZevs.find((zev) => zev.id === selectedZevId) ?? null
 
@@ -79,15 +111,15 @@ export function ManagedZevProvider({ children }: { children: ReactNode }) {
             managedZevs,
             selectedZevId,
             selectedZev,
-            isSelectable: isAdmin,
+            isSelectable: resolution.isSelectable,
             isLoading: zevsQuery.isLoading,
             setSelectedZevId: (zevId: string) => {
-                if (!isAdmin) return
+                if (!resolution.isAllowedId(zevId)) return
                 setSelectedZevIdState(zevId)
-                window.localStorage.setItem('openzev.selectedZevId', zevId)
+                window.localStorage.setItem(STORAGE_KEY, zevId)
             },
         }),
-        [managedZevs, selectedZevId, selectedZev, isAdmin, zevsQuery.isLoading],
+        [managedZevs, selectedZevId, selectedZev, resolution, zevsQuery.isLoading],
     )
 
     return <ManagedZevContext.Provider value={value}>{children}</ManagedZevContext.Provider>

--- a/frontend/tests/managed-zev-selection.test.ts
+++ b/frontend/tests/managed-zev-selection.test.ts
@@ -1,0 +1,297 @@
+import { createRoot } from 'react-dom/client'
+import { act, createElement, useEffect } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchZevs } from '../src/lib/api/zev'
+import { ManagedZevProvider, resolveManagedSelection, useManagedZev } from '../src/lib/managedZev'
+import type { PaginatedResponse, User, UserRole, Zev } from '../src/types/api'
+
+type IdOnly = Pick<Zev, 'id'>
+
+const zev = (id: string): IdOnly => ({ id })
+
+describe('resolveManagedSelection — admin', () => {
+    it('is always selectable and can pick any managed ZEV', () => {
+        const resolution = resolveManagedSelection({
+            role: 'admin',
+            managedZevs: [zev('z1'), zev('z2')],
+            currentId: 'z1',
+        })
+        expect(resolution.isSelectable).toBe(true)
+        expect(resolution.isAllowedId('z1')).toBe(true)
+        expect(resolution.isAllowedId('z2')).toBe(true)
+    })
+
+    it('keeps the current selection while it exists', () => {
+        const resolution = resolveManagedSelection({
+            role: 'admin',
+            managedZevs: [zev('z1'), zev('z2')],
+            currentId: 'z2',
+        })
+        expect(resolution.selection).toBe('z2')
+    })
+
+    it('falls back to the first ZEV when the stored id is stale', () => {
+        const resolution = resolveManagedSelection({
+            role: 'admin',
+            managedZevs: [zev('z1'), zev('z2')],
+            currentId: 'deleted-zev',
+        })
+        expect(resolution.selection).toBe('z1')
+        expect(resolution.isAllowedId('deleted-zev')).toBe(false)
+    })
+})
+
+describe('resolveManagedSelection — zev_owner', () => {
+    it('pins a single owned ZEV and is not selectable', () => {
+        const resolution = resolveManagedSelection({
+            role: 'zev_owner',
+            managedZevs: [zev('own')],
+            currentId: '',
+        })
+        expect(resolution.isSelectable).toBe(false)
+        expect(resolution.selection).toBe('own')
+        expect(resolution.isAllowedId('own')).toBe(true)
+    })
+
+    it('an owner with more than one ZEV can switch among them', () => {
+        const resolution = resolveManagedSelection({
+            role: 'zev_owner',
+            managedZevs: [zev('own1'), zev('own2')],
+            currentId: 'own1',
+        })
+        expect(resolution.isSelectable).toBe(true)
+        expect(resolution.isAllowedId('own1')).toBe(true)
+        expect(resolution.isAllowedId('own2')).toBe(true)
+        expect(resolution.selection).toBe('own1')
+    })
+
+    it('falls back to the first owned ZEV when nothing is stored yet', () => {
+        const resolution = resolveManagedSelection({
+            role: 'zev_owner',
+            managedZevs: [zev('own1'), zev('own2')],
+            currentId: '',
+        })
+        expect(resolution.isSelectable).toBe(true)
+        expect(resolution.selection).toBe('own1')
+    })
+
+    it('rejects a selection that is not one of the owned ZEVs', () => {
+        const resolution = resolveManagedSelection({
+            role: 'zev_owner',
+            managedZevs: [zev('own1'), zev('own2')],
+            currentId: 'own1',
+        })
+        expect(resolution.isAllowedId('someone-elses-zev')).toBe(false)
+    })
+
+    it('keeps an owned selection instead of re-pinning to the first entry', () => {
+        const resolution = resolveManagedSelection({
+            role: 'zev_owner',
+            managedZevs: [zev('own1'), zev('own2')],
+            currentId: 'own2',
+        })
+        expect(resolution.selection).toBe('own2')
+    })
+
+    it('falls back to the first owned ZEV when the stored id is stale', () => {
+        const resolution = resolveManagedSelection({
+            role: 'zev_owner',
+            managedZevs: [zev('taken-over-1'), zev('taken-over-2')],
+            currentId: 'transferred-away',
+        })
+        expect(resolution.isSelectable).toBe(true)
+        expect(resolution.selection).toBe('taken-over-1')
+        expect(resolution.isAllowedId('transferred-away')).toBe(false)
+    })
+})
+
+describe('resolveManagedSelection — roles without management scope', () => {
+    it.each(['participant', 'guest'] as const)('%s gets neither selection nor switching', (role) => {
+        const resolution = resolveManagedSelection({
+            role,
+            managedZevs: [zev('z1')],
+            currentId: 'z1',
+        })
+        expect(resolution.isSelectable).toBe(false)
+        expect(resolution.selection).toBe('')
+        expect(resolution.isAllowedId('z1')).toBe(false)
+    })
+})
+
+describe('resolveManagedSelection — missing data', () => {
+    it('selects nothing before the user or the list is loaded', () => {
+        const resolution = resolveManagedSelection({
+            role: undefined,
+            managedZevs: [],
+            currentId: '',
+        })
+        expect(resolution.isSelectable).toBe(false)
+        expect(resolution.selection).toBe('')
+        expect(resolution.isAllowedId('z1')).toBe(false)
+    })
+})
+
+/**
+ * Provider-level coverage for the localStorage wiring that the pure helper
+ * cannot exercise: the restored selection must survive the loading phase and
+ * not be raced by the reconcile effect (cold cache), and a stale stored ID
+ * must be healed back to the first managed ZEV.
+ */
+
+const authState = vi.hoisted(() => ({ current: null as User | null }))
+
+vi.mock('../src/lib/auth', () => ({
+    useAuth: () => ({ user: authState.current }),
+}))
+
+vi.mock('../src/lib/api/zev', () => ({
+    fetchZevs: vi.fn(),
+}))
+
+const fullZev = (id: string, owner: number): Zev => ({
+    id,
+    name: id,
+    start_date: '2026-01-01',
+    owner,
+    zev_type: 'zev',
+    grid_operator: 'op',
+    billing_interval: 'monthly',
+})
+
+const userWithRole = (role: UserRole): User => ({
+    id: 1,
+    username: 'owner1',
+    email: 'owner1@example.com',
+    first_name: 'Owner',
+    last_name: 'One',
+    role,
+    must_change_password: false,
+})
+
+describe('ManagedZevProvider selection persistence', () => {
+    let container: HTMLDivElement
+    let root: ReturnType<typeof createRoot>
+    let resolveFetch: ((value: PaginatedResponse<Zev>) => void) | undefined
+
+    beforeEach(() => {
+        ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+        localStorage.clear()
+        authState.current = null
+        resolveFetch = undefined
+        vi.mocked(fetchZevs).mockReset()
+        container = document.createElement('div')
+        document.body.appendChild(container)
+        root = createRoot(container)
+    })
+
+    afterEach(() => {
+        act(() => {
+            root.unmount()
+        })
+        container.remove()
+    })
+
+    function renderProvider() {
+        const latest = { current: null as ReturnType<typeof useManagedZev> | null }
+
+        function Harness() {
+            const context = useManagedZev()
+            useEffect(() => {
+                latest.current = context
+            }, [context])
+            return null
+        }
+
+        act(() => {
+            root.render(
+                createElement(
+                    QueryClientProvider,
+                    { client: new QueryClient({ defaultOptions: { queries: { retry: false } } }) },
+                    createElement(ManagedZevProvider, null, createElement(Harness)),
+                ),
+            )
+        })
+
+        return latest
+    }
+
+    function deferFetch() {
+        vi.mocked(fetchZevs).mockImplementation(
+            () => new Promise<PaginatedResponse<Zev>>((resolve) => { resolveFetch = resolve }),
+        )
+    }
+
+    /**
+     * Resolves the pending ZEV fetch and lets the react-query update land.
+     * The observer update is delivered on a later scheduler tick, so a plain
+     * microtask flush inside act is not enough — give it a timer tick.
+     */
+    function resolveTwoZevs() {
+        return act(async () => {
+            resolveFetch?.({
+                count: 2,
+                next: null,
+                previous: null,
+                results: [fullZev('own1', 1), fullZev('own2', 1)],
+            })
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            await new Promise((resolve) => setTimeout(resolve, 0))
+        })
+    }
+
+    it('restores the persisted selection once the list has loaded (cold cache)', async () => {
+        localStorage.setItem('openzev.selectedZevId', 'own2')
+        authState.current = userWithRole('zev_owner')
+        deferFetch()
+
+        const latest = renderProvider()
+
+        // While the list is loading, the restored ID must not be erased.
+        expect(latest.current?.selectedZevId).toBe('own2')
+
+        await resolveTwoZevs()
+
+        expect(latest.current?.managedZevs.map((z) => z.id)).toEqual(['own1', 'own2'])
+        expect(latest.current?.selectedZevId).toBe('own2')
+        expect(localStorage.getItem('openzev.selectedZevId')).toBe('own2')
+    })
+
+    it('heals a stale stored ID back to the first managed ZEV and rewrites localStorage', async () => {
+        localStorage.setItem('openzev.selectedZevId', 'transferred-away')
+        authState.current = userWithRole('zev_owner')
+        deferFetch()
+
+        const latest = renderProvider()
+
+        await resolveTwoZevs()
+
+        expect(latest.current?.selectedZevId).toBe('own1')
+        expect(localStorage.getItem('openzev.selectedZevId')).toBe('own1')
+    })
+
+    it('keeps a still-valid restored ID instead of re-pinning to the first entry', async () => {
+        localStorage.setItem('openzev.selectedZevId', 'own2')
+        authState.current = userWithRole('zev_owner')
+        deferFetch()
+
+        const latest = renderProvider()
+
+        await resolveTwoZevs()
+
+        expect(latest.current?.managedZevs.map((z) => z.id)).toEqual(['own1', 'own2'])
+        expect(latest.current?.selectedZevId).toBe('own2')
+        expect(latest.current?.isSelectable).toBe(true)
+    })
+
+    it('clears the selection and removes the stored key for a non-managing role', async () => {
+        localStorage.setItem('openzev.selectedZevId', 'own1')
+        authState.current = userWithRole('participant')
+
+        const latest = renderProvider()
+
+        expect(latest.current?.selectedZevId).toBe('')
+        expect(latest.current?.isSelectable).toBe(false)
+        expect(localStorage.getItem('openzev.selectedZevId')).toBeNull()
+    })
+})


### PR DESCRIPTION
## Summary

Owners of two or more ZEVs saw a dead ZEV dropdown: `isSelectable` was admin-only, `setSelectedZevId` rejected every non-admin, and a reconciliation effect force-reset owners to their first managed ZEV.

- Selection rules moved to a pure `resolveManagedSelection` helper: admins switch freely; owners stay pinned only while they manage a single ZEV and switch among their own ZEVs with two or more; every user-initiated selection is validated against the managed list (heals a stale `openzev.selectedZevId` after a whole-ZEV transfer).
- Fixed the persisted selection being lost on page load: the stored ID is seeded via lazy state initialisation and the reconcile effect holds off while the ZEV list is loading. The localStorage key is removed when the selection is cleared (role demotion, last ZEV deleted).
- This brings the frontend in line with the user guide (`docs/user-guide/11-roles-and-permissions.md`), which already promised owners can switch between assigned communities.

## Linked spec

- Spec: `docs/specs/2026-03-community-and-access.md` (§9.4 ManagedZevProvider) — updated in this PR
- ADR (if architecture decision changed): none changed — ADR 0003 still applies (selection remains owner-scoped and is now validated on every request)
- No spec needed because: n/a, spec updated

## Validation

- Backend tests run: not run — frontend-only change, no backend/API contract changes
- Frontend build run: `npm run build` — passed (incl. `tsc -b`)
- Frontend tests run: `npm run test:unit` — 156/156 passed across 23 files, incl. 16 new tests in `frontend/tests/managed-zev-selection.test.ts` (unit-level per role + provider-level cold-cache restore)
- Manual checks: not done
- Screenshots: not included

## Checklist

- [x] Spec updated/linked for larger or risky changes — §9.4 of `2026-03-community-and-access.md` updated in this PR
- N/A: ADR updated/linked (no architecture decision changed)
- N/A: backend and frontend updated together (no API contract change)
