### PR TITLE
fix(frontend): fetch every page of DRF-paginated list endpoints

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -90,7 +90,7 @@ export function Layout() {
     const adminIsActive = location.pathname.startsWith('/admin')
     const manageIsActive = isManageSectionPath(location.pathname)
 
-    const ownerById = new Map((usersQuery.data?.results ?? []).map((candidate) => [candidate.id, candidate]))
+    const ownerById = new Map((usersQuery.data ?? []).map((candidate) => [candidate.id, candidate]))
     const selectedZevOwner = selectedZev ? ownerById.get(selectedZev.owner) : undefined
     const effectiveOwner = selectedZevOwner ?? (user?.role === 'zev_owner' ? user : undefined)
     const selectedZevOwnerName = effectiveOwner

--- a/frontend/src/features/feasibility/PrefillFromZevCard.tsx
+++ b/frontend/src/features/feasibility/PrefillFromZevCard.tsx
@@ -18,7 +18,7 @@ export function PrefillFromZevCard({ onPrefillLoaded }: Props) {
     const [selectedZevId, setSelectedZevId] = useState('')
 
     const zevsQuery = useQuery({ queryKey: queryKeys.zev.list(), queryFn: fetchZevs })
-    const zevs = zevsQuery.data?.results ?? []
+    const zevs = zevsQuery.data ?? []
 
     const prefillMutation = useMutation({
         mutationFn: fetchFeasibilityPrefill,

--- a/frontend/src/features/meteringPoints/useMeteringPointActions.tsx
+++ b/frontend/src/features/meteringPoints/useMeteringPointActions.tsx
@@ -339,14 +339,14 @@ export function useMeteringPointActions({
     const participantNameById = useMemo(
         () =>
             new Map(
-                (participantsQuery.data?.results ?? []).map((p) => [p.id, `${p.first_name} ${p.last_name}`]),
+                (participantsQuery.data ?? []).map((p) => [p.id, `${p.first_name} ${p.last_name}`]),
             ),
         [participantsQuery.data],
     )
 
     const assignmentsByMeteringPoint = useMemo(() => {
         const map = new Map<string, MeteringPointAssignment[]>()
-        for (const a of assignmentsQuery.data?.results ?? []) {
+        for (const a of assignmentsQuery.data ?? []) {
             const list = map.get(a.metering_point) ?? []
             list.push(a)
             map.set(a.metering_point, list)
@@ -355,13 +355,13 @@ export function useMeteringPointActions({
     }, [assignmentsQuery.data])
 
     const assignParticipants = useMemo(() => {
-        if (!selectedMpId) return participantsQuery.data?.results ?? []
-        const mp = meteringPointsQuery.data?.results.find((m) => m.id === selectedMpId)
-        if (!mp) return participantsQuery.data?.results ?? []
-        return (participantsQuery.data?.results ?? []).filter((p) => p.zev === mp.zev)
+        if (!selectedMpId) return participantsQuery.data ?? []
+        const mp = meteringPointsQuery.data?.find((m) => m.id === selectedMpId)
+        if (!mp) return participantsQuery.data ?? []
+        return (participantsQuery.data ?? []).filter((p) => p.zev === mp.zev)
     }, [selectedMpId, meteringPointsQuery.data, participantsQuery.data])
 
-    const scopedMeteringPoints = (meteringPointsQuery.data?.results ?? []).filter(
+    const scopedMeteringPoints = (meteringPointsQuery.data ?? []).filter(
         (point) => !canManageMeteringPoints || !selectedZevId || point.zev === selectedZevId,
     )
 

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -12,7 +12,6 @@ import type {
   OAuthProvider,
   OAuthProviderConfig,
   OAuthProviderConfigInput,
-  PaginatedResponse,
   RegisterInput,
   SocialAccount,
   User,
@@ -21,6 +20,7 @@ import type {
   VatRateInput,
 } from '../../types/api'
 import { api } from './client'
+import { fetchAllPages } from './pagination'
 
 export async function login(email: string, password: string): Promise<void> {
   await api.post('/auth/token/', { email, password })
@@ -45,9 +45,8 @@ export async function updateAppSettings(payload: AppSettingsInput): Promise<AppS
   return data
 }
 
-export async function fetchVatRates(): Promise<PaginatedResponse<VatRate>> {
-  const { data } = await api.get<PaginatedResponse<VatRate>>('/auth/vat-rates/')
-  return data
+export async function fetchVatRates(): Promise<VatRate[]> {
+  return fetchAllPages<VatRate>('/auth/vat-rates/')
 }
 
 export async function createVatRate(payload: VatRateInput): Promise<VatRate> {
@@ -79,9 +78,8 @@ export async function updateFeatureFlag(id: number, payload: FeatureFlagInput): 
   return data
 }
 
-export async function fetchUsers(): Promise<PaginatedResponse<User>> {
-  const { data } = await api.get<PaginatedResponse<User>>('/auth/users/')
-  return data
+export async function fetchUsers(): Promise<User[]> {
+  return fetchAllPages<User>('/auth/users/')
 }
 
 export async function impersonateParticipant(userId: number): Promise<ImpersonationResult> {
@@ -157,8 +155,7 @@ export async function deleteSocialAccount(id: number): Promise<void> {
 }
 
 export async function fetchOAuthProviderConfigs(): Promise<OAuthProviderConfig[]> {
-  const { data } = await api.get<PaginatedResponse<OAuthProviderConfig>>('/auth/oauth/providers/config/')
-  return data.results
+  return fetchAllPages<OAuthProviderConfig>('/auth/oauth/providers/config/')
 }
 
 export async function createOAuthProviderConfig(payload: OAuthProviderConfigInput): Promise<OAuthProviderConfig> {
@@ -176,8 +173,7 @@ export async function deleteOAuthProviderConfig(id: number): Promise<void> {
 }
 
 export async function fetchApiKeys(): Promise<ApiKey[]> {
-  const { data } = await api.get<PaginatedResponse<ApiKey>>('/auth/me/api-keys/')
-  return data.results
+  return fetchAllPages<ApiKey>('/auth/me/api-keys/')
 }
 
 /**
@@ -204,8 +200,7 @@ export async function fetchAllApiKeys(filters: AdminApiKeyFilters = {}): Promise
   const params: Record<string, string> = {}
   if (filters.user) params.user = String(filters.user)
   if (filters.status) params.status = filters.status
-  const { data } = await api.get<PaginatedResponse<AdminApiKey>>('/auth/api-keys/', { params })
-  return data.results
+  return fetchAllPages<AdminApiKey>('/auth/api-keys/', params)
 }
 
 /** Revoke any user's key. Admin only; takes effect on the key's next request. */

--- a/frontend/src/lib/api/invoices.ts
+++ b/frontend/src/lib/api/invoices.ts
@@ -4,18 +4,15 @@ import type {
   EmailTemplateResponse,
   Invoice,
   InvoicePeriodOverview,
-  PaginatedResponse,
   PdfTemplateResponse,
 } from '../../types/api'
 import { api } from './client'
+import { fetchAllPages } from './pagination'
 
-export async function fetchInvoices(zevId?: string): Promise<PaginatedResponse<Invoice>> {
-  const { data } = await api.get<PaginatedResponse<Invoice>>('/invoices/invoices/', {
-    // Backend narrows by ?zev_id= on top of role scoping (issue #411); without it,
-    // admins and multi-ZEV owners get every ZEV they can see.
-    params: zevId ? { zev_id: zevId } : undefined,
-  })
-  return data
+export async function fetchInvoices(zevId?: string): Promise<Invoice[]> {
+  // Backend narrows by ?zev_id= on top of role scoping (issue #411); without it,
+  // admins and multi-ZEV owners get every ZEV they can see.
+  return fetchAllPages<Invoice>('/invoices/invoices/', zevId ? { zev_id: zevId } : undefined)
 }
 
 export async function fetchInvoice(invoiceId: string): Promise<Invoice> {

--- a/frontend/src/lib/api/metering.ts
+++ b/frontend/src/lib/api/metering.ts
@@ -6,15 +6,14 @@ import type {
   ImportLog,
   ImportPreviewResult,
   MeteringDashboardSummary,
-  PaginatedResponse,
   RawMeteringDailyRow,
   RawMeteringReading,
 } from '../../types/api'
 import { api } from './client'
+import { fetchAllPages } from './pagination'
 
-export async function fetchImportLogs(): Promise<PaginatedResponse<ImportLog>> {
-  const { data } = await api.get<PaginatedResponse<ImportLog>>('/metering/import-logs/')
-  return data
+export async function fetchImportLogs(): Promise<ImportLog[]> {
+  return fetchAllPages<ImportLog>('/metering/import-logs/')
 }
 
 export async function deleteImportLog(id: string): Promise<ImportDeletionResult> {

--- a/frontend/src/lib/api/pagination.ts
+++ b/frontend/src/lib/api/pagination.ts
@@ -1,0 +1,72 @@
+import type { PaginatedResponse } from '../../types/api'
+import { api, API_BASE_URL } from './client'
+
+/** Hard cap on page requests; a buggy `next` chain must not loop forever. */
+const MAX_PAGES = 200
+
+// DRF builds `next` from the request Host, which behind the dev proxy is an
+// address the browser cannot reach — rewrite each hop to a base-relative URL.
+const BASE_PATH = toPathPrefix(API_BASE_URL)
+
+function toPathPrefix(baseUrl: string): string {
+  try {
+    return new URL(baseUrl).pathname.replace(/\/+$/, '')
+  } catch {
+    // Relative base (the common case): the prefix is the value itself.
+    return baseUrl.replace(/\/+$/, '')
+  }
+}
+
+/** Rewrite DRF's absolute `next` link into the base-relative form used here. */
+function nextToRelative(next: string): string {
+  let url: URL | null = null
+  try {
+    url = new URL(next)
+  } catch {
+    // Already-relative link: take it apart without an origin.
+  }
+  let pathname: string
+  let search: string
+  if (url) {
+    pathname = url.pathname
+    search = url.search
+  } else {
+    const queryIndex = next.indexOf('?')
+    pathname = queryIndex === -1 ? next : next.slice(0, queryIndex)
+    search = queryIndex === -1 ? '' : next.slice(queryIndex)
+  }
+  if (BASE_PATH && pathname.startsWith(`${BASE_PATH}/`)) {
+    pathname = pathname.slice(BASE_PATH.length)
+  }
+  return pathname + search
+}
+
+/** Walk every page of a DRF PageNumberPagination endpoint and return all rows. */
+export async function fetchAllPages<T>(
+  path: string,
+  params?: Record<string, string | number | undefined>,
+): Promise<T[]> {
+  const all: T[] = []
+  let next: string | null = null
+  let requestCount = 0
+
+  do {
+    if (requestCount >= MAX_PAGES) {
+      throw new Error(`fetchAllPages: exceeded ${MAX_PAGES} page requests while fetching ${path}`)
+    }
+    const target: string = next ? nextToRelative(next) : path
+    const data: PaginatedResponse<T> | T[] = (
+      await api.get<PaginatedResponse<T> | T[]>(target, next ? undefined : { params })
+    ).data
+    // Guard against an endpoint that is not DRF-paginated at all.
+    if (Array.isArray(data)) {
+      return data
+    }
+    all.push(...data.results)
+    next = data.next
+    requestCount += 1
+  } while (next)
+
+  return all
+}
+

--- a/frontend/src/lib/api/zev.ts
+++ b/frontend/src/lib/api/zev.ts
@@ -3,7 +3,6 @@ import type {
   MeteringPointAssignment,
   MeteringPointAssignmentInput,
   MeteringPointInput,
-  PaginatedResponse,
   Participant,
   ParticipantAccountCreateResult,
   ParticipantInput,
@@ -15,6 +14,7 @@ import type {
 } from '../../types/api'
 import { api } from './client'
 import { downloadBlob } from '../downloadBlob'
+import { fetchAllPages } from './pagination'
 
 export async function createSelfSetupZev(
   payload: SelfSetupZevInput,
@@ -23,9 +23,8 @@ export async function createSelfSetupZev(
   return data
 }
 
-export async function fetchZevs(): Promise<PaginatedResponse<Zev>> {
-  const { data } = await api.get<PaginatedResponse<Zev>>('/zev/zevs/')
-  return data
+export async function fetchZevs(): Promise<Zev[]> {
+  return fetchAllPages<Zev>('/zev/zevs/')
 }
 
 export async function createZev(payload: ZevInput): Promise<Zev> {
@@ -47,9 +46,8 @@ export async function deleteZev(id: string): Promise<void> {
   await api.delete(`/zev/zevs/${id}/`)
 }
 
-export async function fetchParticipants(): Promise<PaginatedResponse<Participant>> {
-  const { data } = await api.get<PaginatedResponse<Participant>>('/zev/participants/')
-  return data
+export async function fetchParticipants(): Promise<Participant[]> {
+  return fetchAllPages<Participant>('/zev/participants/')
 }
 
 export async function createParticipant(payload: ParticipantInput): Promise<Participant> {
@@ -91,9 +89,8 @@ export async function downloadParticipantContractPdf(participantId: string, file
   downloadBlob(response.data as Blob, filename)
 }
 
-export async function fetchMeteringPoints(): Promise<PaginatedResponse<MeteringPoint>> {
-  const { data } = await api.get<PaginatedResponse<MeteringPoint>>('/zev/metering-points/')
-  return data
+export async function fetchMeteringPoints(): Promise<MeteringPoint[]> {
+  return fetchAllPages<MeteringPoint>('/zev/metering-points/')
 }
 
 export async function createMeteringPoint(payload: MeteringPointInput): Promise<MeteringPoint> {
@@ -118,10 +115,9 @@ export async function deleteMeteringPointReadings(
   return data
 }
 
-export async function fetchMeteringPointAssignments(meteringPointId?: string): Promise<PaginatedResponse<MeteringPointAssignment>> {
+export async function fetchMeteringPointAssignments(meteringPointId?: string): Promise<MeteringPointAssignment[]> {
   const params = meteringPointId ? { metering_point: meteringPointId } : {}
-  const { data } = await api.get<PaginatedResponse<MeteringPointAssignment>>('/zev/metering-point-assignments/', { params })
-  return data
+  return fetchAllPages<MeteringPointAssignment>('/zev/metering-point-assignments/', params)
 }
 
 export async function createMeteringPointAssignment(payload: MeteringPointAssignmentInput): Promise<MeteringPointAssignment> {

--- a/frontend/src/lib/managedZev.tsx
+++ b/frontend/src/lib/managedZev.tsx
@@ -70,11 +70,11 @@ export function ManagedZevProvider({ children }: { children: ReactNode }) {
     })
 
     const managedZevs = useMemo(() => {
-        const allZevs = zevsQuery.data?.results ?? []
+        const allZevs = zevsQuery.data ?? []
         if (isAdmin) return allZevs
         if (isOwner && user) return allZevs.filter((zev) => zev.owner === user.id)
         return []
-    }, [isAdmin, isOwner, user, zevsQuery.data?.results])
+    }, [isAdmin, isOwner, user, zevsQuery.data])
 
     // Restore the persisted selection directly, so it survives the loading
     // phase instead of being raced by the reconcile effect below.

--- a/frontend/src/pages/AdminAccountsPage.tsx
+++ b/frontend/src/pages/AdminAccountsPage.tsx
@@ -224,9 +224,9 @@ export function AdminAccountsPage() {
         return <div className="card error-banner">{t('pages.accounts.loadFailed')}</div>
     }
 
-    const users = usersQuery.data?.results ?? []
-    const participants = participantsQuery.data?.results ?? []
-    const zevNameById = new Map((zevsQuery.data?.results ?? []).map((zev) => [zev.id, zev.name]))
+    const users = usersQuery.data ?? []
+    const participants = participantsQuery.data ?? []
+    const zevNameById = new Map((zevsQuery.data ?? []).map((zev) => [zev.id, zev.name]))
     const userById = new Map(users.map((entry) => [entry.id, entry]))
 
     const participantByUserId = new Map<number, Participant>()

--- a/frontend/src/pages/AdminApiKeysPage.tsx
+++ b/frontend/src/pages/AdminApiKeysPage.tsx
@@ -34,7 +34,7 @@ export function AdminApiKeysPage() {
     })
 
     const keys = keysQuery.data ?? []
-    const users = usersQuery.data?.results ?? []
+    const users = usersQuery.data ?? []
 
     const revokeMutation = useMutation({
         mutationFn: (id: string) => revokeAnyApiKey(id),

--- a/frontend/src/pages/AdminInvoicesPage.tsx
+++ b/frontend/src/pages/AdminInvoicesPage.tsx
@@ -51,7 +51,7 @@ export function AdminInvoicesPage() {
         })
     }, [confirm, deleteInvoiceAsync, t])
 
-    const invoices = invoicesQuery.data?.results ?? EMPTY_INVOICES
+    const invoices = invoicesQuery.data ?? EMPTY_INVOICES
 
     const rows = useMemo(
         () =>

--- a/frontend/src/pages/AdminVatSettingsPage.tsx
+++ b/frontend/src/pages/AdminVatSettingsPage.tsx
@@ -43,7 +43,7 @@ export function AdminVatSettingsPage() {
         queryFn: fetchVatRates,
     })
 
-    const vatRates = vatRatesQuery.data?.results ?? EMPTY_VAT_RATES
+    const vatRates = vatRatesQuery.data ?? EMPTY_VAT_RATES
     const today = todayLocalIso()
 
     const activeVatRate = useMemo(

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -132,14 +132,14 @@ export function DashboardPage() {
     )
     const participantInvoicesWithPdf = useMemo(
         () =>
-            (invoicesQuery.data?.results ?? []).filter(
+            (invoicesQuery.data ?? []).filter(
                 (invoice) => ['approved', 'sent', 'paid'].includes(invoice.status) && !!invoice.pdf_url,
             ),
         [invoicesQuery.data],
     )
     const today = useMemo(() => formatIsoDate(new Date()), [])
     const openInvoices = useMemo(
-        () => selectOpenInvoices(invoicesQuery.data?.results ?? []),
+        () => selectOpenInvoices(invoicesQuery.data ?? []),
         [invoicesQuery.data],
     )
     const openOverdueCount = useMemo(

--- a/frontend/src/pages/ImportsPage.tsx
+++ b/frontend/src/pages/ImportsPage.tsx
@@ -102,8 +102,8 @@ export function ImportsPage() {
     const [bulkDeleteTo, setBulkDeleteTo] = useState('')
 
     const scopedZevId = isManagedScope ? selectedZevId : zevId
-    const availableZevs = (zevsQuery.data?.results ?? []).filter((zev) => !isManagedScope || !selectedZevId || zev.id === selectedZevId)
-    const importLogs = (data?.results ?? []).filter((log) => !isManagedScope || !selectedZevId || log.zev === selectedZevId)
+    const availableZevs = (zevsQuery.data ?? []).filter((zev) => !isManagedScope || !selectedZevId || zev.id === selectedZevId)
+    const importLogs = (data ?? []).filter((log) => !isManagedScope || !selectedZevId || log.zev === selectedZevId)
 
     const previewMutation = useMutation({
         mutationFn: previewCsvImport,

--- a/frontend/src/pages/MeteringChartPage.tsx
+++ b/frontend/src/pages/MeteringChartPage.tsx
@@ -131,10 +131,10 @@ export function MeteringChartPage() {
         enabled: true,
     })
 
-    const meteringPoints = (mpQuery.data?.results ?? []).filter(
+    const meteringPoints = (mpQuery.data ?? []).filter(
         (meteringPoint) => !isManagedScope || !selectedZevId || meteringPoint.zev === selectedZevId,
     )
-    const zevNameById = new Map((zevsQuery.data?.results ?? []).map((z) => [z.id, z.name]))
+    const zevNameById = new Map((zevsQuery.data ?? []).map((z) => [z.id, z.name]))
 
     const data: ChartDataPoint[] = chartQuery.data ?? []
 

--- a/frontend/src/pages/ParticipantsPage.tsx
+++ b/frontend/src/pages/ParticipantsPage.tsx
@@ -106,7 +106,7 @@ export function ParticipantsPage() {
     const invitationMutation = useMutation({
         mutationFn: sendParticipantInvitation,
         onSuccess: (result, participantId) => {
-            const participant = data?.results.find((entry) => entry.id === participantId)
+            const participant = data?.find((entry) => entry.id === participantId)
             pushToast(
                 t('pages.participants.messages.invitationSent', {
                     email: participant?.email || '',
@@ -181,8 +181,8 @@ export function ParticipantsPage() {
     if (isLoading) return <div className="card">{t('common.loading')}</div>
     if (isError) return <div className="card error-banner">{t('common.error')}</div>
 
-    const participants = (data?.results ?? []).filter((participant) => !isManagedScope || !selectedZevId || participant.zev === selectedZevId)
-    const ownerIdByZevId = new Map((zevsQuery.data?.results ?? []).map((zev) => [zev.id, zev.owner]))
+    const participants = (data ?? []).filter((participant) => !isManagedScope || !selectedZevId || participant.zev === selectedZevId)
+    const ownerIdByZevId = new Map((zevsQuery.data ?? []).map((zev) => [zev.id, zev.owner]))
     const isOwnerParticipant = (participant: Participant) => ownerIdByZevId.get(participant.zev) === participant.user
     const editingParticipant = participants.find((participant) => participant.id === editingId)
     const todayIso = todayLocalIso()

--- a/frontend/src/pages/ZevListPage.tsx
+++ b/frontend/src/pages/ZevListPage.tsx
@@ -348,14 +348,14 @@ export function ZevListPage() {
     if (isLoading) return <div className="card">{t('common.loading')}</div>
     if (isError) return <div className="card error-banner">{t('common.error')}</div>
 
-    const ownerNameById = new Map((usersQuery.data?.results ?? []).map((candidate) => [candidate.id, `${candidate.first_name} ${candidate.last_name}`]))
-    const linkedParticipantsForTarget = (participantsQuery.data?.results ?? []).filter((participant) => (
+    const ownerNameById = new Map((usersQuery.data ?? []).map((candidate) => [candidate.id, `${candidate.first_name} ${candidate.last_name}`]))
+    const linkedParticipantsForTarget = (participantsQuery.data ?? []).filter((participant) => (
         participant.zev === ownerTargetZev?.id && participant.user != null
     ))
     const ownerCandidates = linkedParticipantsForTarget
         .map((participant) => {
             const linkedUserId = participant.user as number
-            const linkedUser = usersQuery.data?.results.find((candidate) => candidate.id === linkedUserId)
+            const linkedUser = usersQuery.data?.find((candidate) => candidate.id === linkedUserId)
             return {
                 participant,
                 userId: linkedUserId,
@@ -808,7 +808,7 @@ export function ZevListPage() {
                         </tr>
                     </thead>
                     <tbody>
-                        {data?.results.length ? data.results.map((zev) => (
+                        {data?.length ? data.map((zev) => (
                             <tr key={zev.id}>
                                 <td>
                                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>

--- a/frontend/tests/api-pagination.test.ts
+++ b/frontend/tests/api-pagination.test.ts
@@ -100,7 +100,7 @@ describe('fetchAllPages', () => {
     expect(apiMock.history.get).toHaveLength(2)
     const followUp = apiMock.history.get[1].url ?? ''
     expect(followUp.startsWith('http')).toBe(false)
-    expect(followUp.endsWith('/zev/zevs/?page=2&ordering=-created_at')).toBe(true)
+    expect(followUp).toBe('/zev/zevs/?page=2&ordering=-created_at')
   })
 
   it('propagates an error raised mid-walk', async () => {

--- a/frontend/tests/api-pagination.test.ts
+++ b/frontend/tests/api-pagination.test.ts
@@ -1,0 +1,130 @@
+import MockAdapter from 'axios-mock-adapter'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { api } from '../src/lib/api/client'
+import { fetchAllPages } from '../src/lib/api/pagination'
+
+describe('fetchAllPages', () => {
+  let apiMock: MockAdapter
+
+  beforeEach(() => {
+    apiMock = new MockAdapter(api)
+  })
+
+  afterEach(() => {
+    apiMock.restore()
+  })
+
+  it('walks every page until next is null', async () => {
+    apiMock
+      .onGet('/zev/zevs/')
+      .reply(200, { count: 150, next: 'http://testserver/api/v1/zev/zevs/?page=2', previous: null, results: [{ id: 'a' }] })
+    apiMock
+      .onGet('/zev/zevs/?page=2')
+      .reply(200, { count: 150, next: '/zev/zevs/?page=3', previous: '…', results: [{ id: 'b' }] })
+    apiMock
+      .onGet('/zev/zevs/?page=3')
+      .reply(200, { count: 150, next: null, previous: '…', results: [{ id: 'c' }] })
+
+    const result = await fetchAllPages<{ id: string }>('/zev/zevs/')
+
+    expect(result).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
+    expect(apiMock.history.get).toHaveLength(3)
+  })
+
+  it('returns a single page when there is no next link', async () => {
+    apiMock
+      .onGet('/auth/users/')
+      .reply(200, { count: 2, next: null, previous: null, results: [{ id: 1 }, { id: 2 }] })
+
+    const result = await fetchAllPages<{ id: number }>('/auth/users/')
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }])
+    expect(apiMock.history.get).toHaveLength(1)
+  })
+
+  it('returns a bare array as-is when the endpoint is not DRF-paginated', async () => {
+    apiMock
+      .onGet('/tariffs/tariffs/series/')
+      .reply(200, [{ id: 'a' }, { id: 'b' }])
+
+    const result = await fetchAllPages<{ id: string }>('/tariffs/tariffs/series/')
+
+    expect(result).toEqual([{ id: 'a' }, { id: 'b' }])
+    expect(apiMock.history.get).toHaveLength(1)
+  })
+
+  it('passes params through and keeps them on later pages via the embedded next query', async () => {
+    apiMock.onGet('/invoices/invoices/').reply((config) => {
+      expect(config.params).toEqual({ zev_id: 'zev-1', status: 'draft' })
+      return [
+        200,
+        {
+          count: 2,
+          next: 'http://backend:8000/api/v1/invoices/invoices/?zev_id=zev-1&status=draft&page=2',
+          previous: null,
+          results: [{ id: 'inv-1' }],
+        },
+      ]
+    })
+    apiMock
+      .onGet('/invoices/invoices/?zev_id=zev-1&status=draft&page=2')
+      .reply((config) => {
+        // DRF embeds the original filters in `next`; pages 2+ must keep them.
+        expect(config.url).toContain('?zev_id=zev-1&status=draft&page=2')
+        return [200, { count: 2, next: null, previous: '…', results: [{ id: 'inv-2' }] }]
+      })
+
+    const result = await fetchAllPages<{ id: string }>('/invoices/invoices/', {
+      zev_id: 'zev-1',
+      status: 'draft',
+    })
+
+    expect(result).toEqual([{ id: 'inv-1' }, { id: 'inv-2' }])
+  })
+
+  it('rewrites an absolute next link into the base-relative path with its query preserved', async () => {
+    apiMock
+      .onGet('/zev/zevs/')
+      .reply(200, {
+        count: 51,
+        next: 'http://backend:8000/api/v1/zev/zevs/?page=2&ordering=-created_at',
+        previous: null,
+        results: [{ id: 'a' }],
+      })
+    apiMock
+      .onGet('/zev/zevs/?page=2&ordering=-created_at')
+      .reply(200, { count: 51, next: null, previous: '…', results: [{ id: 'b' }] })
+
+    await fetchAllPages<{ id: string }>('/zev/zevs/')
+
+    expect(apiMock.history.get).toHaveLength(2)
+    const followUp = apiMock.history.get[1].url ?? ''
+    expect(followUp.startsWith('http')).toBe(false)
+    expect(followUp.endsWith('/zev/zevs/?page=2&ordering=-created_at')).toBe(true)
+  })
+
+  it('propagates an error raised mid-walk', async () => {
+    apiMock
+      .onGet('/zev/participants/')
+      .reply(200, { count: 100, next: 'http://testserver/api/v1/zev/participants/?page=2', previous: null, results: [{ id: 'a' }] })
+    apiMock
+      .onGet('/zev/participants/?page=2')
+      .reply(500, { detail: 'boom' })
+
+    await expect(fetchAllPages<{ id: string }>('/zev/participants/')).rejects.toMatchObject({
+      response: { status: 500 },
+    })
+  })
+
+  it('enforces the page-request cap against an endless next chain', async () => {
+    // Every page hands back the same next URL — the walker must bail out at the cap.
+    apiMock.onGet(/zev\/metering-points\//).reply(() => [
+      200,
+      { count: 1, next: 'http://testserver/api/v1/zev/metering-points/?page=1', previous: null, results: [{ id: 'a' }] },
+    ])
+
+    await expect(fetchAllPages<{ id: string }>('/zev/metering-points/')).rejects.toThrow(
+      /exceeded 200 page requests/,
+    )
+  })
+})

--- a/frontend/tests/api-zev.test.ts
+++ b/frontend/tests/api-zev.test.ts
@@ -25,7 +25,7 @@ describe('zev api module', () => {
     })
 
     const result = await fetchMeteringPointAssignments()
-    expect(result.results).toEqual([])
+    expect(result).toEqual([])
   })
 
   it('fetches metering point assignments with metering_point filter', async () => {
@@ -35,7 +35,7 @@ describe('zev api module', () => {
     })
 
     const result = await fetchMeteringPointAssignments('mp-1')
-    expect(result.count).toBe(1)
+    expect(result).toEqual([{ id: 'a-1' }])
   })
 
   it('downloads participant contract and revokes generated object URL', async () => {

--- a/frontend/tests/managed-zev-selection.test.ts
+++ b/frontend/tests/managed-zev-selection.test.ts
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchZevs } from '../src/lib/api/zev'
 import { ManagedZevProvider, resolveManagedSelection, useManagedZev } from '../src/lib/managedZev'
-import type { PaginatedResponse, User, UserRole, Zev } from '../src/types/api'
+import type { User, UserRole, Zev } from '../src/types/api'
 
 type IdOnly = Pick<Zev, 'id'>
 
@@ -172,7 +172,7 @@ const userWithRole = (role: UserRole): User => ({
 describe('ManagedZevProvider selection persistence', () => {
     let container: HTMLDivElement
     let root: ReturnType<typeof createRoot>
-    let resolveFetch: ((value: PaginatedResponse<Zev>) => void) | undefined
+    let resolveFetch: ((value: Zev[]) => void) | undefined
 
     beforeEach(() => {
         ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -218,7 +218,7 @@ describe('ManagedZevProvider selection persistence', () => {
 
     function deferFetch() {
         vi.mocked(fetchZevs).mockImplementation(
-            () => new Promise<PaginatedResponse<Zev>>((resolve) => { resolveFetch = resolve }),
+            () => new Promise<Zev[]>((resolve) => { resolveFetch = resolve }),
         )
     }
 
@@ -229,12 +229,7 @@ describe('ManagedZevProvider selection persistence', () => {
      */
     function resolveTwoZevs() {
         return act(async () => {
-            resolveFetch?.({
-                count: 2,
-                next: null,
-                previous: null,
-                results: [fullZev('own1', 1), fullZev('own2', 1)],
-            })
+            resolveFetch?.([fullZev('own1', 1), fullZev('own2', 1)])
             await new Promise((resolve) => setTimeout(resolve, 0))
             await new Promise((resolve) => setTimeout(resolve, 0))
         })


### PR DESCRIPTION
## Summary

DRF paginates every list endpoint at `PAGE_SIZE=50` and none of the frontend list fetchers sent a `page` param, so ZEVs, participants, metering points, invoices, import logs, users, VAT rates and API keys silently showed only the first 50 rows — including the global ZEV selector.

- Adds `fetchAllPages` in `frontend/src/lib/api/pagination.ts`: walks each endpoint's `next` link until exhausted (capped at 200 page requests) and returns the complete set; a non-paginated endpoint that returns a bare array is passed through as-is. DRF builds `next` from the request Host, which behind the dev proxy is an address the browser cannot reach, so each hop is rewritten to a base-relative URL and stays on the `api` axios instance (proxy route and 401-refresh intact).
- `fetchZevs`, `fetchParticipants`, `fetchMeteringPoints`, `fetchInvoices`, `fetchUsers`, `fetchVatRates`, `fetchImportLogs`, `fetchApiKeys`, `fetchAllApiKeys`, `fetchOAuthProviderConfigs` and `fetchMeteringPointAssignments` now return arrays; every consumer drops the `.results` unwrap.
- Audit events intentionally keep true server-side pagination.

## Linked spec

- No spec needed: isolated frontend bugfix; backend API behavior unchanged

## Validation

- Frontend tests run: `npm run test:unit` — 163 tests passed (24 files), including 7 new `fetchAllPages` tests (multi-page walk, single page, bare-array passthrough, params forwarding, next-link rewriting, error propagation, page cap)
- Frontend build run: `npm run build` — success
- Backend tests run: not run (no backend changes)
- Manual checks: not done
- Screenshots: N/A — no visual change, lists now show complete data

## Checklist

- N/A: Spec updated/linked (isolated frontend bugfix, no documented behavior changed)
- N/A: ADR updated/linked for architecture decisions
- N/A: Backend and frontend updated together (frontend-only change)