### PR TITLE
refactor(ui): replace hand-rolled tab strips with Mantine Tabs

### DIFF
--- a/docs/specs/2026-04-frontend-management-page-design.md
+++ b/docs/specs/2026-04-frontend-management-page-design.md
@@ -50,7 +50,7 @@ in the frontend.
 ### Out of scope
 
 - Marketing or public-auth screens (`LoginPage`, verification, OAuth callback)
-- Admin settings/editor screens that are document-like rather than CRUD management lists
+- Admin settings/editor screens that are document-like rather than CRUD management lists (the admin email/PDF template editors and the admin system settings tabs are covered as tab examples in §7.2)
 - Backend API, serializer, permission, or data model changes
 - A separate component library extraction or token system split from `index.css`
 
@@ -94,6 +94,7 @@ defined by shared frontend primitives and CSS contracts.
 | `frontend/src/components/FormModal.tsx` | `FormModal` | Generic modal shell for CRUD forms and small workflow dialogs. |
 | `frontend/src/components/BillingPeriodSelector.tsx` | `BillingPeriodSelector` | Specialized period-navigation control for invoice workflows; uses the same button language as management-page actions. |
 | `frontend/src/components/StatCard.tsx` | `StatCard` | Summary-stat card for page-level counts and metrics. Renders a `stat-label`, an `h3` value, and an optional muted `hint`. Pages must use it instead of hand-rolled `.stat-card` markup so summary stats stay visually consistent. |
+| `@mantine/core` `Tabs` (`classNames` `app-tabs`/`app-tabs-list`/`app-tabs-tab`) | `Tabs`, `Tabs.List`, `Tabs.Tab`, `Tabs.Panel` | Mantine Tabs + the `app-tabs` classNames for mutually exclusive, document-like views. Mantine v9 emits hashed classes only, so the hooks must be passed via `classNames={{ root: 'app-tabs', list: 'app-tabs-list', tab: 'app-tabs-tab' }}`. All tab content renders as `Tabs.Panel` inside the same `Tabs` root (root `keepMounted={false}` when inactive content must unmount; shared controls may sit between list and panels) so every tab's `aria-controls` resolves to a real `tabpanel`. No hand-rolled strips. |
 
 ### 4.2 CSS contracts
 
@@ -109,6 +110,7 @@ language and should be reused instead of ad hoc page-local CSS when possible:
 | `.button`, `.button-secondary`, `.button-danger`, `.button-compact` | Shared button system (flat `var(--interactive)` fill since SPEC-2026-08-ui-redesign-pdf-style Phase 2; hover `var(--interactive-hover)`) |
 | `.badge`, `.badge-neutral`, `.badge-info`, `.badge-success`, `.badge-danger`, `.badge-warning` (+ invoice workflow variants `.badge-draft/.badge-approved/.badge-sent/.badge-paid/.badge-cancelled`) | Small semantic status/category labels — filled desaturated fills from the generated `--status-*` semantics, never gold-on-white |
 | `.actions-row`, `.actions-row-wrap`, `.actions-row-end` | Inline action layouts |
+| `.app-tabs`, `.app-tabs-list`, `.app-tabs-tab` | Token styling for Mantine `Tabs`: root grid rhythm (1.5rem gap), 1rem tab gap, muted labels with a 2px `--interactive` underline when active; applied via the `classNames` prop. |
 | `.participant-*`, `.metering-*`, `.tariff-*`, `.invoice-*` | Page-family-specific structural patterns that are already in active use |
 
 Tables additionally follow the operational contract introduced by the UI
@@ -199,7 +201,10 @@ Default rule:
 Current application:
 
 - `TariffsPage` uses category sections for `energy`, `grid_fees`, `levies`, and `metering`.
-- `AdminEmailTemplatesPage` is a valid tab example because each tab is a separate template editor document.
+- `MeteringChartPage` uses tabs for chart versus quality views over the same period selection.
+- `AdminEmailTemplatesPage` and `AdminPdfTemplatesPage` are valid tab examples because each tab is a separate template editor document.
+- Tab strips use Mantine `Tabs` with the `.app-tabs` contract and render their content as `Tabs.Panel` inside the same root; hand-rolled tab strips are not permitted.
+- `AdminSystemSettingsPage` predates this contract (default-styled `Tabs` embedded in a card, panels rendered outside the root) and is pending migration.
 
 ### 7.3 Action hierarchy
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2794,3 +2794,41 @@ h3 {
   margin: 0 0 0.5rem;
   font-size: 0.85rem;
 }
+
+/* ── Mantine Tabs (.app-tabs) ────────────────────────────────────────────── */
+
+/* Mantine v9 only emits hashed classes, so these hooks are applied via the
+   Tabs classNames prop: root app-tabs, list app-tabs-list, tab app-tabs-tab. */
+.app-tabs {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.app-tabs-list {
+  gap: 1rem;
+}
+
+.app-tabs-list::before {
+  border-color: var(--border-default);
+}
+
+.app-tabs-tab {
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.app-tabs-tab:hover {
+  background-color: transparent;
+  color: var(--text-primary);
+}
+
+.app-tabs-tab:not([data-active]):hover {
+  border-color: transparent;
+}
+
+.app-tabs-tab[data-active] {
+  color: var(--text-primary);
+  font-weight: 600;
+  border-bottom-color: var(--interactive);
+}

--- a/frontend/src/pages/AdminEmailTemplatesPage.tsx
+++ b/frontend/src/pages/AdminEmailTemplatesPage.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Tabs } from '@mantine/core'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -193,37 +194,32 @@ export function AdminEmailTemplatesPage() {
                 </p>
             </header>
 
-            <div style={{ display: 'flex', gap: '1rem', borderBottom: '1px solid var(--border-default)', marginBottom: '1.5rem' }}>
-                {tabs.map((tab) => (
-                    <button
-                        key={tab.key}
-                        onClick={() => setActiveTab(tab.key)}
-                        style={{
-                            background: 'transparent',
-                            color: activeTab === tab.key ? 'var(--text-primary)' : 'var(--text-muted)',
-                            padding: '0.75rem 1rem',
-                            fontSize: '1rem',
-                            fontWeight: activeTab === tab.key ? 600 : 400,
-                            cursor: 'pointer',
-                            border: 'none',
-                            borderBlockEnd: activeTab === tab.key ? '2px solid var(--interactive)' : 'none',
-                        }}
-                    >
-                        {tab.label}
-                    </button>
-                ))}
-            </div>
+            <Tabs
+                classNames={{ root: 'app-tabs', list: 'app-tabs-list', tab: 'app-tabs-tab' }}
+                value={activeTab}
+                keepMounted={false}
+                onChange={(value) => {
+                    if (value) setActiveTab(value as TemplateKey)
+                }}
+            >
+                <Tabs.List aria-label={t('admin.emailTemplates.title')}>
+                    {tabs.map((tab) => (
+                        <Tabs.Tab key={tab.key} value={tab.key}>
+                            {tab.label}
+                        </Tabs.Tab>
+                    ))}
+                </Tabs.List>
 
-            {tabs.map((tab) =>
-                activeTab === tab.key ? (
-                    <EmailTemplateEditor
-                        key={tab.key}
-                        templateKey={tab.key}
-                        title={tab.label}
-                        fields={tab.fields}
-                    />
-                ) : null,
-            )}
+                {tabs.map((tab) => (
+                    <Tabs.Panel key={tab.key} value={tab.key}>
+                        <EmailTemplateEditor
+                            templateKey={tab.key}
+                            title={tab.label}
+                            fields={tab.fields}
+                        />
+                    </Tabs.Panel>
+                ))}
+            </Tabs>
         </div>
     )
 }

--- a/frontend/src/pages/AdminPdfTemplatesPage.tsx
+++ b/frontend/src/pages/AdminPdfTemplatesPage.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Tabs } from '@mantine/core'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -420,22 +421,6 @@ export function AdminPdfTemplatesPage() {
         annual_statement: t('admin.annualStatementTemplate'),
     }
 
-    const handleTabKeyDown = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
-            const index = PDF_TEMPLATE_TABS.indexOf(activeTab)
-            let next: number | null = null
-            if (event.key === 'ArrowRight') next = (index + 1) % PDF_TEMPLATE_TABS.length
-            else if (event.key === 'ArrowLeft') next = (index - 1 + PDF_TEMPLATE_TABS.length) % PDF_TEMPLATE_TABS.length
-            else if (event.key === 'Home') next = 0
-            else if (event.key === 'End') next = PDF_TEMPLATE_TABS.length - 1
-            if (next === null) return
-            event.preventDefault()
-            setActiveTab(PDF_TEMPLATE_TABS[next])
-            document.getElementById(`pdf-template-tab-${PDF_TEMPLATE_TABS[next]}`)?.focus()
-        },
-        [activeTab],
-    )
-
     const invoiceFieldGroups: FieldGroup[] = [
         {
             title: t('admin.fields.invoiceObject'),
@@ -782,44 +767,23 @@ export function AdminPdfTemplatesPage() {
                 </p>
             </header>
 
-            <div
-                role="tablist"
-                aria-label={t('admin.pdfTemplates')}
-                onKeyDown={handleTabKeyDown}
-                style={{ display: 'flex', gap: '1rem', borderBottom: '1px solid var(--border-default)', marginBottom: '1.5rem' }}
+            <Tabs
+                classNames={{ root: 'app-tabs', list: 'app-tabs-list', tab: 'app-tabs-tab' }}
+                value={activeTab}
+                keepMounted={false}
+                onChange={(value) => {
+                    if (value) setActiveTab(value as PdfTemplateTab)
+                }}
             >
-                {PDF_TEMPLATE_TABS.map((tab) => (
-                    <button
-                        key={tab}
-                        type="button"
-                        role="tab"
-                        id={`pdf-template-tab-${tab}`}
-                        aria-selected={activeTab === tab}
-                        aria-controls={`pdf-template-panel-${tab}`}
-                        tabIndex={activeTab === tab ? 0 : -1}
-                        onClick={() => setActiveTab(tab)}
-                        style={{
-                            background: 'transparent',
-                            color: activeTab === tab ? 'var(--text-primary)' : 'var(--text-muted)',
-                            padding: '0.75rem 1rem',
-                            fontSize: '1rem',
-                            fontWeight: activeTab === tab ? 600 : 400,
-                            cursor: 'pointer',
-                            border: 'none',
-                            borderBlockEnd: activeTab === tab ? '2px solid var(--interactive)' : 'none',
-                        }}
-                    >
-                        {tabLabels[tab]}
-                    </button>
-                ))}
-            </div>
+                <Tabs.List aria-label={t('admin.pdfTemplates')}>
+                    {PDF_TEMPLATE_TABS.map((tab) => (
+                        <Tabs.Tab key={tab} value={tab}>
+                            {tabLabels[tab]}
+                        </Tabs.Tab>
+                    ))}
+                </Tabs.List>
 
-            {activeTab === 'invoice' && (
-                <div
-                    id="pdf-template-panel-invoice"
-                    role="tabpanel"
-                    aria-labelledby="pdf-template-tab-invoice"
-                >
+                <Tabs.Panel value="invoice">
                     <TemplateEditor
                         data={invoiceTemplateQuery.data}
                         isLoading={invoiceTemplateQuery.isLoading}
@@ -832,15 +796,9 @@ export function AdminPdfTemplatesPage() {
                         fieldGroups={invoiceFieldGroups}
                         templateType="invoice"
                     />
-                </div>
-            )}
+                </Tabs.Panel>
 
-            {activeTab === 'contract' && (
-                <div
-                    id="pdf-template-panel-contract"
-                    role="tabpanel"
-                    aria-labelledby="pdf-template-tab-contract"
-                >
+                <Tabs.Panel value="contract">
                     <TemplateEditor
                         data={contractTemplateQuery.data}
                         isLoading={contractTemplateQuery.isLoading}
@@ -853,15 +811,9 @@ export function AdminPdfTemplatesPage() {
                         fieldGroups={contractFieldGroups}
                         templateType="contract"
                     />
-                </div>
-            )}
+                </Tabs.Panel>
 
-            {activeTab === 'annual_statement' && (
-                <div
-                    id="pdf-template-panel-annual_statement"
-                    role="tabpanel"
-                    aria-labelledby="pdf-template-tab-annual_statement"
-                >
+                <Tabs.Panel value="annual_statement">
                     <TemplateEditor
                         data={annualStatementTemplateQuery.data}
                         isLoading={annualStatementTemplateQuery.isLoading}
@@ -874,8 +826,8 @@ export function AdminPdfTemplatesPage() {
                         fieldGroups={annualStatementFieldGroups}
                         templateType="annual_statement"
                     />
-                </div>
-            )}
+                </Tabs.Panel>
+            </Tabs>
         </div>
     )
 }

--- a/frontend/src/pages/MeteringChartPage.tsx
+++ b/frontend/src/pages/MeteringChartPage.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { Tabs } from '@mantine/core'
 import { useCallback, useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
@@ -96,8 +97,7 @@ export function MeteringChartPage() {
     const isManagedScope = user?.role === 'admin' || user?.role === 'zev_owner'
     const interval: BillingInterval = (selectedZev?.billing_interval as BillingInterval) ?? 'monthly'
 
-    // Tab state
-    const [activeTab, setActiveTab] = useState<'chart' | 'quality'>('chart')
+    const activeTab = searchParams.get('tab') === 'quality' ? 'quality' : 'chart'
 
     // Controlled state
     const [selectedMpId, setSelectedMpId] = useState<string>(searchParams.get('metering_point') ?? '')
@@ -142,15 +142,28 @@ export function MeteringChartPage() {
     const totalOut = data.reduce((sum, d) => sum + d.out_kwh, 0)
     const hasOut = data.some((d) => d.out_kwh > 0)
 
-    // Sync the selected MP to the URL
+    // Sync the selected metering point to the URL
     const handleMpChange = useCallback((id: string) => {
         setSelectedMpId(id)
+        const next = new URLSearchParams(searchParams)
         if (id) {
-            setSearchParams({ metering_point: id }, { replace: true })
+            next.set('metering_point', id)
         } else {
-            setSearchParams({}, { replace: true })
+            next.delete('metering_point')
         }
-    }, [setSearchParams])
+        setSearchParams(next, { replace: true })
+    }, [searchParams, setSearchParams])
+
+    // ?tab=quality makes the quality view shareable
+    const handleTabChange = (value: string | null) => {
+        const next = new URLSearchParams(searchParams)
+        if (value === 'quality') {
+            next.set('tab', 'quality')
+        } else {
+            next.delete('tab')
+        }
+        setSearchParams(next, { replace: true })
+    }
 
     const selectedMp = meteringPoints.find((m) => m.id === selectedMpId)
 
@@ -176,385 +189,354 @@ export function MeteringChartPage() {
                 <p className="muted">{t('pages.meteringData.description')}</p>
             </header>
 
-            {/* ── Tabs ──────────────────────────────────────────────────────────── */}
-            <div style={{ display: 'flex', gap: '1rem', borderBottom: '1px solid var(--border-default)', marginBottom: '1.5rem' }}>
-                <button
-                    onClick={() => setActiveTab('chart')}
-                    style={{
-                        background: activeTab === 'chart' ? 'transparent' : 'transparent',
-                        color: activeTab === 'chart' ? 'var(--text-primary)' : 'var(--text-muted)',
-                        borderBottom: activeTab === 'chart' ? '2px solid var(--interactive)' : 'none',
-                        padding: '0.75rem 1rem',
-                        fontSize: '1rem',
-                        fontWeight: activeTab === 'chart' ? 600 : 400,
-                        cursor: 'pointer',
-                        border: 'none',
-                    }}
-                >
-                    {t('nav.meteringData')}
-                </button>
-                <button
-                    onClick={() => setActiveTab('quality')}
-                    style={{
-                        background: activeTab === 'quality' ? 'transparent' : 'transparent',
-                        color: activeTab === 'quality' ? 'var(--text-primary)' : 'var(--text-muted)',
-                        borderBottom: activeTab === 'quality' ? '2px solid var(--interactive)' : 'none',
-                        padding: '0.75rem 1rem',
-                        fontSize: '1rem',
-                        fontWeight: activeTab === 'quality' ? 600 : 400,
-                        cursor: 'pointer',
-                        border: 'none',
-                    }}
-                >
-                    {t('nav.meteringDataQuality')}
-                </button>
-            </div>
-
-            {/* ── Controls ──────────────────────────────────────────────────────── */}
-            <div
-                className="card"
-                style={{
-                    display: 'grid',
-                    gap: '1rem',
-                }}
+            <Tabs
+                classNames={{ root: 'app-tabs', list: 'app-tabs-list', tab: 'app-tabs-tab' }}
+                value={activeTab}
+                keepMounted={false}
+                onChange={handleTabChange}
             >
-                <PeriodSelector
-                    interval={interval}
-                    from={period.from}
-                    to={period.to}
-                    onChange={setPeriod}
-                />
+                <Tabs.List aria-label={t('pages.meteringData.title')}>
+                    <Tabs.Tab value="chart">{t('nav.meteringData')}</Tabs.Tab>
+                    <Tabs.Tab value="quality">{t('nav.meteringDataQuality')}</Tabs.Tab>
+                </Tabs.List>
 
-                {activeTab === 'chart' && (
-                    <div
-                        className="inline-form"
-                        style={{
-                            display: 'grid',
-                            gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-                            gap: '1rem',
-                            alignItems: 'end',
-                        }}
-                    >
-                        <label>
-                            <span>{t('pages.meteringData.meteringPoint')}</span>
-                            <select
-                                value={selectedMpId}
-                                onChange={(e) => handleMpChange(e.target.value)}
-                            >
-                                <option value="">{t('pages.meteringData.selectMeteringPoint')}</option>
-                                {meteringPoints.map((mp) => (
-                                    <option key={mp.id} value={mp.id}>
-                                        {mp.meter_id}
-                                        {zevNameById.has(mp.zev) ? ` (${zevNameById.get(mp.zev)})` : ''}
-                                    </option>
-                                ))}
-                            </select>
-                        </label>
+                <div
+                    className="card"
+                    style={{
+                        display: 'grid',
+                        gap: '1rem',
+                    }}
+                >
+                    <PeriodSelector
+                        interval={interval}
+                        from={period.from}
+                        to={period.to}
+                        onChange={setPeriod}
+                    />
 
-                        <label>
-                            <span>{t('pages.meteringData.resolution')}</span>
-                            <select
-                                value={bucket}
-                                onChange={(e) => setBucket(e.target.value as 'day' | 'hour' | 'month')}
-                            >
-                                <option value="hour">{t('pages.meteringData.resolutions.hour')}</option>
-                                <option value="day">{t('pages.meteringData.resolutions.day')}</option>
-                                <option value="month">{t('pages.meteringData.resolutions.month')}</option>
-                            </select>
-                        </label>
-                    </div>
-                )}
+                    {activeTab === 'chart' && (
+                        <div
+                            className="inline-form"
+                            style={{
+                                display: 'grid',
+                                gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+                                gap: '1rem',
+                                alignItems: 'end',
+                            }}
+                        >
+                            <label>
+                                <span>{t('pages.meteringData.meteringPoint')}</span>
+                                <select
+                                    value={selectedMpId}
+                                    onChange={(e) => handleMpChange(e.target.value)}
+                                >
+                                    <option value="">{t('pages.meteringData.selectMeteringPoint')}</option>
+                                    {meteringPoints.map((mp) => (
+                                        <option key={mp.id} value={mp.id}>
+                                            {mp.meter_id}
+                                            {zevNameById.has(mp.zev) ? ` (${zevNameById.get(mp.zev)})` : ''}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
 
-                {activeTab === 'quality' && (
-                    <div
-                        className="inline-form"
-                        style={{
-                            display: 'grid',
-                            gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-                            gap: '1rem',
-                            alignItems: 'end',
-                        }}
-                    >
-                        <label>
-                            <span>{t('pages.meteringData.meterIdOptional')}</span>
-                            <select
-                                value={selectedMpId}
-                                onChange={(e) => handleMpChange(e.target.value)}
-                            >
-                                <option value="">{t('pages.meteringData.allMeteringPoints')}</option>
-                                {meteringPoints.map((mp) => (
-                                    <option key={mp.id} value={mp.id}>
-                                        {mp.meter_id}
-                                        {zevNameById.has(mp.zev) ? ` (${zevNameById.get(mp.zev)})` : ''}
-                                    </option>
-                                ))}
-                            </select>
-                        </label>
-                    </div>
-                )}
-            </div>
-
-            {/* ── Chart Tab ─────────────────────────────────────────────────────── */}
-            {activeTab === 'chart' && (
-                <>
-                    {/* ── No selection placeholder ──────────────────────────────────────── */}
-                    {!selectedMpId && (
-                        <div className="card" style={{ textAlign: 'center', padding: '3rem 1rem', color: 'var(--text-muted)' }}>
-                            {t('pages.meteringData.noPointSelected')}
+                            <label>
+                                <span>{t('pages.meteringData.resolution')}</span>
+                                <select
+                                    value={bucket}
+                                    onChange={(e) => setBucket(e.target.value as 'day' | 'hour' | 'month')}
+                                >
+                                    <option value="hour">{t('pages.meteringData.resolutions.hour')}</option>
+                                    <option value="day">{t('pages.meteringData.resolutions.day')}</option>
+                                    <option value="month">{t('pages.meteringData.resolutions.month')}</option>
+                                </select>
+                            </label>
                         </div>
                     )}
 
-                    {/* ── Loading / error ───────────────────────────────────────────────── */}
-                    {selectedMpId && chartQuery.isLoading && (
-                        <div className="card" style={{ textAlign: 'center', padding: '2rem' }}>
-                            {t('pages.meteringData.loadingChart')}
+                    {activeTab === 'quality' && (
+                        <div
+                            className="inline-form"
+                            style={{
+                                display: 'grid',
+                                gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+                                gap: '1rem',
+                                alignItems: 'end',
+                            }}
+                        >
+                            <label>
+                                <span>{t('pages.meteringData.meterIdOptional')}</span>
+                                <select
+                                    value={selectedMpId}
+                                    onChange={(e) => handleMpChange(e.target.value)}
+                                >
+                                    <option value="">{t('pages.meteringData.allMeteringPoints')}</option>
+                                    {meteringPoints.map((mp) => (
+                                        <option key={mp.id} value={mp.id}>
+                                            {mp.meter_id}
+                                            {zevNameById.has(mp.zev) ? ` (${zevNameById.get(mp.zev)})` : ''}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
                         </div>
                     )}
-                    {selectedMpId && chartQuery.isError && (
-                        <div className="card error-banner">{t('pages.meteringData.chartError')}</div>
-                    )}
+                </div>
 
-                    {/* ── Results ───────────────────────────────────────────────────────── */}
-                    {selectedMpId && chartQuery.isSuccess && (
-                        <>
-                            {/* Summary stats */}
-                            <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
-                                {selectedMp && (
-                                    <StatBadge
-                                        label={t('pages.meteringData.stats.meterId')}
-                                        value={selectedMp.meter_id}
-                                        color="var(--text-primary)"
-                                    />
-                                )}
-                                <StatBadge
-                                    label={t('pages.meteringData.stats.totalConsumption')}
-                                    value={`${totalIn.toFixed(2)} kWh`}
-                                    color={PROD_COLORS[0]}
-                                />
-                                {hasOut && (
-                                    <StatBadge
-                                        label={t('pages.meteringData.stats.totalFeedIn')}
-                                        value={`${totalOut.toFixed(2)} kWh`}
-                                        color={CONS_COLORS[0]}
-                                    />
-                                )}
-                                <StatBadge
-                                    label={t('pages.meteringData.stats.dataPoints')}
-                                    value={String(data.length)}
-                                    color="var(--text-muted)"
-                                />
+                <Tabs.Panel value="chart">
+                    <div className="page-stack">
+                        {!selectedMpId && (
+                            <div className="card" style={{ textAlign: 'center', padding: '3rem 1rem', color: 'var(--text-muted)' }}>
+                                {t('pages.meteringData.noPointSelected')}
                             </div>
+                        )}
 
-                            {data.length === 0 ? (
-                                <div className="card" style={{ textAlign: 'center', padding: '2rem', color: 'var(--text-muted)' }}>
-                                    {t('pages.meteringData.noReadings')}
+                        {selectedMpId && chartQuery.isLoading && (
+                            <div className="card" style={{ textAlign: 'center', padding: '2rem' }}>
+                                {t('pages.meteringData.loadingChart')}
+                            </div>
+                        )}
+                        {selectedMpId && chartQuery.isError && (
+                            <div className="card error-banner">{t('pages.meteringData.chartError')}</div>
+                        )}
+
+                        {selectedMpId && chartQuery.isSuccess && (
+                            <>
+                                <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+                                    {selectedMp && (
+                                        <StatBadge
+                                            label={t('pages.meteringData.stats.meterId')}
+                                            value={selectedMp.meter_id}
+                                            color="var(--text-primary)"
+                                        />
+                                    )}
+                                    <StatBadge
+                                        label={t('pages.meteringData.stats.totalConsumption')}
+                                        value={`${totalIn.toFixed(2)} kWh`}
+                                        color={PROD_COLORS[0]}
+                                    />
+                                    {hasOut && (
+                                        <StatBadge
+                                            label={t('pages.meteringData.stats.totalFeedIn')}
+                                            value={`${totalOut.toFixed(2)} kWh`}
+                                            color={CONS_COLORS[0]}
+                                        />
+                                    )}
+                                    <StatBadge
+                                        label={t('pages.meteringData.stats.dataPoints')}
+                                        value={String(data.length)}
+                                        color="var(--text-muted)"
+                                    />
                                 </div>
-                            ) : (
-                                <div className="card" style={{ padding: '1.5rem' }}>
-                                    <ResponsiveContainer width="100%" height={380}>
-                                        <BarChart
-                                            data={data}
-                                            margin={{ top: 8, right: 16, left: 0, bottom: 8 }}
-                                            barCategoryGap="20%"
-                                        >
-                                            <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                                            <XAxis
-                                                dataKey="bucket"
-                                                tickFormatter={tickFormatter}
-                                                tick={{ fontSize: 11 }}
-                                                tickLine={false}
-                                                interval="preserveStartEnd"
-                                            />
-                                            <YAxis
-                                                unit=" kWh"
-                                                tick={{ fontSize: 11 }}
-                                                tickLine={false}
-                                                axisLine={false}
-                                                width={72}
-                                            />
-                                            <Tooltip
-                                                content={<CustomTooltip resolution={bucket} settings={settings} />}
-                                            />
-                                            <Legend />
-                                            <Bar
-                                                dataKey="in_kwh"
-                                                name={t('pages.meteringData.series.consumption')}
-                                                fill={PROD_COLORS[0]}
-                                                radius={[3, 3, 0, 0]}
-                                                maxBarSize={48}
-                                            />
-                                            {hasOut && (
+
+                                {data.length === 0 ? (
+                                    <div className="card" style={{ textAlign: 'center', padding: '2rem', color: 'var(--text-muted)' }}>
+                                        {t('pages.meteringData.noReadings')}
+                                    </div>
+                                ) : (
+                                    <div className="card" style={{ padding: '1.5rem' }}>
+                                        <ResponsiveContainer width="100%" height={380}>
+                                            <BarChart
+                                                data={data}
+                                                margin={{ top: 8, right: 16, left: 0, bottom: 8 }}
+                                                barCategoryGap="20%"
+                                            >
+                                                <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                                                <XAxis
+                                                    dataKey="bucket"
+                                                    tickFormatter={tickFormatter}
+                                                    tick={{ fontSize: 11 }}
+                                                    tickLine={false}
+                                                    interval="preserveStartEnd"
+                                                />
+                                                <YAxis
+                                                    unit=" kWh"
+                                                    tick={{ fontSize: 11 }}
+                                                    tickLine={false}
+                                                    axisLine={false}
+                                                    width={72}
+                                                />
+                                                <Tooltip
+                                                    content={<CustomTooltip resolution={bucket} settings={settings} />}
+                                                />
+                                                <Legend />
                                                 <Bar
-                                                    dataKey="out_kwh"
-                                                    name={t('pages.meteringData.series.feedIn')}
-                                                    fill={CONS_COLORS[0]}
+                                                    dataKey="in_kwh"
+                                                    name={t('pages.meteringData.series.consumption')}
+                                                    fill={PROD_COLORS[0]}
                                                     radius={[3, 3, 0, 0]}
                                                     maxBarSize={48}
                                                 />
-                                            )}
-                                        </BarChart>
-                                    </ResponsiveContainer>
-                                </div>
-                            )}
-
-                            <RawMeteringTable
-                                meteringPointId={selectedMpId}
-                                dateFrom={period.from}
-                                dateTo={period.to}
-                                hasOut={hasOut}
-                            />
-                        </>
-                    )}
-                </>
-            )}
-
-            {/* ── Data Quality Tab ──────────────────────────────────────────────── */}
-            {activeTab === 'quality' && (
-                <>
-                    {qualityQuery.isLoading && (
-                        <div className="card" style={{ textAlign: 'center', padding: '2rem' }}>
-                            {t('common.loading')}
-                        </div>
-                    )}
-                    {qualityQuery.isError && (
-                        <div className="card error-banner">{formatApiError(qualityQuery.error as any)}</div>
-                    )}
-                    {qualityQuery.isSuccess && qualityQuery.data && (
-                        <>
-                            {qualityQuery.data.metering_points.length === 0 ? (
-                                <div className="card" style={{ textAlign: 'center', padding: '2rem', color: 'var(--text-muted)' }}>
-                                    {t('meteringDataQuality.noData')}
-                                </div>
-                            ) : (
-                                <>
-                                    {/* Summary cards */}
-                                    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '1rem', marginBottom: '1.5rem' }}>
-                                        <div style={{ background: 'var(--success-100)', border: '1px solid var(--success-200)', borderRadius: '8px', padding: '1rem', textAlign: 'center' }}>
-                                            <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--success-700)' }}>
-                                                {qualityQuery.data.metering_points.filter((mp) => mp.severity === 'green').length}
-                                            </div>
-                                            <div style={{ fontSize: '0.875rem', color: 'var(--brand-mid)' }}>{t('meteringDataQuality.severityGreen')}</div>
-                                        </div>
-                                        <div style={{ background: 'var(--warning-100)', border: '1px solid var(--warning-200)', borderRadius: '8px', padding: '1rem', textAlign: 'center' }}>
-                                            <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--warning-800)' }}>
-                                                {qualityQuery.data.metering_points.filter((mp) => mp.severity === 'yellow').length}
-                                            </div>
-                                            <div style={{ fontSize: '0.875rem', color: 'var(--warning-800)' }}>{t('meteringDataQuality.severityYellow')}</div>
-                                        </div>
-                                        <div style={{ background: 'var(--danger-100)', border: '1px solid var(--danger-300)', borderRadius: '8px', padding: '1rem', textAlign: 'center' }}>
-                                            <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--danger-700)' }}>
-                                                {qualityQuery.data.metering_points.filter((mp) => mp.severity === 'red').length}
-                                            </div>
-                                            <div style={{ fontSize: '0.875rem', color: 'var(--danger-600)' }}>{t('meteringDataQuality.severityRed')}</div>
-                                        </div>
+                                                {hasOut && (
+                                                    <Bar
+                                                        dataKey="out_kwh"
+                                                        name={t('pages.meteringData.series.feedIn')}
+                                                        fill={CONS_COLORS[0]}
+                                                        radius={[3, 3, 0, 0]}
+                                                        maxBarSize={48}
+                                                    />
+                                                )}
+                                            </BarChart>
+                                        </ResponsiveContainer>
                                     </div>
+                                )}
 
-                                    {/* Quality table */}
-                                    <div className="table-card">
-                                        <table>
-                                            <thead>
-                                                <tr>
-                                                    <th>{t('meteringDataQuality.meterId')}</th>
-                                                    <th>{t('meteringDataQuality.participant')}</th>
-                                                    <th>{t('meteringDataQuality.dataCompleteness')}</th>
-                                                    <th>{t('meteringDataQuality.status')}</th>
-                                                    <th>{t('meteringDataQuality.gaps')}</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                {qualityQuery.data.metering_points.map((mp) => (
-                                                    <tr key={mp.id}>
-                                                        <td style={{ fontFamily: 'monospace', fontSize: '0.9em' }}>{mp.meter_id}</td>
-                                                        <td>{mp.participant_name}</td>
-                                                        <td>
-                                                            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                                                                <div style={{ width: '80px', height: '20px', background: 'var(--line-subtle)', borderRadius: '4px', overflow: 'hidden' }}>
-                                                                    <div
-                                                                        style={{
-                                                                            height: '100%',
-                                                                            background:
-                                                                                mp.severity === 'green'
-                                                                                    ? PROD_COLORS[0]
-                                                                                    : mp.severity === 'yellow'
-                                                                                      ? CHART_GRID
-                                                                                      : NEGATIVE_COLOR,
-                                                                            width: `${mp.data_completeness}%`,
-                                                                        }}
-                                                                    />
-                                                                </div>
-                                                                <span style={{ fontSize: '0.875rem', fontWeight: 'bold' }}>{mp.data_completeness}%</span>
-                                                            </div>
-                                                        </td>
-                                                        <td>
-                                                            <span
-                                                                style={{
-                                                                    display: 'inline-block',
-                                                                    padding: '0.25rem 0.75rem',
-                                                                    borderRadius: '4px',
-                                                                    fontSize: '0.875rem',
-                                                                    fontWeight: 'bold',
-                                                                    background:
-                                                                        mp.severity === 'green'
-                                                                                    ? 'var(--success-100)'
-                                                                                    : mp.severity === 'yellow'
-                                                                                      ? 'var(--warning-100)'
-                                                                                      : 'var(--danger-100)',
-                                                                    color:
-                                                                        mp.severity === 'green'
-                                                                                    ? 'var(--success-700)'
-                                                                                    : mp.severity === 'yellow'
-                                                                                      ? 'var(--warning-800)'
-                                                                                      : 'var(--danger-700)',
-                                                                }}
-                                                            >
-                                                                {t(`meteringDataQuality.severity${mp.severity.charAt(0).toUpperCase() + mp.severity.slice(1)}`)}
-                                                            </span>
-                                                            {mp.assignment_overlap && (
-                                                                <div className="metering-dq-warning">
-                                                                    {t('meteringDataQuality.assignmentOverlapWarning')}
-                                                                </div>
-                                                            )}
-                                                            {mp.unassigned_readings > 0 && (
-                                                                <div className="metering-dq-warning">
-                                                                    {t('meteringDataQuality.unassignedWarning', { readings: mp.unassigned_readings, days: mp.unassigned_days })}
-                                                                </div>
-                                                            )}
-                                                        </td>
-                                                        <td style={{ fontSize: '0.875rem' }}>
-                                                            {mp.gaps.length === 0 ? (
-                                                                <span style={{ color: 'var(--success-600)' }}>{t('meteringDataQuality.noGaps')}</span>
-                                                            ) : (
-                                                                <div>
-                                                                    {mp.gaps.slice(0, 1).map((gap, idx) => (
-                                                                        <div key={idx} style={{ color: 'var(--text-body)' }}>
-                                                                            {gap.start_date === gap.end_date ? (
-                                                                                <>{gap.start_date}</>
-                                                                            ) : (
-                                                                                <>
-                                                                                    {gap.start_date} → {gap.end_date}
-                                                                                </>
-                                                                            )}
-                                                                        </div>
-                                                                    ))}
-                                                                    {mp.gaps.length > 1 && (
-                                                                        <div style={{ color: 'var(--text-muted)', fontSize: '0.8em' }}>
-                                                                            +{mp.gaps.length - 1} {t('meteringDataQuality.moreGaps')}
-                                                                        </div>
-                                                                    )}
-                                                                </div>
-                                                            )}
-                                                        </td>
+                                <RawMeteringTable
+                                    meteringPointId={selectedMpId}
+                                    dateFrom={period.from}
+                                    dateTo={period.to}
+                                    hasOut={hasOut}
+                                />
+                            </>
+                        )}
+                    </div>
+                </Tabs.Panel>
+
+                <Tabs.Panel value="quality">
+                    <div className="page-stack">
+                        {qualityQuery.isLoading && (
+                            <div className="card" style={{ textAlign: 'center', padding: '2rem' }}>
+                                {t('common.loading')}
+                            </div>
+                        )}
+                        {qualityQuery.isError && (
+                            <div className="card error-banner">{formatApiError(qualityQuery.error as any)}</div>
+                        )}
+                        {qualityQuery.isSuccess && qualityQuery.data && (
+                            <>
+                                {qualityQuery.data.metering_points.length === 0 ? (
+                                    <div className="card" style={{ textAlign: 'center', padding: '2rem', color: 'var(--text-muted)' }}>
+                                        {t('meteringDataQuality.noData')}
+                                    </div>
+                                ) : (
+                                    <>
+                                        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '1rem', marginBottom: '1.5rem' }}>
+                                            <div style={{ background: 'var(--success-100)', border: '1px solid var(--success-200)', borderRadius: '8px', padding: '1rem', textAlign: 'center' }}>
+                                                <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--success-700)' }}>
+                                                    {qualityQuery.data.metering_points.filter((mp) => mp.severity === 'green').length}
+                                                </div>
+                                                <div style={{ fontSize: '0.875rem', color: 'var(--brand-mid)' }}>{t('meteringDataQuality.severityGreen')}</div>
+                                            </div>
+                                            <div style={{ background: 'var(--warning-100)', border: '1px solid var(--warning-200)', borderRadius: '8px', padding: '1rem', textAlign: 'center' }}>
+                                                <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--warning-800)' }}>
+                                                    {qualityQuery.data.metering_points.filter((mp) => mp.severity === 'yellow').length}
+                                                </div>
+                                                <div style={{ fontSize: '0.875rem', color: 'var(--warning-800)' }}>{t('meteringDataQuality.severityYellow')}</div>
+                                            </div>
+                                            <div style={{ background: 'var(--danger-100)', border: '1px solid var(--danger-300)', borderRadius: '8px', padding: '1rem', textAlign: 'center' }}>
+                                                <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--danger-700)' }}>
+                                                    {qualityQuery.data.metering_points.filter((mp) => mp.severity === 'red').length}
+                                                </div>
+                                                <div style={{ fontSize: '0.875rem', color: 'var(--danger-600)' }}>{t('meteringDataQuality.severityRed')}</div>
+                                            </div>
+                                        </div>
+
+                                        <div className="table-card">
+                                            <table>
+                                                <thead>
+                                                    <tr>
+                                                        <th>{t('meteringDataQuality.meterId')}</th>
+                                                        <th>{t('meteringDataQuality.participant')}</th>
+                                                        <th>{t('meteringDataQuality.dataCompleteness')}</th>
+                                                        <th>{t('meteringDataQuality.status')}</th>
+                                                        <th>{t('meteringDataQuality.gaps')}</th>
                                                     </tr>
-                                                ))}
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </>
-                            )}
-                        </>
-                    )}
-                </>
-            )}
+                                                </thead>
+                                                <tbody>
+                                                    {qualityQuery.data.metering_points.map((mp) => (
+                                                        <tr key={mp.id}>
+                                                            <td style={{ fontFamily: 'monospace', fontSize: '0.9em' }}>{mp.meter_id}</td>
+                                                            <td>{mp.participant_name}</td>
+                                                            <td>
+                                                                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                                                                    <div style={{ width: '80px', height: '20px', background: 'var(--line-subtle)', borderRadius: '4px', overflow: 'hidden' }}>
+                                                                        <div
+                                                                            style={{
+                                                                                height: '100%',
+                                                                                background:
+                                                                                    mp.severity === 'green'
+                                                                                        ? PROD_COLORS[0]
+                                                                                        : mp.severity === 'yellow'
+                                                                                          ? CHART_GRID
+                                                                                          : NEGATIVE_COLOR,
+                                                                                width: `${mp.data_completeness}%`,
+                                                                            }}
+                                                                        />
+                                                                    </div>
+                                                                    <span style={{ fontSize: '0.875rem', fontWeight: 'bold' }}>{mp.data_completeness}%</span>
+                                                                </div>
+                                                            </td>
+                                                            <td>
+                                                                <span
+                                                                    style={{
+                                                                        display: 'inline-block',
+                                                                        padding: '0.25rem 0.75rem',
+                                                                        borderRadius: '4px',
+                                                                        fontSize: '0.875rem',
+                                                                        fontWeight: 'bold',
+                                                                        background:
+                                                                            mp.severity === 'green'
+                                                                                        ? 'var(--success-100)'
+                                                                                        : mp.severity === 'yellow'
+                                                                                          ? 'var(--warning-100)'
+                                                                                          : 'var(--danger-100)',
+                                                                        color:
+                                                                            mp.severity === 'green'
+                                                                                        ? 'var(--success-700)'
+                                                                                        : mp.severity === 'yellow'
+                                                                                          ? 'var(--warning-800)'
+                                                                                          : 'var(--danger-700)',
+                                                                    }}
+                                                                >
+                                                                    {t(`meteringDataQuality.severity${mp.severity.charAt(0).toUpperCase() + mp.severity.slice(1)}`)}
+                                                                </span>
+                                                                {mp.assignment_overlap && (
+                                                                    <div className="metering-dq-warning">
+                                                                        {t('meteringDataQuality.assignmentOverlapWarning')}
+                                                                    </div>
+                                                                )}
+                                                                {mp.unassigned_readings > 0 && (
+                                                                    <div className="metering-dq-warning">
+                                                                        {t('meteringDataQuality.unassignedWarning', { readings: mp.unassigned_readings, days: mp.unassigned_days })}
+                                                                    </div>
+                                                                )}
+                                                            </td>
+                                                            <td style={{ fontSize: '0.875rem' }}>
+                                                                {mp.gaps.length === 0 ? (
+                                                                    <span style={{ color: 'var(--success-600)' }}>{t('meteringDataQuality.noGaps')}</span>
+                                                                ) : (
+                                                                    <div>
+                                                                        {mp.gaps.slice(0, 1).map((gap, idx) => (
+                                                                            <div key={idx} style={{ color: 'var(--text-body)' }}>
+                                                                                {gap.start_date === gap.end_date ? (
+                                                                                    <>{gap.start_date}</>
+                                                                                ) : (
+                                                                                    <>
+                                                                                        {gap.start_date} → {gap.end_date}
+                                                                                    </>
+                                                                                )}
+                                                                            </div>
+                                                                        ))}
+                                                                        {mp.gaps.length > 1 && (
+                                                                            <div style={{ color: 'var(--text-muted)', fontSize: '0.8em' }}>
+                                                                                +{mp.gaps.length - 1} {t('meteringDataQuality.moreGaps')}
+                                                                            </div>
+                                                                        )}
+                                                                    </div>
+                                                                )}
+                                                            </td>
+                                                        </tr>
+                                                    ))}
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </>
+                                )}
+                            </>
+                        )}
+                    </div>
+                </Tabs.Panel>
+            </Tabs>
         </div>
     )
 }


### PR DESCRIPTION
## Summary

Replaces the hand-rolled tab strips on `AdminEmailTemplatesPage`, `AdminPdfTemplatesPage`, and `MeteringChartPage` with Mantine `Tabs` under a new `.app-tabs` CSS contract. All panels render inside the `Tabs` root with `keepMounted={false}`, so inactive content unmounts and every tab's `aria-controls` resolves to a real `tabpanel`. This removes the hand-rolled ARIA and arrow-key handling from `AdminPdfTemplatesPage` (Mantine provides it).

`MeteringChartPage` moves the active tab into the `?tab=` query param so the quality view is shareable, and metering-point changes now preserve the other query params instead of resetting them.

## Linked spec
- Spec: `docs/specs/2026-04-frontend-management-page-design.md` — updated in this PR (§4.1/§4.2 primitives, §7.2 application). `AdminSystemSettingsPage` predates the contract and is recorded as pending migration.
- ADR: none (no architecture decision)

## Validation
- Backend tests run: not run (frontend-only change, no backend files touched)
- Frontend build run: `npm run build` ✅
- Frontend tests run: `npm run test:unit` ✅ (23 files, 156 tests)
- ESLint: `npm run lint` ✅
- Manual checks: not done
- Screenshots: none — tab strips keep the identical token look (muted labels, 2px `--interactive` underline), now sourced from `.app-tabs`

## Checklist
- [x] Spec updated/linked for larger or risky changes
- N/A: ADR (no architecture decision)
- N/A: backend and frontend updated together (no API contract changed)
